### PR TITLE
feat: add wt inspect command for twin state inspection

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -8,9 +8,11 @@
 //	wt reset                  Reset state on all running twins
 //	wt seed <twin> <file>     POST seed data to a twin's /admin/state
 //	wt logs <twin>            Tail stdout/stderr of a running twin
+//	wt inspect <twin> [res]   Query a running twin's internal state
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,6 +52,8 @@ func main() {
 		err = cmdSeed(manifestPath, args)
 	case "logs":
 		err = cmdLogs(manifestPath, args)
+	case "inspect":
+		err = cmdInspect(manifestPath, args)
 	default:
 		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
 		printUsage()
@@ -99,6 +103,7 @@ Commands:
   reset                  Reset state on all running twins
   seed <twin> <file>     POST seed data to a twin
   logs <twin>            Tail logs of a running twin
+  inspect <twin> [res]   Query twin state (res: state|requests|faults|time)
 
 Options:
   --config <path>   Path to wondertwin.yaml (default: ./wondertwin.yaml)
@@ -366,4 +371,72 @@ func cmdLogs(manifestPath string, args []string) error {
 	}()
 
 	return cmd.Run()
+}
+
+// ---------------------------------------------------------------------------
+// wt inspect <twin> [resource]
+// ---------------------------------------------------------------------------
+
+func cmdInspect(manifestPath string, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: wt inspect <twin> [state|requests|faults|time]")
+	}
+
+	twinName := args[0]
+	resource := "state"
+	if len(args) >= 2 {
+		resource = args[1]
+	}
+
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	twin, err := m.Twin(twinName)
+	if err != nil {
+		return err
+	}
+
+	ac := client.New()
+
+	var raw string
+	switch resource {
+	case "state":
+		raw, err = ac.Inspect(twin.AdminPort)
+	case "requests":
+		raw, err = ac.InspectRequests(twin.AdminPort)
+	case "faults":
+		raw, err = ac.InspectFaults(twin.AdminPort)
+	case "time":
+		raw, err = ac.InspectTime(twin.AdminPort)
+	default:
+		return fmt.Errorf("unknown resource %q (expected state, requests, faults, or time)", resource)
+	}
+	if err != nil {
+		return fmt.Errorf("inspecting %s/%s: %w", twinName, resource, err)
+	}
+
+	// Pretty-print the JSON response
+	pretty, err := prettyJSON(raw)
+	if err != nil {
+		// Not valid JSON — print raw
+		fmt.Print(raw)
+		return nil
+	}
+	fmt.Println(pretty)
+	return nil
+}
+
+// prettyJSON re-formats a JSON string with indentation.
+func prettyJSON(raw string) (string, error) {
+	var parsed json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return "", err
+	}
+	indented, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(indented), nil
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -54,6 +54,40 @@ func (c *AdminClient) Reset(adminPort int) (string, error) {
 	return strings.TrimSpace(string(body)), nil
 }
 
+// Inspect fetches GET /admin/state and returns the raw JSON body.
+func (c *AdminClient) Inspect(adminPort int) (string, error) {
+	return c.adminGet(adminPort, "/admin/state")
+}
+
+// InspectRequests fetches GET /admin/requests and returns the raw JSON body.
+func (c *AdminClient) InspectRequests(adminPort int) (string, error) {
+	return c.adminGet(adminPort, "/admin/requests")
+}
+
+// InspectFaults fetches GET /admin/faults and returns the raw JSON body.
+func (c *AdminClient) InspectFaults(adminPort int) (string, error) {
+	return c.adminGet(adminPort, "/admin/faults")
+}
+
+// InspectTime fetches GET /admin/time and returns the raw JSON body.
+func (c *AdminClient) InspectTime(adminPort int) (string, error) {
+	return c.adminGet(adminPort, "/admin/time")
+}
+
+// adminGet is a helper that GETs an admin endpoint and returns the raw body.
+func (c *AdminClient) adminGet(adminPort int, path string) (string, error) {
+	resp, err := c.http.Get(fmt.Sprintf("http://localhost:%d%s", adminPort, path))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s returned status %d: %s", path, resp.StatusCode, body)
+	}
+	return string(body), nil
+}
+
 // Seed POSTs the contents of a JSON file to POST /admin/state on a twin.
 func (c *AdminClient) Seed(adminPort int, filePath string) (string, error) {
 	data, err := os.ReadFile(filePath)


### PR DESCRIPTION
## Summary
- Adds `wt inspect <twin> [resource]` subcommand to query a running twin's internal state via its admin API
- Supported resources: `state` (default), `requests`, `faults`, `time`
- Pretty-prints JSON responses with indentation for easy debugging and AI agent verification
- Adds `Inspect`, `InspectRequests`, `InspectFaults`, `InspectTime` methods to the admin client, backed by a shared `adminGet` helper

## Test plan
- [ ] Run `wt up` to start twins, then `wt inspect <twin>` to verify state output
- [ ] Run `wt inspect <twin> requests` / `faults` / `time` to verify each resource
- [ ] Run `wt inspect <twin> invalid` to verify error message for unknown resource
- [ ] Verify `go vet ./...` and `go build` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)