### PR TITLE
feat: add wt install command for registry-based twin downloads

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,92 @@
+// Package registry fetches the WonderTwin twin registry and resolves
+// twin versions for download.
+package registry
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultRegistryURL is the canonical location of the WonderTwin registry.
+const DefaultRegistryURL = "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.yaml"
+
+// Registry represents the top-level registry manifest.
+type Registry struct {
+	SchemaVersion int                  `yaml:"schema_version"`
+	Twins         map[string]TwinEntry `yaml:"twins"`
+}
+
+// TwinEntry describes a twin available in the registry.
+type TwinEntry struct {
+	Description string             `yaml:"description"`
+	Repo        string             `yaml:"repo"`
+	Category    string             `yaml:"category"`
+	Latest      string             `yaml:"latest"`
+	Versions    map[string]Version `yaml:"versions"`
+}
+
+// Version describes a specific release of a twin.
+type Version struct {
+	Released   string            `yaml:"released"`
+	Checksums  map[string]string `yaml:"checksums"`
+	BinaryURLs map[string]string `yaml:"binary_urls"`
+}
+
+// FetchRegistry downloads and parses the registry YAML from the given URL.
+func FetchRegistry(url string) (*Registry, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading registry response: %w", err)
+	}
+
+	var reg Registry
+	if err := yaml.Unmarshal(body, &reg); err != nil {
+		return nil, fmt.Errorf("parsing registry YAML: %w", err)
+	}
+
+	if reg.Twins == nil {
+		return nil, fmt.Errorf("registry contains no twins")
+	}
+
+	return &reg, nil
+}
+
+// ResolveVersion looks up a twin in the registry and resolves the version spec.
+// The versionSpec may be "latest" or an exact version string like "0.3.2".
+func (r *Registry) ResolveVersion(twinName, versionSpec string) (string, Version, error) {
+	entry, ok := r.Twins[twinName]
+	if !ok {
+		return "", Version{}, fmt.Errorf("twin %q not found in registry", twinName)
+	}
+
+	resolvedVersion := versionSpec
+	if versionSpec == "latest" || versionSpec == "" {
+		if entry.Latest == "" {
+			return "", Version{}, fmt.Errorf("twin %q has no latest version defined", twinName)
+		}
+		resolvedVersion = entry.Latest
+	}
+
+	ver, ok := entry.Versions[resolvedVersion]
+	if !ok {
+		return "", Version{}, fmt.Errorf("twin %q version %q not found in registry", twinName, resolvedVersion)
+	}
+
+	return resolvedVersion, ver, nil
+}

--- a/wondertwin.example.yaml
+++ b/wondertwin.example.yaml
@@ -3,27 +3,33 @@
 # Declares which twins to run locally, their ports, and configuration.
 # The `wt` CLI reads this file to manage twin lifecycle.
 #
-# For v0.1, twin binaries must be pre-compiled and available at the
-# configured `binary` path. No registry download yet.
+# Twins can be configured in two ways:
 #
-# To test with saltwyk-sim twins:
-#   1. cd /path/to/saltwyk-sim && make build
-#   2. Copy this file to wondertwin.yaml and adjust binary paths
+# 1. Version-based (recommended): Set `version` and run `wt install` to
+#    download pre-compiled binaries from the WonderTwin registry.
+#
+# 2. Binary path: Set `binary` to a local path for custom or pre-built twins.
+#
+# Quick start with registry twins:
+#   1. Copy this file to wondertwin.yaml
+#   2. wt install
 #   3. wt up
 
 twins:
+  # Version-based twin — downloaded from registry via `wt install`
   stripe:
-    binary: /path/to/saltwyk-sim/bin/twin-stripe
+    version: "0.3.2"     # or "latest"
     port: 9001
-    # admin_port defaults to same as port (twins serve admin on same router)
-    seed: /path/to/saltwyk-sim/config/seed-data/shopper-signup-fixtures.json
+    seed: /path/to/seed-data/shopper-signup-fixtures.json
     env:
       STRIPE_WEBHOOK_SECRET: "whsec_sim_test_secret"
 
+  # Binary path twin — use a local pre-compiled binary
   twilio:
     binary: /path/to/saltwyk-sim/bin/twin-twilio
     port: 9005
 
 settings:
+  binary_dir: ~/.wondertwin/bin   # where `wt install` saves binaries
   log_dir: .wt/logs
   verbose: true


### PR DESCRIPTION
## Summary

- Adds `wt install` command that fetches the WonderTwin registry, resolves twin versions, downloads pre-compiled binaries, and verifies SHA256 checksums
- New `internal/registry` package with `FetchRegistry`, `ResolveVersion`, and `Install` functions
- Extends the manifest to support a `version` field as an alternative to `binary` paths — twins can now be declared by version and downloaded from the registry

## Usage

```bash
# Install a specific twin
wt install stripe@latest
wt install stripe@0.3.2

# Install all version-based twins from wondertwin.yaml
wt install
```

## How it works

1. Fetches `registry.yaml` from the WonderTwin registry (GitHub-hosted manifest)
2. Resolves version ("latest" or exact match)
3. Downloads the pre-compiled binary for the current OS/arch from GitHub Releases
4. Verifies SHA256 checksum
5. Saves to `~/.wondertwin/bin/twin-{name}` with a `.version` sidecar file

## Manifest changes

Twins can now use `version` instead of `binary`:
```yaml
twins:
  stripe:
    version: "0.3.2"    # downloaded from registry
    port: 9001
  twilio:
    binary: ./bin/twin-twilio  # local path still works
    port: 9005
```

## Test plan

- [ ] `go vet ./...` and `go build` pass cleanly (verified)
- [ ] `wt install stripe@latest` against a live or mock registry
- [ ] `wt install` with version-based twins in wondertwin.yaml
- [ ] Checksum verification rejects a tampered binary
- [ ] `wt help` shows the install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)