### PR TITLE
feat: add wt test scenario runner

### DIFF
--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -1,0 +1,220 @@
+package scenario
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+)
+
+// StepResult records the outcome of a single step.
+type StepResult struct {
+	Name     string
+	Passed   bool
+	Duration time.Duration
+	Error    string // empty when passed
+}
+
+// Result records the outcome of an entire scenario.
+type Result struct {
+	ScenarioName string
+	Passed       bool
+	Steps        []StepResult
+	Duration     time.Duration
+}
+
+// Runner executes scenarios against running twins.
+type Runner struct {
+	manifest *manifest.Manifest
+	http     *http.Client
+}
+
+// NewRunner creates a Runner with the given manifest and a default HTTP client.
+func NewRunner(m *manifest.Manifest) *Runner {
+	return &Runner{
+		manifest: m,
+		http:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Run executes a single scenario and returns its result.
+func (r *Runner) Run(s *Scenario) (*Result, error) {
+	start := time.Now()
+	result := &Result{
+		ScenarioName: s.Name,
+		Passed:       true,
+	}
+
+	// --- Setup phase ---
+	if err := r.runSetup(&s.Setup); err != nil {
+		return nil, fmt.Errorf("setup failed: %w", err)
+	}
+
+	// --- Steps phase ---
+	for _, step := range s.Steps {
+		sr := r.runStep(&step)
+		result.Steps = append(result.Steps, sr)
+		if !sr.Passed {
+			result.Passed = false
+		}
+	}
+
+	result.Duration = time.Since(start)
+	return result, nil
+}
+
+// runSetup executes the reset and seed operations defined in a scenario's setup block.
+func (r *Runner) runSetup(setup *Setup) error {
+	// Reset twins
+	for _, name := range setup.Reset {
+		twin, err := r.manifest.Twin(name)
+		if err != nil {
+			return fmt.Errorf("reset %s: %w", name, err)
+		}
+		resp, err := r.http.Post(
+			fmt.Sprintf("http://localhost:%d/admin/reset", twin.AdminPort),
+			"application/json", nil,
+		)
+		if err != nil {
+			return fmt.Errorf("reset %s: %w", name, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("reset %s: status %d", name, resp.StatusCode)
+		}
+	}
+
+	// Seed twins
+	for name, filePath := range setup.Seed {
+		twin, err := r.manifest.Twin(name)
+		if err != nil {
+			return fmt.Errorf("seed %s: %w", name, err)
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("seed %s: reading %s: %w", name, filePath, err)
+		}
+		resp, err := r.http.Post(
+			fmt.Sprintf("http://localhost:%d/admin/state", twin.AdminPort),
+			"application/json",
+			strings.NewReader(string(data)),
+		)
+		if err != nil {
+			return fmt.Errorf("seed %s: %w", name, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("seed %s: status %d", name, resp.StatusCode)
+		}
+	}
+
+	return nil
+}
+
+// runStep executes a single scenario step and returns its result.
+func (r *Runner) runStep(step *Step) StepResult {
+	start := time.Now()
+	sr := StepResult{Name: step.Name}
+
+	// Expand templates in the URL
+	url, err := ExpandTemplates(step.Request.URL, r.manifest)
+	if err != nil {
+		sr.Error = fmt.Sprintf("template expansion: %v", err)
+		sr.Duration = time.Since(start)
+		return sr
+	}
+
+	// Expand templates in the body
+	body := step.Request.Body
+	if body != "" {
+		body, err = ExpandTemplates(body, r.manifest)
+		if err != nil {
+			sr.Error = fmt.Sprintf("template expansion in body: %v", err)
+			sr.Duration = time.Since(start)
+			return sr
+		}
+	}
+
+	// Build request
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(step.Request.Method, url, reqBody)
+	if err != nil {
+		sr.Error = fmt.Sprintf("building request: %v", err)
+		sr.Duration = time.Since(start)
+		return sr
+	}
+
+	for k, v := range step.Request.Headers {
+		req.Header.Set(k, v)
+	}
+
+	// Execute request
+	resp, err := r.http.Do(req)
+	if err != nil {
+		sr.Error = fmt.Sprintf("request failed: %v", err)
+		sr.Duration = time.Since(start)
+		return sr
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		sr.Error = fmt.Sprintf("reading response body: %v", err)
+		sr.Duration = time.Since(start)
+		return sr
+	}
+
+	// Assert status
+	if step.Assert.Status != 0 && resp.StatusCode != step.Assert.Status {
+		sr.Error = fmt.Sprintf("expected status %d, got %d", step.Assert.Status, resp.StatusCode)
+		sr.Duration = time.Since(start)
+		return sr
+	}
+
+	// Assert body_contains
+	if step.Assert.BodyContains != "" {
+		if !strings.Contains(string(respBody), step.Assert.BodyContains) {
+			sr.Error = fmt.Sprintf("body does not contain %q", step.Assert.BodyContains)
+			sr.Duration = time.Since(start)
+			return sr
+		}
+	}
+
+	// Assert body_json (simple top-level key equality)
+	if len(step.Assert.BodyJSON) > 0 {
+		var parsed map[string]any
+		if err := json.Unmarshal(respBody, &parsed); err != nil {
+			sr.Error = fmt.Sprintf("body is not valid JSON: %v", err)
+			sr.Duration = time.Since(start)
+			return sr
+		}
+		for key, expected := range step.Assert.BodyJSON {
+			actual, ok := parsed[key]
+			if !ok {
+				sr.Error = fmt.Sprintf("body_json: key %q not found in response", key)
+				sr.Duration = time.Since(start)
+				return sr
+			}
+			actualStr := fmt.Sprintf("%v", actual)
+			if actualStr != expected {
+				sr.Error = fmt.Sprintf("body_json: key %q expected %q, got %q", key, expected, actualStr)
+				sr.Duration = time.Since(start)
+				return sr
+			}
+		}
+	}
+
+	// All assertions passed
+	sr.Passed = true
+	sr.Duration = time.Since(start)
+	return sr
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -1,0 +1,100 @@
+// Package scenario loads and runs YAML-based test scenarios against running twins.
+package scenario
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario is a complete test scenario loaded from a YAML file.
+type Scenario struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Setup       Setup  `yaml:"setup"`
+	Steps       []Step `yaml:"steps"`
+}
+
+// Setup defines pre-test actions: resetting twins and seeding data.
+type Setup struct {
+	Reset []string          `yaml:"reset"`
+	Seed  map[string]string `yaml:"seed"`
+}
+
+// Step is a single request/assert pair within a scenario.
+type Step struct {
+	Name    string  `yaml:"name"`
+	Request Request `yaml:"request"`
+	Assert  Assert  `yaml:"assert"`
+}
+
+// Request defines the HTTP request to make during a step.
+type Request struct {
+	Method  string            `yaml:"method"`
+	URL     string            `yaml:"url"`
+	Headers map[string]string `yaml:"headers"`
+	Body    string            `yaml:"body"`
+}
+
+// Assert defines the expected results of a step.
+type Assert struct {
+	Status       int               `yaml:"status"`
+	BodyContains string            `yaml:"body_contains"`
+	BodyJSON     map[string]string `yaml:"body_json"`
+}
+
+// LoadScenario parses a single YAML scenario file.
+func LoadScenario(path string) (*Scenario, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading scenario %s: %w", path, err)
+	}
+
+	var s Scenario
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing scenario %s: %w", path, err)
+	}
+
+	if s.Name == "" {
+		return nil, fmt.Errorf("scenario %s: name is required", path)
+	}
+	if len(s.Steps) == 0 {
+		return nil, fmt.Errorf("scenario %s: at least one step is required", path)
+	}
+
+	return &s, nil
+}
+
+// LoadDir loads all .yaml and .yml scenario files from a directory.
+func LoadDir(dir string) ([]*Scenario, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading scenario directory %s: %w", dir, err)
+	}
+
+	var scenarios []*Scenario
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		s, err := LoadScenario(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		scenarios = append(scenarios, s)
+	}
+
+	if len(scenarios) == 0 {
+		return nil, fmt.Errorf("no scenario files found in %s", dir)
+	}
+
+	return scenarios, nil
+}

--- a/internal/scenario/template.go
+++ b/internal/scenario/template.go
@@ -1,0 +1,61 @@
+package scenario
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+)
+
+// ExpandTemplates replaces {{twins.<name>.port}} and {{twins.<name>.admin_port}}
+// placeholders in a string with actual port values from the manifest.
+func ExpandTemplates(s string, m *manifest.Manifest) (string, error) {
+	result := s
+	for {
+		start := strings.Index(result, "{{twins.")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "}}")
+		if end == -1 {
+			return "", fmt.Errorf("unterminated template expression at position %d", start)
+		}
+		end += start + 2 // move past "}}"
+
+		// Extract the inner expression: twins.<name>.<field>
+		expr := result[start+2 : end-2] // strip {{ and }}
+		value, err := resolveExpr(expr, m)
+		if err != nil {
+			return "", err
+		}
+
+		result = result[:start] + value + result[end:]
+	}
+	return result, nil
+}
+
+// resolveExpr resolves an expression like "twins.stripe.port" or "twins.stripe.admin_port".
+func resolveExpr(expr string, m *manifest.Manifest) (string, error) {
+	parts := strings.SplitN(expr, ".", 3)
+	if len(parts) != 3 || parts[0] != "twins" {
+		return "", fmt.Errorf("invalid template expression: %q (expected twins.<name>.<field>)", expr)
+	}
+
+	twinName := parts[1]
+	field := parts[2]
+
+	twin, err := m.Twin(twinName)
+	if err != nil {
+		return "", fmt.Errorf("template %q: %w", expr, err)
+	}
+
+	switch field {
+	case "port":
+		return strconv.Itoa(twin.Port), nil
+	case "admin_port":
+		return strconv.Itoa(twin.AdminPort), nil
+	default:
+		return "", fmt.Errorf("template %q: unknown field %q (expected port or admin_port)", expr, field)
+	}
+}

