### PR TITLE
feat: add CI/CD pipeline and cross-compilation release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go vet ./...
+      - run: go test ./... -count=1
+      - run: go build -o bin/wt ./cmd/wt/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            EXT=".exe"
+          fi
+          BINARY="wt-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}"
+          go build -ldflags "-s -w -X main.version=${{ github.ref_name }}" \
+            -o "${BINARY}" ./cmd/wt/
+          echo "BINARY=${BINARY}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wt-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ env.BINARY }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum wt-* > checksums.txt
+          cat checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## WonderTwin CLI ${{ github.ref_name }}
+
+            ### Installation
+
+            Download the binary for your platform below, rename it to `wt` (or `wt.exe` on Windows), and place it on your `PATH`.
+
+            **macOS (Apple Silicon):**
+            ```bash
+            curl -Lo wt https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wt-darwin-arm64
+            chmod +x wt && sudo mv wt /usr/local/bin/
+            ```
+
+            **macOS (Intel):**
+            ```bash
+            curl -Lo wt https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wt-darwin-amd64
+            chmod +x wt && sudo mv wt /usr/local/bin/
+            ```
+
+            **Linux (amd64):**
+            ```bash
+            curl -Lo wt https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wt-linux-amd64
+            chmod +x wt && sudo mv wt /usr/local/bin/
+            ```
+
+            ### Verify checksums
+            ```bash
+            sha256sum --check checksums.txt
+            ```
+          files: |
+            dist/wt-*
+            dist/checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,15 @@
+version: 2
+builds:
+  - main: ./cmd/wt
+    binary: wt
+    env: [CGO_ENABLED=0]
+    goos: [darwin, linux, windows]
+    goarch: [amd64, arm64]
+    ldflags: -s -w -X main.version={{.Version}}
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: checksums.txt

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,29 @@
-.PHONY: build clean test vet
+.PHONY: build clean test vet release-local
+
+VERSION ?= dev
+LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
 
 build: ## Build the wt CLI binary
-	go build -o bin/wt ./cmd/wt/
-	@echo "Built bin/wt"
+	go build $(LDFLAGS) -o bin/wt ./cmd/wt/
+	@echo "Built bin/wt (version=$(VERSION))"
 
 clean: ## Remove build artifacts
-	rm -rf bin/
+	rm -rf bin/ dist/
 
 test: ## Run all tests
 	go test ./... -count=1
 
 vet: ## Run go vet
 	go vet ./...
+
+release-local: ## Cross-compile for all supported platforms into dist/
+	@mkdir -p dist
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/wt-darwin-arm64    ./cmd/wt/
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/wt-darwin-amd64    ./cmd/wt/
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/wt-linux-amd64     ./cmd/wt/
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/wt-linux-arm64     ./cmd/wt/
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/wt-windows-amd64.exe ./cmd/wt/
+	@cd dist && sha256sum wt-* > checksums.txt 2>/dev/null || shasum -a 256 wt-* > checksums.txt
+	@echo "Built all binaries in dist/"
+	@echo "Checksums:"
+	@cat dist/checksums.txt

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -32,6 +32,9 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/scenario"
 )
 
+// version is set at build time via -ldflags "-X main.version=..."
+var version = "dev"
+
 const defaultManifest = "wondertwin.yaml"
 
 func main() {
@@ -47,6 +50,9 @@ func main() {
 
 	var err error
 	switch cmd {
+	case "version", "--version", "-v":
+		fmt.Printf("wt version %s\n", version)
+		return
 	case "up":
 		err = cmdUp(manifestPath)
 	case "down":
@@ -104,7 +110,7 @@ func parseArgs() (command string, args []string, manifestPath string) {
 }
 
 func printUsage() {
-	fmt.Print(`wt — WonderTwin CLI v0.1
+	fmt.Printf(`wt — WonderTwin CLI %s
 
 Usage:
   wt [--config <path>] <command> [arguments]
@@ -121,6 +127,7 @@ Commands:
   test [path]                Run YAML test scenarios (default: ./scenarios/)
   install                    Install all twins from wondertwin.yaml
   install <twin>@<version>   Install a specific twin at a version
+  version                    Print the wt version
 
 Options:
   --config <path>   Path to wondertwin.yaml (default: ./wondertwin.yaml)
@@ -128,7 +135,7 @@ Options:
 Environment:
   WT_CONFIG         Override default manifest path
   WT_REGISTRY_URL   Override registry URL
-`)
+`, version)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- CI workflow runs `go vet`, `go test`, and `go build` on every push/PR to main
- Release workflow triggered by version tags (`v*`) cross-compiles for 5 platforms and creates a GitHub Release with checksums
- Adds `wt version` subcommand with ldflags injection
- Adds `.goreleaser.yml` as an alternative release config
- Adds `make release-local` target for local cross-compilation

## Supported platforms

| OS | Arch | Binary |
|---|---|---|
| macOS | Apple Silicon | `wt-darwin-arm64` |
| macOS | Intel | `wt-darwin-amd64` |
| Linux | x86_64 | `wt-linux-amd64` |
| Linux | ARM64 | `wt-linux-arm64` |
| Windows | x86_64 | `wt-windows-amd64.exe` |

## How to release

```bash
git tag v0.1.0
git push origin v0.1.0
# GitHub Actions builds all platforms, creates release with binaries + checksums
```

## Files added/changed

- `.github/workflows/ci.yml` — CI pipeline (vet, test, build)
- `.github/workflows/release.yml` — Cross-compile matrix + GitHub Release creation
- `.goreleaser.yml` — Alternative GoReleaser config
- `cmd/wt/main.go` — Added `version` subcommand, ldflags-injectable version var
- `Makefile` — Version injection, `release-local` target

## Test plan

- [ ] `go vet ./...` and `go build` pass (verified)
- [ ] `wt version` prints "dev" by default
- [ ] CI triggers on PR to main
- [ ] Release triggers on `v*` tag push
- [ ] `make release-local` cross-compiles all 5 platforms into `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)