### PR TITLE
feat: add wt mcp server for agent-native twin management

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/wondertwin-ai/wondertwin/internal/client"
 	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/mcp"
 	"github.com/wondertwin-ai/wondertwin/internal/procmgr"
 )
 
@@ -54,6 +55,8 @@ func main() {
 		err = cmdLogs(manifestPath, args)
 	case "inspect":
 		err = cmdInspect(manifestPath, args)
+	case "mcp":
+		err = cmdMcp(manifestPath)
 	default:
 		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
 		printUsage()
@@ -104,6 +107,7 @@ Commands:
   seed <twin> <file>     POST seed data to a twin
   logs <twin>            Tail logs of a running twin
   inspect <twin> [res]   Query twin state (res: state|requests|faults|time)
+  mcp                    Start MCP server over stdio (for AI agents)
 
 Options:
   --config <path>   Path to wondertwin.yaml (default: ./wondertwin.yaml)
@@ -439,4 +443,18 @@ func prettyJSON(raw string) (string, error) {
 		return "", err
 	}
 	return string(indented), nil
+}
+
+// ---------------------------------------------------------------------------
+// wt mcp
+// ---------------------------------------------------------------------------
+
+func cmdMcp(manifestPath string) error {
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	srv := mcp.NewServer(m)
+	return srv.Serve()
 }

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,0 +1,59 @@
+// Package mcp implements an MCP (Model Context Protocol) server over stdio,
+// exposing WonderTwin management operations as tools for AI coding agents.
+package mcp
+
+import "encoding/json"
+
+// Request represents a JSON-RPC 2.0 request message.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"` // number, string, or null; absent for notifications
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// IsNotification returns true if this is a JSON-RPC notification (no id field).
+func (r *Request) IsNotification() bool {
+	return r.ID == nil || len(r.ID) == 0
+}
+
+// Response represents a JSON-RPC 2.0 response message.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError represents a JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	ErrCodeParse      = -32700
+	ErrCodeInvalidReq = -32600
+	ErrCodeNoMethod   = -32601
+	ErrCodeInvalidParams = -32602
+	ErrCodeInternal   = -32603
+)
+
+// newResponse creates a successful JSON-RPC response.
+func newResponse(id json.RawMessage, result any) Response {
+	return Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+}
+
+// newErrorResponse creates an error JSON-RPC response.
+func newErrorResponse(id json.RawMessage, code int, message string) Response {
+	return Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: message},
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+)
+
+// Server is an MCP server that exposes twin management tools over JSON-RPC 2.0 on stdio.
+type Server struct {
+	manifest *manifest.Manifest
+	client   *client.AdminClient
+	tools    []toolEntry
+	stdin    io.Reader
+	stdout   io.Writer
+}
+
+// NewServer creates a new MCP server for the given manifest.
+func NewServer(m *manifest.Manifest) *Server {
+	return &Server{
+		manifest: m,
+		client:   client.New(),
+		tools:    allTools(),
+		stdin:    os.Stdin,
+		stdout:   os.Stdout,
+	}
+}
+
+// Serve reads JSON-RPC messages from stdin line-by-line and writes responses to stdout.
+// It blocks until stdin is closed or an unrecoverable error occurs.
+func (s *Server) Serve() error {
+	scanner := bufio.NewScanner(s.stdin)
+	// Allow up to 1MB per line for large tool results
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var req Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			s.writeResponse(newErrorResponse(nil, ErrCodeParse, "parse error: "+err.Error()))
+			continue
+		}
+
+		resp, shouldReply := s.dispatch(&req)
+		if shouldReply {
+			s.writeResponse(resp)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading stdin: %w", err)
+	}
+	return nil
+}
+
+// dispatch routes a JSON-RPC request to the appropriate handler.
+// Returns the response and whether a response should be sent (false for notifications).
+func (s *Server) dispatch(req *Request) (Response, bool) {
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req), true
+
+	case "notifications/initialized":
+		// Notification — no response
+		return Response{}, false
+
+	case "tools/list":
+		return s.handleToolsList(req), true
+
+	case "tools/call":
+		return s.handleToolsCall(req), true
+
+	default:
+		if req.IsNotification() {
+			// Unknown notifications are silently ignored per spec
+			return Response{}, false
+		}
+		return newErrorResponse(req.ID, ErrCodeNoMethod, "method not found: "+req.Method), true
+	}
+}
+
+// handleInitialize responds to the MCP initialize handshake.
+func (s *Server) handleInitialize(req *Request) Response {
+	result := map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities": map[string]any{
+			"tools": map[string]any{},
+		},
+		"serverInfo": map[string]any{
+			"name":    "wondertwin-mcp",
+			"version": "0.1.0",
+		},
+	}
+	return newResponse(req.ID, result)
+}
+
+// handleToolsList returns the list of available MCP tools.
+func (s *Server) handleToolsList(req *Request) Response {
+	tools := make([]Tool, len(s.tools))
+	for i, t := range s.tools {
+		tools[i] = t.Tool
+	}
+	result := map[string]any{
+		"tools": tools,
+	}
+	return newResponse(req.ID, result)
+}
+
+// toolsCallParams holds the parameters for a tools/call request.
+type toolsCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// handleToolsCall dispatches a tool invocation and returns the result.
+func (s *Server) handleToolsCall(req *Request) Response {
+	var params toolsCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return newErrorResponse(req.ID, ErrCodeInvalidParams, "invalid params: "+err.Error())
+	}
+
+	for _, t := range s.tools {
+		if t.Tool.Name == params.Name {
+			result := t.Handler(s.manifest, s.client, params.Arguments)
+			return newResponse(req.ID, result)
+		}
+	}
+
+	return newErrorResponse(req.ID, ErrCodeNoMethod, "unknown tool: "+params.Name)
+}
+
+// writeResponse marshals a Response to JSON and writes it as a single line to stdout.
+func (s *Server) writeResponse(resp Response) {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		// Last resort: write a hard-coded error
+		fmt.Fprintf(s.stdout, `{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal marshal error"}}`+"\n")
+		return
+	}
+	fmt.Fprintf(s.stdout, "%s\n", data)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,315 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/procmgr"
+)
+
+// Tool describes an MCP tool definition.
+type Tool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"inputSchema"`
+}
+
+// ToolResult is returned from tool invocations.
+type ToolResult struct {
+	Content []ToolContent `json:"content"`
+}
+
+// ToolContent holds a single piece of tool output.
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// textResult creates a ToolResult with a single text content item.
+func textResult(text string) ToolResult {
+	return ToolResult{
+		Content: []ToolContent{{Type: "text", Text: text}},
+	}
+}
+
+// toolHandler is a function that handles an MCP tool call.
+type toolHandler func(m *manifest.Manifest, ac *client.AdminClient, params json.RawMessage) ToolResult
+
+// toolEntry bundles a tool definition with its handler.
+type toolEntry struct {
+	Tool    Tool
+	Handler toolHandler
+}
+
+// allTools returns the set of MCP tools the server exposes.
+func allTools() []toolEntry {
+	return []toolEntry{
+		{
+			Tool: Tool{
+				Name:        "wt_up",
+				Description: "Start all twins defined in wondertwin.yaml. Launches each twin binary as a background process and waits for health checks.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {}, "required": []}`),
+			},
+			Handler: handleUp,
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_down",
+				Description: "Stop all running twins. Sends SIGTERM with graceful shutdown, falling back to SIGKILL after 5 seconds.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {}, "required": []}`),
+			},
+			Handler: handleDown,
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_status",
+				Description: "Health check all twins and return their status including PID, port, and health state.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {}, "required": []}`),
+			},
+			Handler: handleStatus,
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_reset",
+				Description: "Reset state on all twins or a specific twin. When a twin name is provided, only that twin is reset.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {"twin": {"type": "string", "description": "Name of a specific twin to reset (optional; omit to reset all)"}}, "required": []}`),
+			},
+			Handler: handleReset,
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_seed",
+				Description: "Seed a twin with fixture data by POSTing a JSON file to its /admin/state endpoint.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {"twin": {"type": "string", "description": "Name of the twin to seed"}, "file": {"type": "string", "description": "Path to the JSON seed file"}}, "required": ["twin", "file"]}`),
+			},
+			Handler: handleSeed,
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_inspect",
+				Description: "Get the current internal state of a twin by querying its /admin/state endpoint.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {"twin": {"type": "string", "description": "Name of the twin to inspect"}}, "required": ["twin"]}`),
+			},
+			Handler: handleInspect,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+func handleUp(m *manifest.Manifest, ac *client.AdminClient, _ json.RawMessage) ToolResult {
+	pids, _ := procmgr.LoadPids()
+
+	var out strings.Builder
+	names := m.TwinNames()
+
+	for _, name := range names {
+		twin := m.Twins[name]
+
+		if entry, ok := pids[name]; ok && procmgr.IsRunning(entry.PID) {
+			fmt.Fprintf(&out, "%-20s already running (pid %d)\n", name, entry.PID)
+			continue
+		}
+
+		pid, err := procmgr.Start(name, twin, m.Settings.LogDir, m.Settings.Verbose)
+		if err != nil {
+			fmt.Fprintf(&out, "%-20s FAILED - %v\n", name, err)
+			continue
+		}
+
+		pids[name] = procmgr.PidEntry{
+			PID:    pid,
+			Port:   twin.Port,
+			Binary: twin.Binary,
+		}
+		fmt.Fprintf(&out, "%-20s started (pid %d, port %d)\n", name, pid, twin.Port)
+	}
+
+	if err := procmgr.SavePids(pids); err != nil {
+		fmt.Fprintf(&out, "\nError saving pid state: %v\n", err)
+	}
+
+	// Brief pause for port binding
+	time.Sleep(1500 * time.Millisecond)
+
+	out.WriteString("\nHealth:\n")
+	for _, name := range names {
+		twin := m.Twins[name]
+		ok, _ := ac.Health(twin.AdminPort)
+		status := "healthy"
+		if !ok {
+			status = "unhealthy"
+		}
+		fmt.Fprintf(&out, "%-20s %s  http://localhost:%d\n", name, status, twin.Port)
+	}
+
+	return textResult(out.String())
+}
+
+func handleDown(_ *manifest.Manifest, _ *client.AdminClient, _ json.RawMessage) ToolResult {
+	pids, err := procmgr.LoadPids()
+	if err != nil {
+		return textResult(fmt.Sprintf("Error loading pid state: %v", err))
+	}
+
+	if len(pids) == 0 {
+		return textResult("No twins running.")
+	}
+
+	var out strings.Builder
+	for name, entry := range pids {
+		if !procmgr.IsRunning(entry.PID) {
+			fmt.Fprintf(&out, "%-20s already stopped\n", name)
+			continue
+		}
+		if err := procmgr.Stop(name, entry); err != nil {
+			fmt.Fprintf(&out, "%-20s FAILED - %v\n", name, err)
+		} else {
+			fmt.Fprintf(&out, "%-20s stopped (was pid %d)\n", name, entry.PID)
+		}
+	}
+
+	procmgr.RemovePidFile()
+	out.WriteString("\nAll twins stopped.")
+	return textResult(out.String())
+}
+
+func handleStatus(m *manifest.Manifest, ac *client.AdminClient, _ json.RawMessage) ToolResult {
+	pids, _ := procmgr.LoadPids()
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "%-20s %-8s %-7s %-11s %s\n", "TWIN", "PID", "PORT", "HEALTH", "URL")
+	fmt.Fprintf(&out, "%-20s %-8s %-7s %-11s %s\n", "----", "---", "----", "------", "---")
+
+	for _, name := range m.TwinNames() {
+		twin := m.Twins[name]
+		pidStr := "-"
+		health := "stopped"
+
+		if entry, ok := pids[name]; ok && procmgr.IsRunning(entry.PID) {
+			pidStr = fmt.Sprintf("%d", entry.PID)
+			ok, _ := ac.Health(twin.AdminPort)
+			if ok {
+				health = "healthy"
+			} else {
+				health = "unhealthy"
+			}
+		}
+
+		fmt.Fprintf(&out, "%-20s %-8s %-7d %-11s http://localhost:%d\n",
+			name, pidStr, twin.Port, health, twin.Port)
+	}
+
+	return textResult(out.String())
+}
+
+type resetParams struct {
+	Twin string `json:"twin"`
+}
+
+func handleReset(m *manifest.Manifest, ac *client.AdminClient, params json.RawMessage) ToolResult {
+	var p resetParams
+	if len(params) > 0 {
+		json.Unmarshal(params, &p)
+	}
+
+	pids, _ := procmgr.LoadPids()
+
+	names := m.TwinNames()
+	if p.Twin != "" {
+		// Validate the twin exists
+		if _, err := m.Twin(p.Twin); err != nil {
+			return textResult(fmt.Sprintf("Error: %v", err))
+		}
+		names = []string{p.Twin}
+	}
+
+	var out strings.Builder
+	for _, name := range names {
+		twin := m.Twins[name]
+		if entry, ok := pids[name]; !ok || !procmgr.IsRunning(entry.PID) {
+			fmt.Fprintf(&out, "%-20s skipped (not running)\n", name)
+			continue
+		}
+
+		resp, err := ac.Reset(twin.AdminPort)
+		if err != nil {
+			fmt.Fprintf(&out, "%-20s FAILED - %v\n", name, err)
+		} else {
+			fmt.Fprintf(&out, "%-20s reset   %s\n", name, resp)
+		}
+	}
+
+	return textResult(out.String())
+}
+
+type seedParams struct {
+	Twin string `json:"twin"`
+	File string `json:"file"`
+}
+
+func handleSeed(m *manifest.Manifest, ac *client.AdminClient, params json.RawMessage) ToolResult {
+	var p seedParams
+	if len(params) > 0 {
+		json.Unmarshal(params, &p)
+	}
+
+	if p.Twin == "" || p.File == "" {
+		return textResult("Error: both 'twin' and 'file' arguments are required")
+	}
+
+	twin, err := m.Twin(p.Twin)
+	if err != nil {
+		return textResult(fmt.Sprintf("Error: %v", err))
+	}
+
+	resp, err := ac.Seed(twin.AdminPort, p.File)
+	if err != nil {
+		return textResult(fmt.Sprintf("Error seeding %s: %v", p.Twin, err))
+	}
+
+	return textResult(fmt.Sprintf("Seeded %s: %s", p.Twin, resp))
+}
+
+type inspectParams struct {
+	Twin string `json:"twin"`
+}
+
+func handleInspect(m *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+	var p inspectParams
+	if len(params) > 0 {
+		json.Unmarshal(params, &p)
+	}
+
+	if p.Twin == "" {
+		return textResult("Error: 'twin' argument is required")
+	}
+
+	twin, err := m.Twin(p.Twin)
+	if err != nil {
+		return textResult(fmt.Sprintf("Error: %v", err))
+	}
+
+	// GET /admin/state to retrieve current twin state
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/admin/state", twin.AdminPort))
+	if err != nil {
+		return textResult(fmt.Sprintf("Error inspecting %s: %v", p.Twin, err))
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return textResult(fmt.Sprintf("Error inspecting %s: status %d: %s", p.Twin, resp.StatusCode, body))
+	}
+
+	return textResult(string(body))
+}