--- a/scenarios/example.yaml
+++ b/scenarios/example.yaml
@@ -1,0 +1,10 @@
+name: "Twin health check"
+description: "Verify twins are running and healthy"
+
+steps:
+  - name: "Check stripe health"
+    request:
+      method: GET
+      url: "http://localhost:{{twins.stripe.port}}/admin/health"
+    assert:
+      status: 200


### PR DESCRIPTION
## Summary

- Adds `wt test` command that runs YAML-based test scenarios against running twins
- New `internal/scenario` package with scenario parsing, template expansion, and HTTP-based test runner
- Supports setup phase (reset/seed), sequential step execution, and assertions on status code, body content, and JSON fields
- Includes `scenarios/example.yaml` as a reference scenario

## Scenario format

```yaml
name: "Payment flow - happy path"
setup:
  reset: [stripe]
  seed:
    stripe: ./fixtures/stripe.json
steps:
  - name: "Create payment intent"
    request:
      method: POST
      url: "http://localhost:{{twins.stripe.port}}/v1/payment_intents"
      headers:
        Authorization: "Bearer sk_test_xxx"
      body: "amount=500&currency=usd"
    assert:
      status: 200
      body_contains: "payment_intent"
```

## Usage

```bash
wt test                        # Run all scenarios in ./scenarios/
wt test scenarios/example.yaml # Run a specific scenario file
wt test path/to/dir/           # Run all scenarios in a directory
```

Output shows PASS/FAIL per step with timing, and a summary with exit code 1 on any failure.

## Test plan

- [ ] `wt test` with no running twins reports connection errors per step
- [ ] `wt test scenarios/example.yaml` against running stripe twin passes health check
- [ ] Scenario with `setup.reset` calls POST /admin/reset before steps
- [ ] Template expansion resolves `{{twins.<name>.port}}` and `{{twins.<name>.admin_port}}`
- [ ] Exit code is 1 when any step fails, 0 when all pass
- [ ] `go vet ./...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)