### PR TITLE
feat: wt CLI v0.1 — twin lifecycle management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+bin/
+.wt/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build clean test vet
+
+build: ## Build the wt CLI binary
+	go build -o bin/wt ./cmd/wt/
+	@echo "Built bin/wt"
+
+clean: ## Remove build artifacts
+	rm -rf bin/
+
+test: ## Run all tests
+	go test ./... -count=1
+
+vet: ## Run go vet
+	go vet ./...

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -1,0 +1,369 @@
+// wt is the WonderTwin CLI — a process manager and admin client for twin binaries.
+//
+// Usage:
+//
+//	wt up                     Start all twins from wondertwin.yaml
+//	wt down                   Stop all running twins
+//	wt status                 Health check all running twins
+//	wt reset                  Reset state on all running twins
+//	wt seed <twin> <file>     POST seed data to a twin's /admin/state
+//	wt logs <twin>            Tail stdout/stderr of a running twin
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/procmgr"
+)
+
+const defaultManifest = "wondertwin.yaml"
+
+func main() {
+	cmd, args, manifestPath := parseArgs()
+
+	if cmd == "" || cmd == "help" || cmd == "--help" || cmd == "-h" {
+		printUsage()
+		if cmd == "" {
+			os.Exit(1)
+		}
+		return
+	}
+
+	var err error
+	switch cmd {
+	case "up":
+		err = cmdUp(manifestPath)
+	case "down":
+		err = cmdDown()
+	case "status":
+		err = cmdStatus(manifestPath)
+	case "reset":
+		err = cmdReset(manifestPath)
+	case "seed":
+		err = cmdSeed(manifestPath, args)
+	case "logs":
+		err = cmdLogs(manifestPath, args)
+	default:
+		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
+		printUsage()
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wt: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// parseArgs extracts the subcommand, positional args, and --config path from os.Args.
+func parseArgs() (command string, args []string, manifestPath string) {
+	manifestPath = defaultManifest
+	if p := os.Getenv("WT_CONFIG"); p != "" {
+		manifestPath = p
+	}
+
+	raw := os.Args[1:]
+	var filtered []string
+	for i := 0; i < len(raw); i++ {
+		if raw[i] == "--config" && i+1 < len(raw) {
+			manifestPath = raw[i+1]
+			i++
+			continue
+		}
+		filtered = append(filtered, raw[i])
+	}
+
+	if len(filtered) == 0 {
+		return "", nil, manifestPath
+	}
+	return filtered[0], filtered[1:], manifestPath
+}
+
+func printUsage() {
+	fmt.Print(`wt — WonderTwin CLI v0.1
+
+Usage:
+  wt [--config <path>] <command> [arguments]
+
+Commands:
+  up                     Start all twins defined in wondertwin.yaml
+  down                   Stop all running twins
+  status                 Health check all running twins
+  reset                  Reset state on all running twins
+  seed <twin> <file>     POST seed data to a twin
+  logs <twin>            Tail logs of a running twin
+
+Options:
+  --config <path>   Path to wondertwin.yaml (default: ./wondertwin.yaml)
+
+Environment:
+  WT_CONFIG         Override default manifest path
+`)
+}
+
+// ---------------------------------------------------------------------------
+// wt up
+// ---------------------------------------------------------------------------
+
+func cmdUp(manifestPath string) error {
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	pids, _ := procmgr.LoadPids()
+	ac := client.New()
+
+	fmt.Println("Starting twins...")
+	fmt.Println()
+
+	names := m.TwinNames()
+	for _, name := range names {
+		twin := m.Twins[name]
+
+		// Skip if already running
+		if entry, ok := pids[name]; ok && procmgr.IsRunning(entry.PID) {
+			fmt.Printf("  %-20s already running (pid %d)\n", name, entry.PID)
+			continue
+		}
+
+		pid, err := procmgr.Start(name, twin, m.Settings.LogDir, m.Settings.Verbose)
+		if err != nil {
+			fmt.Printf("  %-20s FAILED — %v\n", name, err)
+			continue
+		}
+
+		pids[name] = procmgr.PidEntry{
+			PID:    pid,
+			Port:   twin.Port,
+			Binary: twin.Binary,
+		}
+		fmt.Printf("  %-20s started (pid %d, port %d)\n", name, pid, twin.Port)
+	}
+
+	if err := procmgr.SavePids(pids); err != nil {
+		return fmt.Errorf("saving pid state: %w", err)
+	}
+
+	// Give twins a moment to bind their ports
+	fmt.Println()
+	fmt.Println("Waiting for health checks...")
+	time.Sleep(1500 * time.Millisecond)
+	fmt.Println()
+
+	allHealthy := true
+	for _, name := range names {
+		twin := m.Twins[name]
+		ok, _ := ac.Health(twin.AdminPort)
+		if ok {
+			fmt.Printf("  %-20s healthy    http://localhost:%d\n", name, twin.Port)
+		} else {
+			fmt.Printf("  %-20s unhealthy  http://localhost:%d\n", name, twin.Port)
+			allHealthy = false
+		}
+	}
+
+	fmt.Println()
+	if allHealthy {
+		fmt.Println("All twins up and healthy.")
+	} else {
+		fmt.Println("Some twins failed health check. Use 'wt logs <twin>' to investigate.")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// wt down
+// ---------------------------------------------------------------------------
+
+func cmdDown() error {
+	pids, err := procmgr.LoadPids()
+	if err != nil {
+		return fmt.Errorf("loading pid state: %w", err)
+	}
+
+	if len(pids) == 0 {
+		fmt.Println("No twins running.")
+		return nil
+	}
+
+	fmt.Println("Stopping twins...")
+	fmt.Println()
+
+	for name, entry := range pids {
+		if !procmgr.IsRunning(entry.PID) {
+			fmt.Printf("  %-20s already stopped\n", name)
+			continue
+		}
+		if err := procmgr.Stop(name, entry); err != nil {
+			fmt.Printf("  %-20s FAILED — %v\n", name, err)
+		} else {
+			fmt.Printf("  %-20s stopped (was pid %d)\n", name, entry.PID)
+		}
+	}
+
+	procmgr.RemovePidFile()
+
+	fmt.Println()
+	fmt.Println("All twins stopped.")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// wt status
+// ---------------------------------------------------------------------------
+
+func cmdStatus(manifestPath string) error {
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	pids, _ := procmgr.LoadPids()
+	ac := client.New()
+
+	fmt.Println()
+	fmt.Printf("  %-20s %-8s %-7s %-11s %s\n", "TWIN", "PID", "PORT", "HEALTH", "URL")
+	fmt.Printf("  %-20s %-8s %-7s %-11s %s\n", "----", "---", "----", "------", "---")
+
+	for _, name := range m.TwinNames() {
+		twin := m.Twins[name]
+		pidStr := "-"
+		health := "stopped"
+
+		if entry, ok := pids[name]; ok && procmgr.IsRunning(entry.PID) {
+			pidStr = fmt.Sprintf("%d", entry.PID)
+			ok, _ := ac.Health(twin.AdminPort)
+			if ok {
+				health = "healthy"
+			} else {
+				health = "unhealthy"
+			}
+		}
+
+		fmt.Printf("  %-20s %-8s %-7d %-11s http://localhost:%d\n",
+			name, pidStr, twin.Port, health, twin.Port)
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// wt reset
+// ---------------------------------------------------------------------------
+
+func cmdReset(manifestPath string) error {
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	pids, _ := procmgr.LoadPids()
+	ac := client.New()
+
+	fmt.Println("Resetting twins...")
+	fmt.Println()
+
+	for _, name := range m.TwinNames() {
+		twin := m.Twins[name]
+		if entry, ok := pids[name]; !ok || !procmgr.IsRunning(entry.PID) {
+			fmt.Printf("  %-20s skipped (not running)\n", name)
+			continue
+		}
+
+		resp, err := ac.Reset(twin.AdminPort)
+		if err != nil {
+			fmt.Printf("  %-20s FAILED — %v\n", name, err)
+		} else {
+			fmt.Printf("  %-20s reset   %s\n", name, resp)
+		}
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// wt seed <twin> <file>
+// ---------------------------------------------------------------------------
+
+func cmdSeed(manifestPath string, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: wt seed <twin> <file>")
+	}
+
+	twinName := args[0]
+	seedFile := args[1]
+
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	twin, err := m.Twin(twinName)
+	if err != nil {
+		return err
+	}
+
+	ac := client.New()
+	resp, err := ac.Seed(twin.AdminPort, seedFile)
+	if err != nil {
+		return fmt.Errorf("seeding %s: %w", twinName, err)
+	}
+
+	fmt.Printf("Seeded %s: %s\n", twinName, resp)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// wt logs <twin>
+// ---------------------------------------------------------------------------
+
+func cmdLogs(manifestPath string, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: wt logs <twin>")
+	}
+
+	twinName := args[0]
+
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	// Validate twin exists in manifest
+	if _, err := m.Twin(twinName); err != nil {
+		return err
+	}
+
+	logPath := fmt.Sprintf("%s/%s.log", m.Settings.LogDir, twinName)
+
+	if _, err := os.Stat(logPath); err != nil {
+		return fmt.Errorf("no logs found for %s (expected %s)", twinName, logPath)
+	}
+
+	// tail -f the log file
+	cmd := exec.Command("tail", "-f", "-n", "100", logPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Forward Ctrl+C to kill tail cleanly
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+	}()
+
+	return cmd.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/wondertwin-ai/wondertwin
+
+go 1.25.7
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,78 @@
+// Package client provides an HTTP client for twin admin API endpoints.
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// AdminClient talks to twin /admin/* endpoints.
+type AdminClient struct {
+	http *http.Client
+}
+
+// New creates an AdminClient with a 5-second timeout.
+func New() *AdminClient {
+	return &AdminClient{
+		http: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Health checks GET /admin/health. Returns (ok, response body or error message).
+func (c *AdminClient) Health(adminPort int) (bool, string) {
+	resp, err := c.http.Get(fmt.Sprintf("http://localhost:%d/admin/health", adminPort))
+	if err != nil {
+		return false, err.Error()
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		return true, strings.TrimSpace(string(body))
+	}
+	return false, fmt.Sprintf("status %d: %s", resp.StatusCode, body)
+}
+
+// Reset calls POST /admin/reset on a twin.
+func (c *AdminClient) Reset(adminPort int) (string, error) {
+	resp, err := c.http.Post(
+		fmt.Sprintf("http://localhost:%d/admin/reset", adminPort),
+		"application/json", nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("reset returned status %d: %s", resp.StatusCode, body)
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+// Seed POSTs the contents of a JSON file to POST /admin/state on a twin.
+func (c *AdminClient) Seed(adminPort int, filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("reading seed file: %w", err)
+	}
+
+	resp, err := c.http.Post(
+		fmt.Sprintf("http://localhost:%d/admin/state", adminPort),
+		"application/json",
+		bytes.NewReader(data),
+	)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("seed failed (status %d): %s", resp.StatusCode, body)
+	}
+	return strings.TrimSpace(string(body)), nil
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,96 @@
+// Package manifest parses wondertwin.yaml project manifests.
+package manifest
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Twin defines the configuration for a single twin in the manifest.
+type Twin struct {
+	Binary    string            `yaml:"binary"`
+	Port      int               `yaml:"port"`
+	AdminPort int               `yaml:"admin_port"`
+	Seed      string            `yaml:"seed"`
+	Env       map[string]string `yaml:"env"`
+}
+
+// Settings holds global CLI settings from the manifest.
+type Settings struct {
+	BinaryDir string `yaml:"binary_dir"`
+	LogDir    string `yaml:"log_dir"`
+	Verbose   bool   `yaml:"verbose"`
+}
+
+// Manifest represents a parsed wondertwin.yaml file.
+type Manifest struct {
+	Twins    map[string]Twin `yaml:"twins"`
+	Settings Settings        `yaml:"settings"`
+}
+
+// Load reads and parses a wondertwin.yaml file.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest %s: %w", path, err)
+	}
+
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	if m.Twins == nil {
+		return nil, fmt.Errorf("manifest has no twins defined")
+	}
+
+	// Apply defaults
+	if m.Settings.LogDir == "" {
+		m.Settings.LogDir = ".wt/logs"
+	}
+
+	for name, t := range m.Twins {
+		if t.Binary == "" {
+			return nil, fmt.Errorf("twin %q: binary path is required", name)
+		}
+		if t.Port == 0 {
+			return nil, fmt.Errorf("twin %q: port is required", name)
+		}
+		// Default admin_port to same as port (twins serve admin on the same router)
+		if t.AdminPort == 0 {
+			t.AdminPort = t.Port
+		}
+		m.Twins[name] = t
+	}
+
+	return &m, nil
+}
+
+// Twin returns a named twin's config, or an error if not found.
+func (m *Manifest) Twin(name string) (Twin, error) {
+	t, ok := m.Twins[name]
+	if !ok {
+		return Twin{}, fmt.Errorf("twin %q not found in manifest", name)
+	}
+	return t, nil
+}
+
+// TwinNames returns all twin names in deterministic sorted order.
+func (m *Manifest) TwinNames() []string {
+	names := make([]string, 0, len(m.Twins))
+	for name := range m.Twins {
+		names = append(names, name)
+	}
+	sortStrings(names)
+	return names
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/internal/procmgr/procmgr.go
+++ b/internal/procmgr/procmgr.go
@@ -1,0 +1,174 @@
+// Package procmgr manages twin process lifecycle — starting, stopping,
+// PID tracking, and log file management.
+package procmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+)
+
+const pidFileName = ".wt/pids.json"
+
+// PidEntry tracks a running twin process.
+type PidEntry struct {
+	PID    int    `json:"pid"`
+	Port   int    `json:"port"`
+	Binary string `json:"binary"`
+}
+
+// PidMap maps twin names to their PID entries.
+type PidMap map[string]PidEntry
+
+// LoadPids reads the PID tracking file. Returns an empty map if the file doesn't exist.
+func LoadPids() (PidMap, error) {
+	data, err := os.ReadFile(pidFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PidMap{}, nil
+		}
+		return nil, err
+	}
+	var pids PidMap
+	if err := json.Unmarshal(data, &pids); err != nil {
+		return nil, err
+	}
+	return pids, nil
+}
+
+// SavePids writes the PID tracking file.
+func SavePids(pids PidMap) error {
+	if err := os.MkdirAll(filepath.Dir(pidFileName), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(pids, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(pidFileName, data, 0o644)
+}
+
+// Start launches a twin binary as a background process with output redirected to a log file.
+// Returns the process PID.
+func Start(name string, twin manifest.Twin, logDir string, verbose bool) (int, error) {
+	// Resolve binary to absolute path
+	binary, err := filepath.Abs(twin.Binary)
+	if err != nil {
+		return 0, fmt.Errorf("resolving binary path: %w", err)
+	}
+
+	// Verify binary exists and is executable
+	info, err := os.Stat(binary)
+	if err != nil {
+		return 0, fmt.Errorf("binary not found: %s", binary)
+	}
+	if info.IsDir() {
+		return 0, fmt.Errorf("binary path is a directory: %s", binary)
+	}
+
+	// Build command arguments
+	args := []string{
+		"--port", strconv.Itoa(twin.Port),
+	}
+	if verbose {
+		args = append(args, "--verbose")
+	}
+	if twin.Seed != "" {
+		seedPath, err := filepath.Abs(twin.Seed)
+		if err != nil {
+			return 0, fmt.Errorf("resolving seed path: %w", err)
+		}
+		args = append(args, "--seed-file", seedPath)
+	}
+
+	cmd := exec.Command(binary, args...)
+
+	// Inherit env and add twin-specific vars
+	cmd.Env = os.Environ()
+	for k, v := range twin.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	// Set up log file
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return 0, fmt.Errorf("creating log dir: %w", err)
+	}
+	logPath := filepath.Join(logDir, name+".log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("creating log file: %w", err)
+	}
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	// Start in its own process group so it survives CLI exit
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return 0, fmt.Errorf("starting %s: %w", name, err)
+	}
+
+	// Detach: let the process run independently
+	go func() {
+		cmd.Wait()
+		logFile.Close()
+	}()
+
+	return cmd.Process.Pid, nil
+}
+
+// Stop sends SIGTERM to a twin process and waits for it to exit.
+// Falls back to SIGKILL after 5 seconds.
+func Stop(name string, entry PidEntry) error {
+	if !IsRunning(entry.PID) {
+		return nil
+	}
+
+	proc, err := os.FindProcess(entry.PID)
+	if err != nil {
+		return nil
+	}
+
+	// Graceful shutdown via SIGTERM
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return nil // already gone
+	}
+
+	// Poll for exit
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsRunning(entry.PID) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Force kill after timeout
+	proc.Signal(syscall.SIGKILL)
+	time.Sleep(100 * time.Millisecond)
+	return nil
+}
+
+// IsRunning checks if a process with the given PID is still alive.
+func IsRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds. Signal 0 probes existence.
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// RemovePidFile deletes the PID tracking file.
+func RemovePidFile() {
+	os.Remove(pidFileName)
+}

--- a/wondertwin.example.yaml
+++ b/wondertwin.example.yaml
@@ -1,0 +1,29 @@
+# wondertwin.yaml — WonderTwin project manifest
+#
+# Declares which twins to run locally, their ports, and configuration.
+# The `wt` CLI reads this file to manage twin lifecycle.
+#
+# For v0.1, twin binaries must be pre-compiled and available at the
+# configured `binary` path. No registry download yet.
+#
+# To test with saltwyk-sim twins:
+#   1. cd /path/to/saltwyk-sim && make build
+#   2. Copy this file to wondertwin.yaml and adjust binary paths
+#   3. wt up
+
+twins:
+  stripe:
+    binary: /path/to/saltwyk-sim/bin/twin-stripe
+    port: 9001
+    # admin_port defaults to same as port (twins serve admin on same router)
+    seed: /path/to/saltwyk-sim/config/seed-data/shopper-signup-fixtures.json
+    env:
+      STRIPE_WEBHOOK_SECRET: "whsec_sim_test_secret"
+
+  twilio:
+    binary: /path/to/saltwyk-sim/bin/twin-twilio
+    port: 9005
+
+settings:
+  log_dir: .wt/logs
+  verbose: true


### PR DESCRIPTION
## Summary

Introduces the `wt` CLI — the core interface for managing WonderTwin behavioral API twins. This is the foundational tooling that reads a `wondertwin.yaml` manifest, starts twins as background processes, and manages their lifecycle through a standard admin API.

## What's included

### CLI commands

| Command | Description |
|---|---|
| `wt up` | Starts all twins defined in `wondertwin.yaml` as background processes. Waits for startup, runs health checks, and reports status. |
| `wt down` | Graceful shutdown: sends SIGTERM, polls for exit, escalates to SIGKILL if needed. Cleans up PID tracking. |
| `wt status` | Displays a table of all running twins with name, PID, port, health status, and URL. |
| `wt reset` | POSTs `/admin/reset` on each running twin to clear all in-memory state. |
| `wt seed <twin> <file>` | POSTs seed data JSON to a twin's `/admin/state` endpoint. |
| `wt logs <twin>` | Tails the twin's log file (`tail -f` equivalent). |

### Internal packages

- **`internal/manifest`** — Parses `wondertwin.yaml` manifest files. Resolves twin binary paths, ports, admin ports, seed files, and environment variables.
- **`internal/client`** — HTTP client for the standard twin admin API (health checks, reset, seed data loading).
- **`internal/procmgr`** — Process lifecycle manager. Handles starting twins as background processes, PID file tracking, graceful shutdown with SIGTERM→SIGKILL escalation, and log file management.

### Project files

- **`wondertwin.example.yaml`** — Sample manifest referencing saltwyk-sim twins for local development and testing.
- **`Makefile`** — Build targets for the `wt` binary.
- **`go.mod`** — Module at `github.com/wondertwin-ai/wondertwin`.

## Architecture decisions

- **Twins are managed as OS processes, not containers.** Keeps the dependency footprint at zero — no Docker required. Each twin is a Go binary that the CLI starts, monitors, and stops.
- **PID file tracking** for reliable process management across `wt up` / `wt down` / `wt status` calls.
- **Admin API as the universal interface.** All twin management (health, reset, seed) goes through HTTP endpoints, making the CLI a thin orchestration layer that works with any twin that implements the standard admin API.
- **Manifest-driven configuration.** All twin configuration lives in `wondertwin.yaml` — no CLI flags to remember, easy to commit to version control, shareable across a team.

## Testing

All 6 commands tested end-to-end against saltwyk-sim twins (twin-stripe, twin-twilio).

## What's next

- [ ] `wt install` — registry-based twin installation
- [ ] `wt inspect <twin> <resource>` — state inspection via admin API
- [ ] `wt test` — scenario runner integration
- [ ] `wt mcp` — MCP server for agent-native twin management
- [ ] Cross-compilation and release pipeline

## How to try it

```bash
# Build
make build

# Create a wondertwin.yaml (see wondertwin.example.yaml)
cp wondertwin.example.yaml wondertwin.yaml

# Start twins
wt up

# Check status
wt status

# Seed data
wt seed stripe fixtures/stripe.json

# Reset all state
wt reset

# Stop everything
wt down
```