### PR DESCRIPTION
## Summary

Adds a `wt mcp` command that starts a Model Context Protocol (MCP) server over stdio, enabling AI coding agents to manage twins programmatically via JSON-RPC 2.0. Implemented entirely with the Go standard library — no new external dependencies.

## MCP tools exposed

| Tool | Args | Description |
|------|------|-------------|
| `wt_up` | none | Start all twins from the manifest |
| `wt_down` | none | Stop all running twins |
| `wt_status` | none | Health check all twins, return status table |
| `wt_reset` | `twin` (optional) | Reset all twins or a specific twin |
| `wt_seed` | `twin`, `file` (required) | Seed a twin with fixture data |
| `wt_inspect` | `twin` (required) | GET current state from /admin/state |

## Internal structure

- `internal/mcp/jsonrpc.go` — JSON-RPC 2.0 request/response types and error codes
- `internal/mcp/server.go` — Stdio server with initialize handshake, tools/list, tools/call dispatch
- `internal/mcp/tools.go` — Tool definitions (JSON Schema) and handlers wired to existing client/procmgr

## Test plan
- [ ] `go vet ./...` and `go build` pass (verified)
- [ ] Run initialize handshake and verify response
- [ ] Run tools/list and verify all six tools with correct schemas
- [ ] Run tools/call for wt_status and verify text output

🤖 Generated with [Claude Code](https://claude.com/claude-code)