### PR TITLE
Migrate pkg/ and 6 twins from saltwyk-sim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
-.PHONY: build clean test vet release-local
+.PHONY: build build-twins build-all clean test vet release-local
 
 VERSION ?= dev
 LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
 
+TWINS := stripe twilio resend posthog clerk logodev
+
 build: ## Build the wt CLI binary
 	go build $(LDFLAGS) -o bin/wt ./cmd/wt/
 	@echo "Built bin/wt (version=$(VERSION))"
+
+build-twins: ## Build all twin binaries
+	@mkdir -p bin
+	$(foreach twin,$(TWINS),go build -o bin/twin-$(twin) ./twin-$(twin)/cmd/twin-$(twin)/;)
+	@echo "Built twins: $(TWINS)"
+
+build-all: build build-twins ## Build wt CLI and all twins
 
 clean: ## Remove build artifacts
 	rm -rf bin/ dist/

--- a/go.work
+++ b/go.work
@@ -1,0 +1,12 @@
+go 1.25.7
+
+use (
+	.
+	./pkg
+	./twin-clerk
+	./twin-logodev
+	./twin-posthog
+	./twin-resend
+	./twin-stripe
+	./twin-twilio
+)

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -1,0 +1,188 @@
+// Package admin provides the shared /admin/* control plane handlers
+// used by all WonderTwin twins for state management, fault injection, and inspection.
+package admin
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/store"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+)
+
+// StateStore is the interface a twin must implement to support admin state management.
+type StateStore interface {
+	// Snapshot returns the full state as a JSON-serializable value.
+	Snapshot() any
+	// LoadState replaces the full state from a JSON body.
+	LoadState(data []byte) error
+	// Reset clears all state and optionally reloads seed data.
+	Reset()
+}
+
+// WebhookFlusher is optionally implemented by twins that have pending webhooks.
+type WebhookFlusher interface {
+	FlushWebhooks() error
+}
+
+// Handler provides the shared admin endpoints.
+type Handler struct {
+	state   StateStore
+	flusher WebhookFlusher
+	mw      *twincore.Middleware
+	clock   *store.Clock
+}
+
+// NewHandler creates a new admin handler.
+func NewHandler(state StateStore, mw *twincore.Middleware, clock *store.Clock) *Handler {
+	return &Handler{
+		state: state,
+		mw:    mw,
+		clock: clock,
+	}
+}
+
+// SetFlusher sets the webhook flusher (optional).
+func (h *Handler) SetFlusher(f WebhookFlusher) {
+	h.flusher = f
+}
+
+// Routes mounts the admin endpoints on the given router.
+func (h *Handler) Routes(r chi.Router) {
+	r.Route("/admin", func(r chi.Router) {
+		r.Post("/reset", h.handleReset)
+		r.Get("/state", h.handleGetState)
+		r.Post("/state", h.handleLoadState)
+		r.Post("/fault/{endpoint}", h.handleInjectFault)
+		r.Delete("/fault/{endpoint}", h.handleRemoveFault)
+		r.Get("/faults", h.handleListFaults)
+		r.Get("/requests", h.handleGetRequests)
+		r.Post("/webhooks/flush", h.handleFlushWebhooks)
+		r.Post("/time/advance", h.handleTimeAdvance)
+		r.Get("/time", h.handleGetTime)
+		r.Get("/health", h.handleHealth)
+	})
+}
+
+func (h *Handler) handleReset(w http.ResponseWriter, r *http.Request) {
+	h.state.Reset()
+	h.mw.ReqLog.Clear()
+	h.mw.Faults.Reset()
+	h.mw.Idempotent.Reset()
+	if h.clock != nil {
+		h.clock.Reset()
+	}
+	twincore.JSON(w, http.StatusOK, map[string]string{"status": "reset"})
+}
+
+func (h *Handler) handleGetState(w http.ResponseWriter, r *http.Request) {
+	twincore.JSON(w, http.StatusOK, h.state.Snapshot())
+}
+
+func (h *Handler) handleLoadState(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		twincore.Error(w, http.StatusBadRequest, "failed to read body: "+err.Error())
+		return
+	}
+	if err := h.state.LoadState(body); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "failed to load state: "+err.Error())
+		return
+	}
+	twincore.JSON(w, http.StatusOK, map[string]string{"status": "loaded"})
+}
+
+func (h *Handler) handleInjectFault(w http.ResponseWriter, r *http.Request) {
+	endpoint := "/" + chi.URLParam(r, "endpoint")
+
+	var fault twincore.FaultConfig
+	if err := json.NewDecoder(r.Body).Decode(&fault); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid fault config: "+err.Error())
+		return
+	}
+	h.mw.Faults.Set(endpoint, fault)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"status":   "injected",
+		"endpoint": endpoint,
+		"fault":    fault,
+	})
+}
+
+func (h *Handler) handleRemoveFault(w http.ResponseWriter, r *http.Request) {
+	endpoint := "/" + chi.URLParam(r, "endpoint")
+	if h.mw.Faults.Remove(endpoint) {
+		twincore.JSON(w, http.StatusOK, map[string]any{"status": "removed", "endpoint": endpoint})
+	} else {
+		twincore.Error(w, http.StatusNotFound, "no fault registered for "+endpoint)
+	}
+}
+
+func (h *Handler) handleListFaults(w http.ResponseWriter, r *http.Request) {
+	twincore.JSON(w, http.StatusOK, h.mw.Faults.All())
+}
+
+func (h *Handler) handleGetRequests(w http.ResponseWriter, r *http.Request) {
+	twincore.JSON(w, http.StatusOK, h.mw.ReqLog.Entries())
+}
+
+func (h *Handler) handleFlushWebhooks(w http.ResponseWriter, r *http.Request) {
+	if h.flusher == nil {
+		twincore.JSON(w, http.StatusOK, map[string]string{"status": "no webhooks configured"})
+		return
+	}
+	if err := h.flusher.FlushWebhooks(); err != nil {
+		twincore.Error(w, http.StatusInternalServerError, "flush failed: "+err.Error())
+		return
+	}
+	twincore.JSON(w, http.StatusOK, map[string]string{"status": "flushed"})
+}
+
+func (h *Handler) handleTimeAdvance(w http.ResponseWriter, r *http.Request) {
+	if h.clock == nil {
+		twincore.Error(w, http.StatusBadRequest, "simulated clock not configured")
+		return
+	}
+
+	var req struct {
+		Duration string `json:"duration"` // Go duration string, e.g., "24h", "30m"
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid request: "+err.Error())
+		return
+	}
+
+	d, err := time.ParseDuration(req.Duration)
+	if err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid duration: "+err.Error())
+		return
+	}
+
+	h.clock.Advance(d)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"status":     "advanced",
+		"duration":   d.String(),
+		"offset":     h.clock.Offset().String(),
+		"simulated":  h.clock.Now().Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) handleGetTime(w http.ResponseWriter, r *http.Request) {
+	if h.clock == nil {
+		twincore.JSON(w, http.StatusOK, map[string]any{
+			"real": time.Now().Format(time.RFC3339),
+		})
+		return
+	}
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"real":      time.Now().Format(time.RFC3339),
+		"simulated": h.clock.Now().Format(time.RFC3339),
+		"offset":    h.clock.Offset().String(),
+	})
+}
+
+func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
+	twincore.JSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/pkg/admin/admin_test.go
+++ b/pkg/admin/admin_test.go
@@ -1,0 +1,535 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/store"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+)
+
+// ---------------------------------------------------------------------------
+// Mock state store
+// ---------------------------------------------------------------------------
+
+type mockState struct {
+	data      map[string]string
+	resetCalled bool
+}
+
+func newMockState() *mockState {
+	return &mockState{data: map[string]string{"key": "value"}}
+}
+
+func (m *mockState) Snapshot() any {
+	return m.data
+}
+
+func (m *mockState) LoadState(data []byte) error {
+	var d map[string]string
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+	m.data = d
+	return nil
+}
+
+func (m *mockState) Reset() {
+	m.resetCalled = true
+	m.data = map[string]string{"key": "value"} // reset to default
+}
+
+// ---------------------------------------------------------------------------
+// Mock webhook flusher
+// ---------------------------------------------------------------------------
+
+type mockFlusher struct {
+	flushErr error
+	flushed  bool
+}
+
+func (m *mockFlusher) FlushWebhooks() error {
+	m.flushed = true
+	return m.flushErr
+}
+
+// ---------------------------------------------------------------------------
+// Helper to create a test server
+// ---------------------------------------------------------------------------
+
+func setupTestServer(state StateStore, clock *store.Clock, flusher WebhookFlusher) *httptest.Server {
+	cfg := &twincore.Config{Name: "test-admin"}
+	mw := twincore.NewMiddleware(cfg, nil)
+
+	h := NewHandler(state, mw, clock)
+	if flusher != nil {
+		h.SetFlusher(flusher)
+	}
+
+	r := chi.NewRouter()
+	h.Routes(r)
+
+	return httptest.NewServer(r)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestHandleHealth(t *testing.T) {
+	srv := setupTestServer(newMockState(), store.NewClock(), nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/health")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %+v", body)
+	}
+}
+
+func TestHandleReset(t *testing.T) {
+	state := newMockState()
+	clk := store.NewClock()
+	clk.Advance(1000)
+
+	srv := setupTestServer(state, clk, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/reset", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !state.resetCalled {
+		t.Error("expected state Reset to be called")
+	}
+	if clk.Offset() != 0 {
+		t.Errorf("expected clock offset to be reset, got %v", clk.Offset())
+	}
+}
+
+func TestHandleGetState(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/state")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["key"] != "value" {
+		t.Errorf("expected key=value, got %+v", body)
+	}
+}
+
+func TestHandleLoadState(t *testing.T) {
+	state := newMockState()
+	srv := setupTestServer(state, nil, nil)
+	defer srv.Close()
+
+	newState := `{"foo":"bar"}`
+	resp, err := http.Post(srv.URL+"/admin/state", "application/json", strings.NewReader(newState))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if state.data["foo"] != "bar" {
+		t.Errorf("expected state to be updated, got %+v", state.data)
+	}
+}
+
+func TestHandleLoadStateInvalid(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/state", "application/json", strings.NewReader("{bad json"))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleInjectFault(t *testing.T) {
+	cfg := &twincore.Config{Name: "test"}
+	mw := twincore.NewMiddleware(cfg, nil)
+	state := newMockState()
+
+	h := NewHandler(state, mw, nil)
+	r := chi.NewRouter()
+	h.Routes(r)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	body := `{"status_code":503,"rate":1.0}`
+	resp, err := http.Post(srv.URL+"/admin/fault/charges", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Verify the fault was registered (handler prepends "/" to the endpoint param)
+	fault := mw.Faults.Check("/charges")
+	if fault == nil {
+		t.Fatal("expected fault to be registered")
+	}
+	if fault.StatusCode != 503 {
+		t.Errorf("expected status 503, got %d", fault.StatusCode)
+	}
+}
+
+func TestHandleInjectFaultInvalidBody(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/fault/test", "application/json", strings.NewReader("{bad"))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleRemoveFault(t *testing.T) {
+	cfg := &twincore.Config{Name: "test"}
+	mw := twincore.NewMiddleware(cfg, nil)
+	mw.Faults.Set("/test", twincore.FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	state := newMockState()
+	h := NewHandler(state, mw, nil)
+	r := chi.NewRouter()
+	h.Routes(r)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/admin/fault/test", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if mw.Faults.Check("/test") != nil {
+		t.Error("expected fault to be removed")
+	}
+}
+
+func TestHandleRemoveFaultNotFound(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/admin/fault/nonexistent", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleListFaults(t *testing.T) {
+	cfg := &twincore.Config{Name: "test"}
+	mw := twincore.NewMiddleware(cfg, nil)
+	mw.Faults.Set("/a", twincore.FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	state := newMockState()
+	h := NewHandler(state, mw, nil)
+	r := chi.NewRouter()
+	h.Routes(r)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/faults")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]twincore.FaultConfig
+	json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["/a"]; !ok {
+		t.Errorf("expected fault /a in listing, got %+v", body)
+	}
+}
+
+func TestHandleGetRequests(t *testing.T) {
+	cfg := &twincore.Config{Name: "test"}
+	mw := twincore.NewMiddleware(cfg, nil)
+	mw.ReqLog.Add(twincore.RequestLogEntry{Method: "GET", Path: "/test"})
+
+	state := newMockState()
+	h := NewHandler(state, mw, nil)
+	r := chi.NewRouter()
+	h.Routes(r)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/requests")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body []twincore.RequestLogEntry
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(body))
+	}
+	if body[0].Method != "GET" {
+		t.Errorf("expected GET, got %s", body[0].Method)
+	}
+}
+
+func TestHandleTimeAdvance(t *testing.T) {
+	clk := store.NewClock()
+	srv := setupTestServer(newMockState(), clk, nil)
+	defer srv.Close()
+
+	body := `{"duration":"1h"}`
+	resp, err := http.Post(srv.URL+"/admin/time/advance", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["status"] != "advanced" {
+		t.Errorf("expected status=advanced, got %v", result["status"])
+	}
+}
+
+func TestHandleTimeAdvanceNoClock(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	body := `{"duration":"1h"}`
+	resp, err := http.Post(srv.URL+"/admin/time/advance", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 when no clock configured, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleTimeAdvanceInvalidDuration(t *testing.T) {
+	clk := store.NewClock()
+	srv := setupTestServer(newMockState(), clk, nil)
+	defer srv.Close()
+
+	body := `{"duration":"not-a-duration"}`
+	resp, err := http.Post(srv.URL+"/admin/time/advance", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid duration, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleTimeAdvanceInvalidJSON(t *testing.T) {
+	clk := store.NewClock()
+	srv := setupTestServer(newMockState(), clk, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/time/advance", "application/json", strings.NewReader("{bad"))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid JSON, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleGetTime(t *testing.T) {
+	clk := store.NewClock()
+	srv := setupTestServer(newMockState(), clk, nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/time")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["real"]; !ok {
+		t.Error("expected 'real' field")
+	}
+	if _, ok := body["simulated"]; !ok {
+		t.Error("expected 'simulated' field")
+	}
+	if _, ok := body["offset"]; !ok {
+		t.Error("expected 'offset' field")
+	}
+}
+
+func TestHandleGetTimeNoClock(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/admin/time")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["real"]; !ok {
+		t.Error("expected 'real' field")
+	}
+	if _, ok := body["simulated"]; ok {
+		t.Error("did not expect 'simulated' field when no clock")
+	}
+}
+
+func TestHandleFlushWebhooksNoFlusher(t *testing.T) {
+	srv := setupTestServer(newMockState(), nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/webhooks/flush", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["status"] != "no webhooks configured" {
+		t.Errorf("unexpected status: %s", body["status"])
+	}
+}
+
+func TestHandleFlushWebhooksSuccess(t *testing.T) {
+	flusher := &mockFlusher{}
+	srv := setupTestServer(newMockState(), nil, flusher)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/webhooks/flush", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !flusher.flushed {
+		t.Error("expected FlushWebhooks to be called")
+	}
+}
+
+func TestHandleFlushWebhooksError(t *testing.T) {
+	flusher := &mockFlusher{flushErr: fmt.Errorf("delivery failed")}
+	srv := setupTestServer(newMockState(), nil, flusher)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/webhooks/flush", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleResetWithNilClock(t *testing.T) {
+	state := newMockState()
+	srv := setupTestServer(state, nil, nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/reset", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !state.resetCalled {
+		t.Error("expected state Reset to be called")
+	}
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,5 @@
+module github.com/wondertwin-ai/wondertwin/pkg
+
+go 1.25.7
+
+require github.com/go-chi/chi/v5 v5.2.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,270 @@
+// Package store provides a generic, thread-safe, in-memory key-value store
+// for use by WonderTwin twins. It supports CRUD operations, listing with cursor-based
+// pagination, and deterministic ID generation.
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Store is a generic, thread-safe, in-memory store for objects of type T.
+// T must be a struct that can be marshaled/unmarshaled to JSON.
+type Store[T any] struct {
+	mu      sync.RWMutex
+	items   map[string]T
+	order   []string // insertion order for deterministic listing
+	prefix  string
+	counter atomic.Uint64
+}
+
+// New creates a new Store with the given ID prefix (e.g., "acct", "msg", "evt").
+func New[T any](prefix string) *Store[T] {
+	return &Store[T]{
+		items:  make(map[string]T),
+		order:  make([]string, 0),
+		prefix: prefix,
+	}
+}
+
+// NextID generates a deterministic ID with the store's prefix.
+// IDs are of the form "{prefix}_{counter}" e.g., "acct_000001".
+func (s *Store[T]) NextID() string {
+	n := s.counter.Add(1)
+	return fmt.Sprintf("%s_%06d", s.prefix, n)
+}
+
+// Set stores an item with the given ID. If the ID already exists, it is overwritten
+// but its position in the insertion order is preserved.
+func (s *Store[T]) Set(id string, item T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.items[id]; !exists {
+		s.order = append(s.order, id)
+	}
+	s.items[id] = item
+}
+
+// Get retrieves an item by ID. Returns the item and true if found, zero value and false otherwise.
+func (s *Store[T]) Get(id string) (T, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.items[id]
+	return item, ok
+}
+
+// Delete removes an item by ID. Returns true if the item existed.
+func (s *Store[T]) Delete(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.items[id]; !exists {
+		return false
+	}
+	delete(s.items, id)
+	for i, oid := range s.order {
+		if oid == id {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// List returns all items in insertion order.
+func (s *Store[T]) List() []T {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]T, 0, len(s.order))
+	for _, id := range s.order {
+		result = append(result, s.items[id])
+	}
+	return result
+}
+
+// ListIDs returns all IDs in insertion order.
+func (s *Store[T]) ListIDs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, len(s.order))
+	copy(out, s.order)
+	return out
+}
+
+// Page represents a paginated result set.
+type Page[T any] struct {
+	Data    []T    `json:"data"`
+	HasMore bool   `json:"has_more"`
+	Cursor  string `json:"cursor,omitempty"`
+	Total   int    `json:"total"`
+}
+
+// Paginate returns a page of items using cursor-based pagination.
+// The cursor is the last ID seen. An empty cursor starts from the beginning.
+// Limit controls the page size (0 means return all).
+func (s *Store[T]) Paginate(cursor string, limit int) Page[T] {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	startIdx := 0
+	if cursor != "" {
+		for i, id := range s.order {
+			if id == cursor {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+
+	if limit <= 0 {
+		limit = len(s.order)
+	}
+
+	endIdx := startIdx + limit
+	hasMore := false
+	if endIdx > len(s.order) {
+		endIdx = len(s.order)
+	} else if endIdx < len(s.order) {
+		hasMore = true
+	}
+
+	data := make([]T, 0, endIdx-startIdx)
+	var lastCursor string
+	for i := startIdx; i < endIdx; i++ {
+		data = append(data, s.items[s.order[i]])
+		lastCursor = s.order[i]
+	}
+
+	return Page[T]{
+		Data:    data,
+		HasMore: hasMore,
+		Cursor:  lastCursor,
+		Total:   len(s.order),
+	}
+}
+
+// Count returns the number of items in the store.
+func (s *Store[T]) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.items)
+}
+
+// Filter returns items that match the given predicate, in insertion order.
+func (s *Store[T]) Filter(predicate func(id string, item T) bool) []T {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []T
+	for _, id := range s.order {
+		if predicate(id, s.items[id]) {
+			result = append(result, s.items[id])
+		}
+	}
+	return result
+}
+
+// FilterWithIDs returns items and their IDs that match the given predicate.
+func (s *Store[T]) FilterWithIDs(predicate func(id string, item T) bool) ([]string, []T) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var ids []string
+	var items []T
+	for _, id := range s.order {
+		if predicate(id, s.items[id]) {
+			ids = append(ids, id)
+			items = append(items, s.items[id])
+		}
+	}
+	return ids, items
+}
+
+// Reset clears all items and resets the ID counter.
+func (s *Store[T]) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = make(map[string]T)
+	s.order = make([]string, 0)
+	s.counter.Store(0)
+}
+
+// Snapshot returns all items as a JSON-serializable map.
+func (s *Store[T]) Snapshot() map[string]T {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	snapshot := make(map[string]T, len(s.items))
+	for k, v := range s.items {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+// LoadSnapshot replaces all items from a JSON-serializable map.
+// Existing items are cleared. IDs are sorted to maintain deterministic order.
+func (s *Store[T]) LoadSnapshot(snapshot map[string]T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = make(map[string]T, len(snapshot))
+	s.order = make([]string, 0, len(snapshot))
+	for k, v := range snapshot {
+		s.items[k] = v
+		s.order = append(s.order, k)
+	}
+	sort.Strings(s.order)
+}
+
+// MarshalJSON serializes the store to JSON (the items map).
+func (s *Store[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.Snapshot())
+}
+
+// UnmarshalJSON deserializes JSON into the store, replacing existing items.
+func (s *Store[T]) UnmarshalJSON(data []byte) error {
+	var snapshot map[string]T
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return err
+	}
+	s.LoadSnapshot(snapshot)
+	return nil
+}
+
+// Clock provides a simulated clock for time-dependent twin behavior.
+type Clock struct {
+	mu     sync.RWMutex
+	offset time.Duration
+}
+
+// NewClock creates a new simulated clock with no offset.
+func NewClock() *Clock {
+	return &Clock{}
+}
+
+// Now returns the current simulated time.
+func (c *Clock) Now() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return time.Now().Add(c.offset)
+}
+
+// Advance moves the simulated clock forward by the given duration.
+func (c *Clock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.offset += d
+}
+
+// Reset resets the clock offset to zero.
+func (c *Clock) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.offset = 0
+}
+
+// Offset returns the current clock offset.
+func (c *Clock) Offset() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.offset
+}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,0 +1,485 @@
+package store
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// testItem is a simple struct used throughout store tests.
+type testItem struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+// ---------------------------------------------------------------------------
+// Store[T] – basic CRUD
+// ---------------------------------------------------------------------------
+
+func TestNew(t *testing.T) {
+	s := New[testItem]("acct")
+	if s == nil {
+		t.Fatal("expected non-nil store")
+	}
+	if s.Count() != 0 {
+		t.Errorf("expected empty store, got count %d", s.Count())
+	}
+}
+
+func TestNextID(t *testing.T) {
+	s := New[testItem]("acct")
+	id1 := s.NextID()
+	id2 := s.NextID()
+
+	if id1 != "acct_000001" {
+		t.Errorf("expected acct_000001, got %s", id1)
+	}
+	if id2 != "acct_000002" {
+		t.Errorf("expected acct_000002, got %s", id2)
+	}
+}
+
+func TestSetAndGet(t *testing.T) {
+	s := New[testItem]("item")
+	item := testItem{Name: "alpha", Value: 1}
+	s.Set("item_000001", item)
+
+	got, ok := s.Get("item_000001")
+	if !ok {
+		t.Fatal("expected item to be found")
+	}
+	if got.Name != "alpha" || got.Value != 1 {
+		t.Errorf("unexpected item: %+v", got)
+	}
+}
+
+func TestGetMissing(t *testing.T) {
+	s := New[testItem]("item")
+	_, ok := s.Get("nonexistent")
+	if ok {
+		t.Error("expected ok=false for missing item")
+	}
+}
+
+func TestSetOverwrite(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("id1", testItem{Name: "first", Value: 1})
+	s.Set("id1", testItem{Name: "second", Value: 2})
+
+	got, _ := s.Get("id1")
+	if got.Name != "second" {
+		t.Errorf("expected overwritten item, got %+v", got)
+	}
+	// Overwrite should not add a duplicate entry to order.
+	if s.Count() != 1 {
+		t.Errorf("expected count 1 after overwrite, got %d", s.Count())
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("id1", testItem{Name: "a", Value: 1})
+
+	if !s.Delete("id1") {
+		t.Error("expected Delete to return true for existing item")
+	}
+	if s.Delete("id1") {
+		t.Error("expected Delete to return false for already-deleted item")
+	}
+	if s.Count() != 0 {
+		t.Errorf("expected empty store after delete, got count %d", s.Count())
+	}
+}
+
+func TestDeleteNonExistent(t *testing.T) {
+	s := New[testItem]("item")
+	if s.Delete("nope") {
+		t.Error("expected Delete to return false for non-existent item")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+// ---------------------------------------------------------------------------
+
+func TestListAndListIDs(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "alpha", Value: 1})
+	s.Set("b", testItem{Name: "beta", Value: 2})
+	s.Set("c", testItem{Name: "gamma", Value: 3})
+
+	items := s.List()
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	// insertion order
+	if items[0].Name != "alpha" || items[1].Name != "beta" || items[2].Name != "gamma" {
+		t.Errorf("unexpected list order: %+v", items)
+	}
+
+	ids := s.ListIDs()
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 ids, got %d", len(ids))
+	}
+	if ids[0] != "a" || ids[1] != "b" || ids[2] != "c" {
+		t.Errorf("unexpected id order: %v", ids)
+	}
+}
+
+func TestListIDsReturnsCopy(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "a", Value: 1})
+
+	ids := s.ListIDs()
+	ids[0] = "mutated"
+
+	original := s.ListIDs()
+	if original[0] != "a" {
+		t.Error("ListIDs did not return a copy; mutation affected the store")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+func TestPaginateAll(t *testing.T) {
+	s := New[testItem]("item")
+	for i := 0; i < 5; i++ {
+		s.Set(s.NextID(), testItem{Name: "item", Value: i})
+	}
+
+	page := s.Paginate("", 0)
+	if len(page.Data) != 5 {
+		t.Errorf("expected 5 items, got %d", len(page.Data))
+	}
+	if page.HasMore {
+		t.Error("expected HasMore=false when returning all")
+	}
+	if page.Total != 5 {
+		t.Errorf("expected Total=5, got %d", page.Total)
+	}
+}
+
+func TestPaginateWithLimit(t *testing.T) {
+	s := New[testItem]("item")
+	for i := 0; i < 5; i++ {
+		s.Set(s.NextID(), testItem{Name: "item", Value: i})
+	}
+
+	page1 := s.Paginate("", 2)
+	if len(page1.Data) != 2 {
+		t.Fatalf("expected 2 items in first page, got %d", len(page1.Data))
+	}
+	if !page1.HasMore {
+		t.Error("expected HasMore=true on first page")
+	}
+	if page1.Cursor == "" {
+		t.Error("expected non-empty cursor")
+	}
+
+	page2 := s.Paginate(page1.Cursor, 2)
+	if len(page2.Data) != 2 {
+		t.Fatalf("expected 2 items in second page, got %d", len(page2.Data))
+	}
+	if !page2.HasMore {
+		t.Error("expected HasMore=true on second page")
+	}
+
+	page3 := s.Paginate(page2.Cursor, 2)
+	if len(page3.Data) != 1 {
+		t.Fatalf("expected 1 item in third page, got %d", len(page3.Data))
+	}
+	if page3.HasMore {
+		t.Error("expected HasMore=false on last page")
+	}
+}
+
+func TestPaginateEmptyStore(t *testing.T) {
+	s := New[testItem]("item")
+	page := s.Paginate("", 10)
+	if len(page.Data) != 0 {
+		t.Errorf("expected 0 items, got %d", len(page.Data))
+	}
+	if page.HasMore {
+		t.Error("expected HasMore=false for empty store")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Filter / FilterWithIDs
+// ---------------------------------------------------------------------------
+
+func TestFilter(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "alpha", Value: 10})
+	s.Set("b", testItem{Name: "beta", Value: 20})
+	s.Set("c", testItem{Name: "gamma", Value: 30})
+
+	result := s.Filter(func(id string, item testItem) bool {
+		return item.Value >= 20
+	})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 filtered items, got %d", len(result))
+	}
+	if result[0].Name != "beta" || result[1].Name != "gamma" {
+		t.Errorf("unexpected filter result: %+v", result)
+	}
+}
+
+func TestFilterNoMatch(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "alpha", Value: 1})
+
+	result := s.Filter(func(id string, item testItem) bool {
+		return item.Value > 100
+	})
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d items", len(result))
+	}
+}
+
+func TestFilterWithIDs(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "alpha", Value: 10})
+	s.Set("b", testItem{Name: "beta", Value: 20})
+
+	ids, items := s.FilterWithIDs(func(id string, item testItem) bool {
+		return id == "a"
+	})
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Errorf("expected [a], got %v", ids)
+	}
+	if len(items) != 1 || items[0].Name != "alpha" {
+		t.Errorf("expected [alpha], got %+v", items)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot / LoadSnapshot
+// ---------------------------------------------------------------------------
+
+func TestSnapshotAndLoadSnapshot(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("b", testItem{Name: "beta", Value: 2})
+	s.Set("a", testItem{Name: "alpha", Value: 1})
+
+	snap := s.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 items in snapshot, got %d", len(snap))
+	}
+
+	s2 := New[testItem]("item")
+	s2.LoadSnapshot(snap)
+	if s2.Count() != 2 {
+		t.Fatalf("expected 2 items after LoadSnapshot, got %d", s2.Count())
+	}
+
+	// LoadSnapshot sorts IDs, so order should be deterministic.
+	ids := s2.ListIDs()
+	if ids[0] != "a" || ids[1] != "b" {
+		t.Errorf("expected sorted IDs after LoadSnapshot, got %v", ids)
+	}
+}
+
+func TestLoadSnapshotReplacesExisting(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("old", testItem{Name: "old", Value: 0})
+
+	snap := map[string]testItem{
+		"new": {Name: "new", Value: 99},
+	}
+	s.LoadSnapshot(snap)
+
+	if s.Count() != 1 {
+		t.Fatalf("expected 1 item, got %d", s.Count())
+	}
+	_, ok := s.Get("old")
+	if ok {
+		t.Error("old item should have been replaced")
+	}
+	got, ok := s.Get("new")
+	if !ok {
+		t.Fatal("new item not found")
+	}
+	if got.Value != 99 {
+		t.Errorf("expected Value=99, got %d", got.Value)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON marshaling
+// ---------------------------------------------------------------------------
+
+func TestMarshalJSON(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("id1", testItem{Name: "alpha", Value: 1})
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("MarshalJSON error: %v", err)
+	}
+
+	var m map[string]testItem
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if m["id1"].Name != "alpha" {
+		t.Errorf("unexpected marshaled value: %+v", m)
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	data := []byte(`{"x":{"name":"x-item","value":42}}`)
+
+	s := New[testItem]("item")
+	if err := json.Unmarshal(data, s); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+
+	got, ok := s.Get("x")
+	if !ok {
+		t.Fatal("expected item x")
+	}
+	if got.Name != "x-item" || got.Value != 42 {
+		t.Errorf("unexpected item: %+v", got)
+	}
+}
+
+func TestUnmarshalJSONInvalid(t *testing.T) {
+	s := New[testItem]("item")
+	if err := json.Unmarshal([]byte(`{bad json`), s); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+func TestReset(t *testing.T) {
+	s := New[testItem]("item")
+	s.Set("a", testItem{Name: "a", Value: 1})
+	_ = s.NextID()
+	_ = s.NextID()
+
+	s.Reset()
+
+	if s.Count() != 0 {
+		t.Errorf("expected 0 items after reset, got %d", s.Count())
+	}
+	// Counter should be reset, so next ID starts at 1 again.
+	if id := s.NextID(); id != "item_000001" {
+		t.Errorf("expected item_000001 after reset, got %s", id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Count
+// ---------------------------------------------------------------------------
+
+func TestCount(t *testing.T) {
+	s := New[testItem]("item")
+	if s.Count() != 0 {
+		t.Errorf("expected 0, got %d", s.Count())
+	}
+	s.Set("a", testItem{})
+	s.Set("b", testItem{})
+	if s.Count() != 2 {
+		t.Errorf("expected 2, got %d", s.Count())
+	}
+	s.Delete("a")
+	if s.Count() != 1 {
+		t.Errorf("expected 1, got %d", s.Count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+func TestConcurrentAccess(t *testing.T) {
+	s := New[testItem]("item")
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := s.NextID()
+			s.Set(id, testItem{Name: "concurrent", Value: i})
+			s.Get(id)
+			s.List()
+			s.Count()
+		}(i)
+	}
+	wg.Wait()
+
+	if s.Count() != 100 {
+		t.Errorf("expected 100, got %d", s.Count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Clock
+// ---------------------------------------------------------------------------
+
+func TestNewClock(t *testing.T) {
+	c := NewClock()
+	if c == nil {
+		t.Fatal("expected non-nil clock")
+	}
+	if c.Offset() != 0 {
+		t.Errorf("expected zero offset, got %v", c.Offset())
+	}
+}
+
+func TestClockNow(t *testing.T) {
+	c := NewClock()
+	before := time.Now()
+	now := c.Now()
+	after := time.Now()
+
+	if now.Before(before) || now.After(after) {
+		t.Errorf("clock.Now() outside expected range: before=%v now=%v after=%v", before, now, after)
+	}
+}
+
+func TestClockAdvance(t *testing.T) {
+	c := NewClock()
+	c.Advance(24 * time.Hour)
+
+	if c.Offset() != 24*time.Hour {
+		t.Errorf("expected 24h offset, got %v", c.Offset())
+	}
+
+	now := c.Now()
+	realNow := time.Now()
+	diff := now.Sub(realNow)
+
+	// The simulated time should be roughly 24h ahead (within a few ms tolerance).
+	if diff < 23*time.Hour+59*time.Minute || diff > 24*time.Hour+1*time.Minute {
+		t.Errorf("expected ~24h offset, got %v", diff)
+	}
+}
+
+func TestClockAdvanceCumulative(t *testing.T) {
+	c := NewClock()
+	c.Advance(1 * time.Hour)
+	c.Advance(2 * time.Hour)
+
+	if c.Offset() != 3*time.Hour {
+		t.Errorf("expected 3h cumulative offset, got %v", c.Offset())
+	}
+}
+
+func TestClockReset(t *testing.T) {
+	c := NewClock()
+	c.Advance(10 * time.Hour)
+	c.Reset()
+
+	if c.Offset() != 0 {
+		t.Errorf("expected zero offset after reset, got %v", c.Offset())
+	}
+}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,0 +1,239 @@
+// Package testutil provides HTTP twin client, admin client, and assertion
+// helpers for testing WonderTwin twins.
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TwinClient is an HTTP client for interacting with a WonderTwin twin in tests.
+type TwinClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	t          *testing.T
+}
+
+// NewTwinClient creates a client pointed at a test server.
+func NewTwinClient(t *testing.T, server *httptest.Server) *TwinClient {
+	return &TwinClient{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+		t:          t,
+	}
+}
+
+// NewTwinClientURL creates a client pointed at a specific URL.
+func NewTwinClientURL(t *testing.T, baseURL string) *TwinClient {
+	return &TwinClient{
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		HTTPClient: &http.Client{},
+		t:          t,
+	}
+}
+
+// Response wraps an HTTP response with helper methods.
+type Response struct {
+	StatusCode int
+	Body       []byte
+	Headers    http.Header
+	t          *testing.T
+}
+
+// JSON unmarshals the response body into v.
+func (r *Response) JSON(v any) {
+	r.t.Helper()
+	if err := json.Unmarshal(r.Body, v); err != nil {
+		r.t.Fatalf("failed to unmarshal response: %v\nbody: %s", err, string(r.Body))
+	}
+}
+
+// JSONMap returns the response body as a map.
+func (r *Response) JSONMap() map[string]any {
+	r.t.Helper()
+	var m map[string]any
+	r.JSON(&m)
+	return m
+}
+
+// AssertStatus asserts the response has the expected status code.
+func (r *Response) AssertStatus(expected int) *Response {
+	r.t.Helper()
+	if r.StatusCode != expected {
+		r.t.Errorf("expected status %d, got %d\nbody: %s", expected, r.StatusCode, string(r.Body))
+	}
+	return r
+}
+
+// AssertBodyContains asserts the response body contains the given substring.
+func (r *Response) AssertBodyContains(substr string) *Response {
+	r.t.Helper()
+	if !strings.Contains(string(r.Body), substr) {
+		r.t.Errorf("expected body to contain %q, got: %s", substr, string(r.Body))
+	}
+	return r
+}
+
+// Get performs a GET request.
+func (c *TwinClient) Get(path string) *Response {
+	c.t.Helper()
+	return c.do("GET", path, nil, nil)
+}
+
+// Post performs a POST request with a JSON body.
+func (c *TwinClient) Post(path string, body any) *Response {
+	c.t.Helper()
+	return c.do("POST", path, body, nil)
+}
+
+// PostForm performs a POST request with form-encoded body.
+func (c *TwinClient) PostForm(path string, values map[string]string) *Response {
+	c.t.Helper()
+	form := make([]string, 0, len(values))
+	for k, v := range values {
+		form = append(form, fmt.Sprintf("%s=%s", k, v))
+	}
+	body := strings.Join(form, "&")
+
+	req, err := http.NewRequest("POST", c.BaseURL+path, strings.NewReader(body))
+	if err != nil {
+		c.t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return c.doReq(req)
+}
+
+// Patch performs a PATCH request with a JSON body.
+func (c *TwinClient) Patch(path string, body any) *Response {
+	c.t.Helper()
+	return c.do("PATCH", path, body, nil)
+}
+
+// Delete performs a DELETE request.
+func (c *TwinClient) Delete(path string) *Response {
+	c.t.Helper()
+	return c.do("DELETE", path, nil, nil)
+}
+
+// DoWithHeaders performs a request with custom headers.
+func (c *TwinClient) DoWithHeaders(method, path string, body any, headers map[string]string) *Response {
+	c.t.Helper()
+	return c.do(method, path, body, headers)
+}
+
+func (c *TwinClient) do(method, path string, body any, headers map[string]string) *Response {
+	c.t.Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			c.t.Fatalf("failed to marshal body: %v", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
+	if err != nil {
+		c.t.Fatalf("failed to create request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return c.doReq(req)
+}
+
+func (c *TwinClient) doReq(req *http.Request) *Response {
+	c.t.Helper()
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		c.t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.t.Fatalf("failed to read response: %v", err)
+	}
+
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+		Headers:    resp.Header,
+		t:          c.t,
+	}
+}
+
+// AdminClient provides convenience methods for the /admin/* control plane.
+type AdminClient struct {
+	*TwinClient
+}
+
+// NewAdminClient creates an admin client from a twin client.
+func NewAdminClient(tc *TwinClient) *AdminClient {
+	return &AdminClient{tc}
+}
+
+// Reset calls POST /admin/reset.
+func (ac *AdminClient) Reset() *Response {
+	ac.t.Helper()
+	return ac.Post("/admin/reset", nil)
+}
+
+// GetState calls GET /admin/state.
+func (ac *AdminClient) GetState() *Response {
+	ac.t.Helper()
+	return ac.Get("/admin/state")
+}
+
+// LoadState calls POST /admin/state with the given state data.
+func (ac *AdminClient) LoadState(state any) *Response {
+	ac.t.Helper()
+	return ac.Post("/admin/state", state)
+}
+
+// InjectFault calls POST /admin/fault/{endpoint}.
+func (ac *AdminClient) InjectFault(endpoint string, fault any) *Response {
+	ac.t.Helper()
+	return ac.Post("/admin/fault/"+strings.TrimPrefix(endpoint, "/"), fault)
+}
+
+// RemoveFault calls DELETE /admin/fault/{endpoint}.
+func (ac *AdminClient) RemoveFault(endpoint string) *Response {
+	ac.t.Helper()
+	return ac.Delete("/admin/fault/" + strings.TrimPrefix(endpoint, "/"))
+}
+
+// GetRequests calls GET /admin/requests.
+func (ac *AdminClient) GetRequests() *Response {
+	ac.t.Helper()
+	return ac.Get("/admin/requests")
+}
+
+// FlushWebhooks calls POST /admin/webhooks/flush.
+func (ac *AdminClient) FlushWebhooks() *Response {
+	ac.t.Helper()
+	return ac.Post("/admin/webhooks/flush", nil)
+}
+
+// AdvanceTime calls POST /admin/time/advance.
+func (ac *AdminClient) AdvanceTime(duration string) *Response {
+	ac.t.Helper()
+	return ac.Post("/admin/time/advance", map[string]string{"duration": duration})
+}
+
+// Health calls GET /admin/health.
+func (ac *AdminClient) Health() *Response {
+	ac.t.Helper()
+	return ac.Get("/admin/health")
+}

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -1,0 +1,452 @@
+package testutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helper: create a test server with typical endpoints
+// ---------------------------------------------------------------------------
+
+func newTestServer() *httptest.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]string{{"id": "1"}, {"id": "2"}})
+	})
+
+	mux.HandleFunc("GET /items/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"id": r.PathValue("id")})
+	})
+
+	mux.HandleFunc("POST /items", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		body["id"] = "new_1"
+		json.NewEncoder(w).Encode(body)
+	})
+
+	mux.HandleFunc("PATCH /items/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"id": r.PathValue("id"), "updated": "true"})
+	})
+
+	mux.HandleFunc("DELETE /items/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("POST /form", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		result := map[string]string{}
+		for k, v := range r.Form {
+			result[k] = v[0]
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+
+	mux.HandleFunc("GET /echo-headers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		headers := map[string]string{}
+		for k := range r.Header {
+			headers[k] = r.Header.Get(k)
+		}
+		json.NewEncoder(w).Encode(headers)
+	})
+
+	// Admin-like endpoints
+	mux.HandleFunc("GET /admin/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	mux.HandleFunc("POST /admin/reset", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "reset"})
+	})
+
+	mux.HandleFunc("GET /admin/state", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"items": []string{"a", "b"}})
+	})
+
+	mux.HandleFunc("POST /admin/state", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "loaded"})
+	})
+
+	mux.HandleFunc("POST /admin/fault/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "injected"})
+	})
+
+	mux.HandleFunc("DELETE /admin/fault/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "removed"})
+	})
+
+	mux.HandleFunc("GET /admin/requests", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]string{{"method": "GET", "path": "/items"}})
+	})
+
+	mux.HandleFunc("POST /admin/webhooks/flush", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "flushed"})
+	})
+
+	mux.HandleFunc("POST /admin/time/advance", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "advanced"})
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// ---------------------------------------------------------------------------
+// TwinClient tests
+// ---------------------------------------------------------------------------
+
+func TestNewTwinClient(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	if tc.BaseURL != srv.URL {
+		t.Errorf("expected BaseURL=%s, got %s", srv.URL, tc.BaseURL)
+	}
+}
+
+func TestNewTwinClientURL(t *testing.T) {
+	tc := NewTwinClientURL(t, "http://localhost:8080/")
+	if tc.BaseURL != "http://localhost:8080" {
+		t.Errorf("expected trailing slash trimmed, got %s", tc.BaseURL)
+	}
+}
+
+func TestTwinClientGet(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	resp.AssertStatus(http.StatusOK)
+	var items []map[string]string
+	resp.JSON(&items)
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestTwinClientPost(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Post("/items", map[string]string{"name": "test"})
+
+	resp.AssertStatus(http.StatusCreated)
+	m := resp.JSONMap()
+	if m["id"] != "new_1" {
+		t.Errorf("expected id=new_1, got %v", m["id"])
+	}
+}
+
+func TestTwinClientPatch(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Patch("/items/42", map[string]string{"name": "updated"})
+
+	resp.AssertStatus(http.StatusOK)
+	m := resp.JSONMap()
+	if m["updated"] != "true" {
+		t.Errorf("expected updated=true, got %v", m["updated"])
+	}
+}
+
+func TestTwinClientDelete(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Delete("/items/42")
+
+	resp.AssertStatus(http.StatusNoContent)
+}
+
+func TestTwinClientPostForm(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.PostForm("/form", map[string]string{"key": "val"})
+
+	resp.AssertStatus(http.StatusOK)
+	m := resp.JSONMap()
+	if m["key"] != "val" {
+		t.Errorf("expected key=val, got %v", m["key"])
+	}
+}
+
+func TestTwinClientDoWithHeaders(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.DoWithHeaders("GET", "/echo-headers", nil, map[string]string{
+		"X-Custom": "header-value",
+	})
+
+	resp.AssertStatus(http.StatusOK)
+	m := resp.JSONMap()
+	if m["X-Custom"] != "header-value" {
+		t.Errorf("expected X-Custom=header-value, got %v", m["X-Custom"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+func TestResponseJSON(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	var items []map[string]string
+	resp.JSON(&items)
+	if len(items) == 0 {
+		t.Error("expected non-empty items")
+	}
+}
+
+func TestResponseJSONMap(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items/42")
+
+	m := resp.JSONMap()
+	if m["id"] != "42" {
+		t.Errorf("expected id=42, got %v", m["id"])
+	}
+}
+
+func TestResponseAssertStatus(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	// Should not fail.
+	resp.AssertStatus(http.StatusOK)
+}
+
+func TestResponseAssertBodyContains(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	resp.AssertBodyContains(`"id"`)
+}
+
+func TestResponseAssertStatusChaining(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	// AssertStatus returns the same Response for chaining.
+	chained := resp.AssertStatus(http.StatusOK)
+	if chained != resp {
+		t.Error("expected AssertStatus to return the same Response for chaining")
+	}
+}
+
+func TestResponseAssertBodyContainsChaining(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	resp := tc.Get("/items")
+
+	// AssertBodyContains returns the same Response for chaining.
+	chained := resp.AssertBodyContains(`"id"`)
+	if chained != resp {
+		t.Error("expected AssertBodyContains to return the same Response for chaining")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AdminClient tests
+// ---------------------------------------------------------------------------
+
+func TestAdminClientHealth(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.Health()
+	resp.AssertStatus(http.StatusOK)
+	m := resp.JSONMap()
+	if m["status"] != "ok" {
+		t.Errorf("expected status=ok, got %v", m["status"])
+	}
+}
+
+func TestAdminClientReset(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.Reset()
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("reset")
+}
+
+func TestAdminClientGetState(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.GetState()
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("items")
+}
+
+func TestAdminClientLoadState(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.LoadState(map[string]any{"key": "value"})
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("loaded")
+}
+
+func TestAdminClientInjectFault(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.InjectFault("/v1/charges", map[string]any{"status_code": 503})
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("injected")
+}
+
+func TestAdminClientRemoveFault(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.RemoveFault("/test")
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("removed")
+}
+
+func TestAdminClientGetRequests(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.GetRequests()
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("method")
+}
+
+func TestAdminClientFlushWebhooks(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.FlushWebhooks()
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("flushed")
+}
+
+func TestAdminClientAdvanceTime(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.AdvanceTime("1h")
+	resp.AssertStatus(http.StatusOK)
+	resp.AssertBodyContains("advanced")
+}
+
+// ---------------------------------------------------------------------------
+// AdminClient with leading slash handling
+// ---------------------------------------------------------------------------
+
+func TestAdminClientInjectFaultStripsLeadingSlash(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	// The InjectFault method should strip the leading "/" from the endpoint
+	// so we end up with /admin/fault/v1/charges (not /admin/fault//v1/charges)
+	resp := ac.InjectFault("/v1/charges", map[string]any{"status_code": 500})
+	resp.AssertStatus(http.StatusOK)
+}
+
+func TestAdminClientRemoveFaultStripsLeadingSlash(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	tc := NewTwinClient(t, srv)
+	ac := NewAdminClient(tc)
+
+	resp := ac.RemoveFault("/test")
+	resp.AssertStatus(http.StatusOK)
+}

--- a/pkg/twincore/middleware.go
+++ b/pkg/twincore/middleware.go
@@ -1,0 +1,308 @@
+package twincore
+
+import (
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// RequestLogEntry captures details of an incoming request for admin inspection.
+type RequestLogEntry struct {
+	Timestamp  time.Time         `json:"timestamp"`
+	Method     string            `json:"method"`
+	Path       string            `json:"path"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	StatusCode int               `json:"status_code"`
+	Duration   time.Duration     `json:"duration_ms"`
+	RequestID  string            `json:"request_id,omitempty"`
+}
+
+// RequestLog is a thread-safe ring buffer of recent requests.
+type RequestLog struct {
+	mu      sync.RWMutex
+	entries []RequestLogEntry
+	maxSize int
+}
+
+// NewRequestLog creates a request log with the given max size.
+func NewRequestLog(maxSize int) *RequestLog {
+	return &RequestLog{
+		entries: make([]RequestLogEntry, 0, maxSize),
+		maxSize: maxSize,
+	}
+}
+
+// Add appends an entry, evicting the oldest if at capacity.
+func (rl *RequestLog) Add(entry RequestLogEntry) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if len(rl.entries) >= rl.maxSize {
+		rl.entries = rl.entries[1:]
+	}
+	rl.entries = append(rl.entries, entry)
+}
+
+// Entries returns a copy of all log entries.
+func (rl *RequestLog) Entries() []RequestLogEntry {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	out := make([]RequestLogEntry, len(rl.entries))
+	copy(out, rl.entries)
+	return out
+}
+
+// Clear removes all entries.
+func (rl *RequestLog) Clear() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.entries = rl.entries[:0]
+}
+
+// FaultConfig defines a fault injection for a specific endpoint pattern.
+type FaultConfig struct {
+	StatusCode int           `json:"status_code"`
+	Body       string        `json:"body,omitempty"`
+	Delay      time.Duration `json:"delay_ms,omitempty"`
+	Rate       float64       `json:"rate"` // 0.0-1.0, probability of fault triggering
+}
+
+// FaultRegistry manages injected faults for specific endpoint patterns.
+type FaultRegistry struct {
+	mu     sync.RWMutex
+	faults map[string]FaultConfig // path pattern -> fault config
+}
+
+// NewFaultRegistry creates a new fault registry.
+func NewFaultRegistry() *FaultRegistry {
+	return &FaultRegistry{
+		faults: make(map[string]FaultConfig),
+	}
+}
+
+// Set injects a fault for the given endpoint pattern.
+func (fr *FaultRegistry) Set(pattern string, fault FaultConfig) {
+	fr.mu.Lock()
+	defer fr.mu.Unlock()
+	if fault.Rate == 0 {
+		fault.Rate = 1.0
+	}
+	fr.faults[pattern] = fault
+}
+
+// Remove removes a fault for the given endpoint pattern.
+func (fr *FaultRegistry) Remove(pattern string) bool {
+	fr.mu.Lock()
+	defer fr.mu.Unlock()
+	_, existed := fr.faults[pattern]
+	delete(fr.faults, pattern)
+	return existed
+}
+
+// Check returns a fault config if one matches the given path, or nil if no fault applies.
+func (fr *FaultRegistry) Check(path string) *FaultConfig {
+	fr.mu.RLock()
+	defer fr.mu.RUnlock()
+	if f, ok := fr.faults[path]; ok {
+		if f.Rate >= 1.0 || rand.Float64() < f.Rate {
+			return &f
+		}
+	}
+	return nil
+}
+
+// All returns all registered faults.
+func (fr *FaultRegistry) All() map[string]FaultConfig {
+	fr.mu.RLock()
+	defer fr.mu.RUnlock()
+	out := make(map[string]FaultConfig, len(fr.faults))
+	for k, v := range fr.faults {
+		out[k] = v
+	}
+	return out
+}
+
+// Reset clears all faults.
+func (fr *FaultRegistry) Reset() {
+	fr.mu.Lock()
+	defer fr.mu.Unlock()
+	fr.faults = make(map[string]FaultConfig)
+}
+
+// IdempotencyTracker tracks idempotency keys and their cached responses.
+type IdempotencyTracker struct {
+	mu      sync.RWMutex
+	entries map[string]idempotencyEntry
+}
+
+type idempotencyEntry struct {
+	StatusCode int
+	Body       []byte
+	CreatedAt  time.Time
+}
+
+// NewIdempotencyTracker creates a new tracker.
+func NewIdempotencyTracker() *IdempotencyTracker {
+	return &IdempotencyTracker{
+		entries: make(map[string]idempotencyEntry),
+	}
+}
+
+// Check returns cached response data for the given key, or false if not seen.
+func (it *IdempotencyTracker) Check(key string) (int, []byte, bool) {
+	it.mu.RLock()
+	defer it.mu.RUnlock()
+	if e, ok := it.entries[key]; ok {
+		return e.StatusCode, e.Body, true
+	}
+	return 0, nil, false
+}
+
+// Store caches a response for the given idempotency key.
+func (it *IdempotencyTracker) Store(key string, statusCode int, body []byte) {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	it.entries[key] = idempotencyEntry{
+		StatusCode: statusCode,
+		Body:       body,
+		CreatedAt:  time.Now(),
+	}
+}
+
+// Reset clears all tracked keys.
+func (it *IdempotencyTracker) Reset() {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	it.entries = make(map[string]idempotencyEntry)
+}
+
+// Middleware provides common middleware functions for all twins.
+type Middleware struct {
+	cfg        *Config
+	logger     *slog.Logger
+	ReqLog     *RequestLog
+	Faults     *FaultRegistry
+	Idempotent *IdempotencyTracker
+}
+
+// NewMiddleware creates a new Middleware instance.
+func NewMiddleware(cfg *Config, logger *slog.Logger) *Middleware {
+	return &Middleware{
+		cfg:        cfg,
+		logger:     logger,
+		ReqLog:     NewRequestLog(1000),
+		Faults:     NewFaultRegistry(),
+		Idempotent: NewIdempotencyTracker(),
+	}
+}
+
+// CORS adds permissive CORS headers (appropriate for a test twin).
+func (m *Middleware) CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Idempotency-Key, Stripe-Account, X-Api-Key")
+		w.Header().Set("Access-Control-Max-Age", "3600")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// statusRecorder captures the status code written by downstream handlers.
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (sr *statusRecorder) WriteHeader(code int) {
+	sr.statusCode = code
+	sr.ResponseWriter.WriteHeader(code)
+}
+
+// RequestLog middleware captures request details into the ring buffer.
+func (m *Middleware) RequestLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, statusCode: 200}
+
+		next.ServeHTTP(rec, r)
+
+		entry := RequestLogEntry{
+			Timestamp:  start,
+			Method:     r.Method,
+			Path:       r.URL.Path,
+			StatusCode: rec.statusCode,
+			Duration:   time.Since(start),
+		}
+		if m.cfg.Verbose {
+			entry.Headers = make(map[string]string)
+			for k := range r.Header {
+				entry.Headers[k] = r.Header.Get(k)
+			}
+		}
+		m.ReqLog.Add(entry)
+
+		if m.cfg.Verbose {
+			m.logger.Debug("request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", rec.statusCode,
+				"duration", time.Since(start),
+			)
+		}
+	})
+}
+
+// LatencyInjection adds configurable latency to every request.
+func (m *Middleware) LatencyInjection(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.cfg.Latency > 0 {
+			// Add some jitter: 80-120% of configured latency
+			jitter := 0.8 + rand.Float64()*0.4
+			delay := time.Duration(float64(m.cfg.Latency) * jitter)
+			time.Sleep(delay)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RandomFailure randomly returns 500 errors based on the configured fail rate.
+func (m *Middleware) RandomFailure(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.cfg.FailRate > 0 && rand.Float64() < m.cfg.FailRate {
+			Error(w, http.StatusInternalServerError, "simulated random failure")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// FaultInjection checks the fault registry and applies any matching faults.
+// This should be applied INSIDE route groups, not globally, so admin endpoints
+// are not affected.
+func (m *Middleware) FaultInjection(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fault := m.Faults.Check(r.URL.Path); fault != nil {
+			if fault.Delay > 0 {
+				time.Sleep(fault.Delay)
+			}
+			if fault.StatusCode > 0 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(fault.StatusCode)
+				if fault.Body != "" {
+					fmt.Fprint(w, fault.Body)
+				} else {
+					fmt.Fprintf(w, `{"error":{"message":"injected fault","type":"api_error","code":%d}}`, fault.StatusCode)
+				}
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/twincore/middleware_test.go
+++ b/pkg/twincore/middleware_test.go
@@ -1,0 +1,502 @@
+package twincore
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// RequestLog
+// ---------------------------------------------------------------------------
+
+func TestNewRequestLog(t *testing.T) {
+	rl := NewRequestLog(10)
+	if rl == nil {
+		t.Fatal("expected non-nil RequestLog")
+	}
+	if len(rl.Entries()) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(rl.Entries()))
+	}
+}
+
+func TestRequestLogAdd(t *testing.T) {
+	rl := NewRequestLog(10)
+	rl.Add(RequestLogEntry{Method: "GET", Path: "/test"})
+
+	entries := rl.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Method != "GET" || entries[0].Path != "/test" {
+		t.Errorf("unexpected entry: %+v", entries[0])
+	}
+}
+
+func TestRequestLogRingBuffer(t *testing.T) {
+	rl := NewRequestLog(3)
+
+	for i := 0; i < 5; i++ {
+		rl.Add(RequestLogEntry{Path: "/" + string(rune('a'+i))})
+	}
+
+	entries := rl.Entries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries (ring buffer), got %d", len(entries))
+	}
+	// oldest entries should have been evicted
+	if entries[0].Path != "/c" {
+		t.Errorf("expected /c, got %s", entries[0].Path)
+	}
+	if entries[1].Path != "/d" {
+		t.Errorf("expected /d, got %s", entries[1].Path)
+	}
+	if entries[2].Path != "/e" {
+		t.Errorf("expected /e, got %s", entries[2].Path)
+	}
+}
+
+func TestRequestLogEntriesReturnsCopy(t *testing.T) {
+	rl := NewRequestLog(10)
+	rl.Add(RequestLogEntry{Path: "/orig"})
+
+	entries := rl.Entries()
+	entries[0].Path = "/mutated"
+
+	fresh := rl.Entries()
+	if fresh[0].Path != "/orig" {
+		t.Error("Entries did not return a copy; mutation leaked")
+	}
+}
+
+func TestRequestLogClear(t *testing.T) {
+	rl := NewRequestLog(10)
+	rl.Add(RequestLogEntry{Path: "/test"})
+	rl.Clear()
+
+	if len(rl.Entries()) != 0 {
+		t.Errorf("expected 0 entries after clear, got %d", len(rl.Entries()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FaultRegistry
+// ---------------------------------------------------------------------------
+
+func TestNewFaultRegistry(t *testing.T) {
+	fr := NewFaultRegistry()
+	if fr == nil {
+		t.Fatal("expected non-nil FaultRegistry")
+	}
+	if len(fr.All()) != 0 {
+		t.Errorf("expected 0 faults, got %d", len(fr.All()))
+	}
+}
+
+func TestFaultRegistrySetAndCheck(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/v1/test", FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	fault := fr.Check("/v1/test")
+	if fault == nil {
+		t.Fatal("expected fault to be returned")
+	}
+	if fault.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", fault.StatusCode)
+	}
+}
+
+func TestFaultRegistrySetDefaultRate(t *testing.T) {
+	fr := NewFaultRegistry()
+	// Rate=0 should default to 1.0
+	fr.Set("/test", FaultConfig{StatusCode: 429, Rate: 0})
+
+	fault := fr.Check("/test")
+	if fault == nil {
+		t.Fatal("expected fault with default rate=1.0")
+	}
+}
+
+func TestFaultRegistryCheckNoMatch(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/v1/foo", FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	if fr.Check("/v1/bar") != nil {
+		t.Error("expected nil for non-matching path")
+	}
+}
+
+func TestFaultRegistryRemove(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/test", FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	if !fr.Remove("/test") {
+		t.Error("expected Remove to return true for existing fault")
+	}
+	if fr.Remove("/test") {
+		t.Error("expected Remove to return false after already removed")
+	}
+	if fr.Check("/test") != nil {
+		t.Error("expected nil after removal")
+	}
+}
+
+func TestFaultRegistryAll(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/a", FaultConfig{StatusCode: 500, Rate: 1.0})
+	fr.Set("/b", FaultConfig{StatusCode: 429, Rate: 1.0})
+
+	all := fr.All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 faults, got %d", len(all))
+	}
+	if all["/a"].StatusCode != 500 || all["/b"].StatusCode != 429 {
+		t.Errorf("unexpected faults: %+v", all)
+	}
+}
+
+func TestFaultRegistryAllReturnsCopy(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/a", FaultConfig{StatusCode: 500, Rate: 1.0})
+
+	all := fr.All()
+	all["/a"] = FaultConfig{StatusCode: 200}
+
+	fresh := fr.All()
+	if fresh["/a"].StatusCode != 500 {
+		t.Error("All did not return a copy; mutation leaked")
+	}
+}
+
+func TestFaultRegistryReset(t *testing.T) {
+	fr := NewFaultRegistry()
+	fr.Set("/test", FaultConfig{StatusCode: 500, Rate: 1.0})
+	fr.Reset()
+
+	if len(fr.All()) != 0 {
+		t.Errorf("expected 0 faults after reset, got %d", len(fr.All()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IdempotencyTracker
+// ---------------------------------------------------------------------------
+
+func TestNewIdempotencyTracker(t *testing.T) {
+	it := NewIdempotencyTracker()
+	if it == nil {
+		t.Fatal("expected non-nil IdempotencyTracker")
+	}
+}
+
+func TestIdempotencyTrackerStoreAndCheck(t *testing.T) {
+	it := NewIdempotencyTracker()
+	it.Store("key1", 200, []byte(`{"id":"123"}`))
+
+	status, body, ok := it.Check("key1")
+	if !ok {
+		t.Fatal("expected key to be found")
+	}
+	if status != 200 {
+		t.Errorf("expected status 200, got %d", status)
+	}
+	if string(body) != `{"id":"123"}` {
+		t.Errorf("unexpected body: %s", string(body))
+	}
+}
+
+func TestIdempotencyTrackerCheckMissing(t *testing.T) {
+	it := NewIdempotencyTracker()
+	_, _, ok := it.Check("nonexistent")
+	if ok {
+		t.Error("expected ok=false for missing key")
+	}
+}
+
+func TestIdempotencyTrackerReset(t *testing.T) {
+	it := NewIdempotencyTracker()
+	it.Store("k", 200, []byte("ok"))
+	it.Reset()
+
+	_, _, ok := it.Check("k")
+	if ok {
+		t.Error("expected key to be cleared after reset")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware – CORS
+// ---------------------------------------------------------------------------
+
+func TestCORSMiddleware(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.CORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Normal request
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("expected Access-Control-Allow-Origin: *")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestCORSOptionsRequest(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	innerCalled := false
+	handler := mw.CORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for OPTIONS, got %d", rec.Code)
+	}
+	if innerCalled {
+		t.Error("expected inner handler NOT to be called for OPTIONS")
+	}
+	if rec.Header().Get("Access-Control-Max-Age") != "3600" {
+		t.Error("expected Access-Control-Max-Age: 3600")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware – RequestLog (the middleware, not the data structure)
+// ---------------------------------------------------------------------------
+
+func TestRequestLogMiddleware(t *testing.T) {
+	cfg := &Config{Verbose: false}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.RequestLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/resources", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	entries := mw.ReqLog.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Method != "POST" {
+		t.Errorf("expected POST, got %s", entries[0].Method)
+	}
+	if entries[0].Path != "/v1/resources" {
+		t.Errorf("expected /v1/resources, got %s", entries[0].Path)
+	}
+	if entries[0].StatusCode != 201 {
+		t.Errorf("expected 201, got %d", entries[0].StatusCode)
+	}
+}
+
+func TestRequestLogMiddlewareVerbose(t *testing.T) {
+	cfg := &Config{Verbose: true}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.RequestLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Custom", "value")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	entries := mw.ReqLog.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Headers == nil {
+		t.Fatal("expected headers to be captured in verbose mode")
+	}
+	if entries[0].Headers["X-Custom"] != "value" {
+		t.Errorf("expected X-Custom=value, got %s", entries[0].Headers["X-Custom"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware – FaultInjection
+// ---------------------------------------------------------------------------
+
+func TestFaultInjectionMiddleware(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+	mw.Faults.Set("/v1/test", FaultConfig{StatusCode: 503, Rate: 1.0})
+
+	innerCalled := false
+	handler := mw.FaultInjection(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/v1/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != 503 {
+		t.Errorf("expected 503 from fault injection, got %d", rec.Code)
+	}
+	if innerCalled {
+		t.Error("expected inner handler NOT to be called when fault is injected")
+	}
+}
+
+func TestFaultInjectionWithCustomBody(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+	mw.Faults.Set("/v1/test", FaultConfig{StatusCode: 429, Body: `{"error":"rate_limited"}`, Rate: 1.0})
+
+	handler := mw.FaultInjection(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/v1/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != 429 {
+		t.Errorf("expected 429, got %d", rec.Code)
+	}
+	if rec.Body.String() != `{"error":"rate_limited"}` {
+		t.Errorf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestFaultInjectionNoFault(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	innerCalled := false
+	handler := mw.FaultInjection(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/v1/clean", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !innerCalled {
+		t.Error("expected inner handler to be called when no fault matches")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware – LatencyInjection
+// ---------------------------------------------------------------------------
+
+func TestLatencyInjectionMiddleware(t *testing.T) {
+	cfg := &Config{Latency: 50 * time.Millisecond}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.LatencyInjection(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	// Expect at least 80% of 50ms = 40ms (due to jitter)
+	if elapsed < 30*time.Millisecond {
+		t.Errorf("expected at least ~40ms latency, got %v", elapsed)
+	}
+}
+
+func TestLatencyInjectionZero(t *testing.T) {
+	cfg := &Config{Latency: 0}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.LatencyInjection(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("expected near-zero latency, got %v", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware – RandomFailure
+// ---------------------------------------------------------------------------
+
+func TestRandomFailureAlways(t *testing.T) {
+	cfg := &Config{FailRate: 1.0}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.RandomFailure(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 with fail rate 1.0, got %d", rec.Code)
+	}
+}
+
+func TestRandomFailureNever(t *testing.T) {
+	cfg := &Config{FailRate: 0.0}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	handler := mw.RandomFailure(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with fail rate 0.0, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewMiddleware
+// ---------------------------------------------------------------------------
+
+func TestNewMiddleware(t *testing.T) {
+	cfg := &Config{}
+	mw := NewMiddleware(cfg, slog.Default())
+
+	if mw.ReqLog == nil {
+		t.Error("expected non-nil ReqLog")
+	}
+	if mw.Faults == nil {
+		t.Error("expected non-nil Faults")
+	}
+	if mw.Idempotent == nil {
+		t.Error("expected non-nil Idempotent")
+	}
+}

--- a/pkg/twincore/server.go
+++ b/pkg/twincore/server.go
@@ -1,0 +1,170 @@
+// Package twincore provides the base HTTP server, CLI flags, middleware chain,
+// and response helpers shared by all WonderTwin twins.
+package twincore
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
+)
+
+// Config holds the common configuration for all twins, parsed from CLI flags.
+type Config struct {
+	Port       int
+	Latency    time.Duration
+	FailRate   float64
+	WebhookURL string
+	SeedFile   string
+	Verbose    bool
+	Name       string // twin name for logging
+}
+
+// ParseFlags parses common CLI flags and returns a Config.
+// The twinName is used for logging and identification.
+func ParseFlags(twinName string) *Config {
+	cfg := &Config{Name: twinName}
+	flag.IntVar(&cfg.Port, "port", 0, "HTTP listen port (default: auto-assigned)")
+	flag.DurationVar(&cfg.Latency, "latency", 0, "Base simulated latency")
+	flag.Float64Var(&cfg.FailRate, "fail-rate", 0.0, "Random failure rate 0.0-1.0")
+	flag.StringVar(&cfg.WebhookURL, "webhook-url", "", "URL to send webhooks to")
+	flag.StringVar(&cfg.SeedFile, "seed-file", "", "Path to JSON fixture for initial state")
+	flag.BoolVar(&cfg.Verbose, "verbose", false, "Enable request/response logging")
+	flag.Parse()
+
+	if cfg.Port == 0 {
+		if p := os.Getenv("PORT"); p != "" {
+			fmt.Sscanf(p, "%d", &cfg.Port)
+		}
+		if cfg.Port == 0 {
+			cfg.Port = 8080
+		}
+	}
+
+	return cfg
+}
+
+// Twin is the base server for a WonderTwin twin. It wraps a chi router with
+// common middleware and provides lifecycle management.
+type Twin struct {
+	Config *Config
+	Router *chi.Mux
+	Logger *slog.Logger
+	mw     *Middleware
+}
+
+// New creates a new Twin with the given config.
+func New(cfg *Config) *Twin {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	if cfg.Verbose {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+	}
+
+	r := chi.NewRouter()
+	mw := NewMiddleware(cfg, logger)
+
+	// Common middleware stack
+	r.Use(chimw.RequestID)
+	r.Use(chimw.RealIP)
+	r.Use(mw.CORS)
+	r.Use(mw.RequestLog)
+	if cfg.Latency > 0 {
+		r.Use(mw.LatencyInjection)
+	}
+	if cfg.FailRate > 0 {
+		r.Use(mw.RandomFailure)
+	}
+
+	return &Twin{
+		Config: cfg,
+		Router: r,
+		Logger: logger,
+		mw:     mw,
+	}
+}
+
+// Middleware returns the middleware instance for external access (e.g., fault injection).
+func (t *Twin) Middleware() *Middleware {
+	return t.mw
+}
+
+// Serve starts the HTTP server and blocks until shutdown signal.
+func (t *Twin) Serve() error {
+	addr := fmt.Sprintf(":%d", t.Config.Port)
+
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      t.Router,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Graceful shutdown
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		t.Logger.Info("starting twin", "name", t.Config.Name, "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			t.Logger.Error("server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-done
+	t.Logger.Info("shutting down twin", "name", t.Config.Name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return srv.Shutdown(ctx)
+}
+
+// ServeHTTP implements http.Handler so Twin can be used directly in tests.
+func (t *Twin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.Router.ServeHTTP(w, r)
+}
+
+// JSON writes a JSON response with the given status code.
+func JSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if v != nil {
+		json.NewEncoder(w).Encode(v)
+	}
+}
+
+// Error writes a JSON error response.
+func Error(w http.ResponseWriter, status int, message string) {
+	JSON(w, status, map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    http.StatusText(status),
+			"code":    status,
+		},
+	})
+}
+
+// StripeError writes an error response in Stripe's error format.
+func StripeError(w http.ResponseWriter, status int, errType, code, message string) {
+	JSON(w, status, map[string]any{
+		"error": map[string]any{
+			"type":    errType,
+			"code":    code,
+			"message": message,
+		},
+	})
+}

--- a/pkg/twincore/server_test.go
+++ b/pkg/twincore/server_test.go
@@ -1,0 +1,251 @@
+package twincore
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// JSON helper
+// ---------------------------------------------------------------------------
+
+func TestJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSON(rec, http.StatusOK, map[string]string{"key": "value"})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if body["key"] != "value" {
+		t.Errorf("expected key=value, got %+v", body)
+	}
+}
+
+func TestJSONNilBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSON(rec, http.StatusNoContent, nil)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %s", rec.Body.String())
+	}
+}
+
+func TestJSONWithDifferentStatuses(t *testing.T) {
+	tests := []struct {
+		status int
+		body   any
+	}{
+		{http.StatusCreated, map[string]string{"id": "123"}},
+		{http.StatusAccepted, map[string]bool{"ok": true}},
+	}
+
+	for _, tt := range tests {
+		rec := httptest.NewRecorder()
+		JSON(rec, tt.status, tt.body)
+
+		if rec.Code != tt.status {
+			t.Errorf("expected %d, got %d", tt.status, rec.Code)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error helper
+// ---------------------------------------------------------------------------
+
+func TestError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Error(rec, http.StatusBadRequest, "something went wrong")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %+v", body)
+	}
+	if errObj["message"] != "something went wrong" {
+		t.Errorf("expected message 'something went wrong', got %v", errObj["message"])
+	}
+	if errObj["type"] != "Bad Request" {
+		t.Errorf("expected type 'Bad Request', got %v", errObj["type"])
+	}
+	if int(errObj["code"].(float64)) != 400 {
+		t.Errorf("expected code 400, got %v", errObj["code"])
+	}
+}
+
+func TestErrorNotFound(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Error(rec, http.StatusNotFound, "resource not found")
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	errObj := body["error"].(map[string]any)
+	if errObj["type"] != "Not Found" {
+		t.Errorf("expected type 'Not Found', got %v", errObj["type"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StripeError helper
+// ---------------------------------------------------------------------------
+
+func TestStripeError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	StripeError(rec, http.StatusPaymentRequired, "card_error", "card_declined", "Your card was declined.")
+
+	if rec.Code != http.StatusPaymentRequired {
+		t.Errorf("expected 402, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %+v", body)
+	}
+	if errObj["type"] != "card_error" {
+		t.Errorf("expected type 'card_error', got %v", errObj["type"])
+	}
+	if errObj["code"] != "card_declined" {
+		t.Errorf("expected code 'card_declined', got %v", errObj["code"])
+	}
+	if errObj["message"] != "Your card was declined." {
+		t.Errorf("expected message, got %v", errObj["message"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Twin creation
+// ---------------------------------------------------------------------------
+
+func TestNewTwin(t *testing.T) {
+	cfg := &Config{
+		Port:    9999,
+		Name:    "test-twin",
+		Verbose: false,
+	}
+	twin := New(cfg)
+
+	if twin == nil {
+		t.Fatal("expected non-nil Twin")
+	}
+	if twin.Config != cfg {
+		t.Error("expected Config to match")
+	}
+	if twin.Router == nil {
+		t.Error("expected non-nil Router")
+	}
+	if twin.Logger == nil {
+		t.Error("expected non-nil Logger")
+	}
+	if twin.Middleware() == nil {
+		t.Error("expected non-nil Middleware")
+	}
+}
+
+func TestNewTwinVerbose(t *testing.T) {
+	cfg := &Config{
+		Port:    9998,
+		Name:    "verbose-twin",
+		Verbose: true,
+	}
+	twin := New(cfg)
+
+	if twin == nil {
+		t.Fatal("expected non-nil Twin")
+	}
+}
+
+func TestNewTwinWithLatencyAndFailRate(t *testing.T) {
+	cfg := &Config{
+		Port:     9997,
+		Name:     "configured-twin",
+		Latency:  100,
+		FailRate: 0.5,
+	}
+	twin := New(cfg)
+
+	if twin == nil {
+		t.Fatal("expected non-nil Twin")
+	}
+}
+
+func TestTwinServeHTTP(t *testing.T) {
+	cfg := &Config{Name: "test-twin"}
+	twin := New(cfg)
+
+	// Mount a test handler
+	twin.Router.Get("/ping", func(w http.ResponseWriter, r *http.Request) {
+		JSON(w, http.StatusOK, map[string]string{"pong": "true"})
+	})
+
+	req := httptest.NewRequest("GET", "/ping", nil)
+	rec := httptest.NewRecorder()
+	twin.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if body["pong"] != "true" {
+		t.Errorf("expected pong=true, got %+v", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// statusRecorder
+// ---------------------------------------------------------------------------
+
+func TestStatusRecorderDefaultCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec, statusCode: 200}
+
+	// Without explicit WriteHeader, statusCode should remain 200 (the default).
+	if sr.statusCode != 200 {
+		t.Errorf("expected default status 200, got %d", sr.statusCode)
+	}
+}
+
+func TestStatusRecorderExplicitCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec, statusCode: 200}
+
+	sr.WriteHeader(404)
+	if sr.statusCode != 404 {
+		t.Errorf("expected 404, got %d", sr.statusCode)
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,264 @@
+// Package webhook provides an outbound webhook dispatcher with delivery,
+// retry, and pluggable signing for WonderTwin twins.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Signer signs webhook payloads. Each twin implements its own signing scheme.
+type Signer interface {
+	// Sign returns headers to add to the webhook request for signature verification.
+	Sign(payload []byte, secret string) map[string]string
+}
+
+// Event represents a webhook event to be dispatched.
+type Event struct {
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Payload   map[string]any `json:"data"`
+	CreatedAt time.Time      `json:"created_at"`
+}
+
+// Delivery records a webhook delivery attempt.
+type Delivery struct {
+	EventID    string    `json:"event_id"`
+	URL        string    `json:"url"`
+	StatusCode int       `json:"status_code"`
+	Error      string    `json:"error,omitempty"`
+	Attempt    int       `json:"attempt"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
+// Dispatcher manages outbound webhook delivery.
+type Dispatcher struct {
+	mu          sync.RWMutex
+	url         string
+	secret      string
+	signer      Signer
+	logger      *slog.Logger
+	queue       []Event
+	deliveries  []Delivery
+	maxRetries  int
+	retryDelay  time.Duration
+	client      *http.Client
+	eventPrefix string
+	counter     int
+	autoDeliver bool
+}
+
+// Config configures the webhook dispatcher.
+type Config struct {
+	URL         string
+	Secret      string
+	Signer      Signer
+	Logger      *slog.Logger
+	MaxRetries  int
+	RetryDelay  time.Duration
+	EventPrefix string // e.g., "evt" for Stripe-style events
+	AutoDeliver bool   // automatically deliver events when queued
+}
+
+// NewDispatcher creates a new webhook dispatcher.
+func NewDispatcher(cfg Config) *Dispatcher {
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.RetryDelay == 0 {
+		cfg.RetryDelay = 1 * time.Second
+	}
+	if cfg.EventPrefix == "" {
+		cfg.EventPrefix = "evt"
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	return &Dispatcher{
+		url:         cfg.URL,
+		secret:      cfg.Secret,
+		signer:      cfg.Signer,
+		logger:      cfg.Logger,
+		queue:       make([]Event, 0),
+		deliveries:  make([]Delivery, 0),
+		maxRetries:  cfg.MaxRetries,
+		retryDelay:  cfg.RetryDelay,
+		client:      &http.Client{Timeout: 30 * time.Second},
+		eventPrefix: cfg.EventPrefix,
+		autoDeliver: cfg.AutoDeliver,
+	}
+}
+
+// SetURL updates the webhook delivery URL.
+func (d *Dispatcher) SetURL(url string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.url = url
+}
+
+// SetSecret updates the webhook signing secret.
+func (d *Dispatcher) SetSecret(secret string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.secret = secret
+}
+
+// Enqueue adds an event to the dispatch queue. If AutoDeliver is true,
+// it will be delivered asynchronously.
+func (d *Dispatcher) Enqueue(eventType string, payload map[string]any) Event {
+	d.mu.Lock()
+	d.counter++
+	evt := Event{
+		ID:        fmt.Sprintf("%s_%06d", d.eventPrefix, d.counter),
+		Type:      eventType,
+		Payload:   payload,
+		CreatedAt: time.Now(),
+	}
+	d.queue = append(d.queue, evt)
+	autoDeliver := d.autoDeliver
+	d.mu.Unlock()
+
+	if autoDeliver {
+		go d.deliverEvent(evt)
+	}
+
+	return evt
+}
+
+// Flush delivers all queued events synchronously.
+func (d *Dispatcher) Flush() error {
+	d.mu.RLock()
+	events := make([]Event, len(d.queue))
+	copy(events, d.queue)
+	d.mu.RUnlock()
+
+	var lastErr error
+	for _, evt := range events {
+		if err := d.deliverEvent(evt); err != nil {
+			lastErr = err
+		}
+	}
+
+	d.mu.Lock()
+	d.queue = d.queue[:0]
+	d.mu.Unlock()
+
+	return lastErr
+}
+
+// FlushWebhooks implements admin.WebhookFlusher.
+func (d *Dispatcher) FlushWebhooks() error {
+	return d.Flush()
+}
+
+func (d *Dispatcher) deliverEvent(evt Event) error {
+	d.mu.RLock()
+	url := d.url
+	secret := d.secret
+	signer := d.signer
+	d.mu.RUnlock()
+
+	if url == "" {
+		d.logger.Debug("no webhook URL configured, skipping delivery", "event_id", evt.ID)
+		return nil
+	}
+
+	payload, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= d.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		if signer != nil && secret != "" {
+			for k, v := range signer.Sign(payload, secret) {
+				req.Header.Set(k, v)
+			}
+		}
+
+		resp, err := d.client.Do(req)
+		delivery := Delivery{
+			EventID:   evt.ID,
+			URL:       url,
+			Attempt:   attempt,
+			Timestamp: time.Now(),
+		}
+
+		if err != nil {
+			delivery.Error = err.Error()
+			delivery.StatusCode = 0
+			lastErr = err
+		} else {
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+			delivery.StatusCode = resp.StatusCode
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				d.mu.Lock()
+				d.deliveries = append(d.deliveries, delivery)
+				d.mu.Unlock()
+				return nil
+			}
+			lastErr = fmt.Errorf("webhook delivery failed: status %d", resp.StatusCode)
+		}
+
+		d.mu.Lock()
+		d.deliveries = append(d.deliveries, delivery)
+		d.mu.Unlock()
+
+		if attempt < d.maxRetries {
+			time.Sleep(d.retryDelay)
+		}
+	}
+
+	return lastErr
+}
+
+// Deliveries returns all delivery records.
+func (d *Dispatcher) Deliveries() []Delivery {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make([]Delivery, len(d.deliveries))
+	copy(out, d.deliveries)
+	return out
+}
+
+// QueuedEvents returns all queued but undelivered events.
+func (d *Dispatcher) QueuedEvents() []Event {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make([]Event, len(d.queue))
+	copy(out, d.queue)
+	return out
+}
+
+// AllEvents returns all events (queued + delivered).
+func (d *Dispatcher) AllEvents() []Event {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make([]Event, len(d.queue))
+	copy(out, d.queue)
+	return out
+}
+
+// Reset clears all events, deliveries, and the queue.
+func (d *Dispatcher) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.queue = d.queue[:0]
+	d.deliveries = d.deliveries[:0]
+	d.counter = 0
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,409 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Mock signer
+// ---------------------------------------------------------------------------
+
+type mockSigner struct{}
+
+func (m *mockSigner) Sign(payload []byte, secret string) map[string]string {
+	return map[string]string{
+		"X-Signature": "sig_" + secret,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewDispatcher
+// ---------------------------------------------------------------------------
+
+func TestNewDispatcher(t *testing.T) {
+	d := NewDispatcher(Config{})
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	if d.maxRetries != 3 {
+		t.Errorf("expected default maxRetries=3, got %d", d.maxRetries)
+	}
+	if d.retryDelay != 1*time.Second {
+		t.Errorf("expected default retryDelay=1s, got %v", d.retryDelay)
+	}
+	if d.eventPrefix != "evt" {
+		t.Errorf("expected default eventPrefix=evt, got %s", d.eventPrefix)
+	}
+}
+
+func TestNewDispatcherCustomConfig(t *testing.T) {
+	d := NewDispatcher(Config{
+		MaxRetries:  5,
+		RetryDelay:  2 * time.Second,
+		EventPrefix: "whevt",
+	})
+	if d.maxRetries != 5 {
+		t.Errorf("expected maxRetries=5, got %d", d.maxRetries)
+	}
+	if d.retryDelay != 2*time.Second {
+		t.Errorf("expected retryDelay=2s, got %v", d.retryDelay)
+	}
+	if d.eventPrefix != "whevt" {
+		t.Errorf("expected eventPrefix=whevt, got %s", d.eventPrefix)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue
+// ---------------------------------------------------------------------------
+
+func TestEnqueue(t *testing.T) {
+	d := NewDispatcher(Config{})
+	evt := d.Enqueue("customer.created", map[string]any{"id": "cus_123"})
+
+	if evt.ID != "evt_000001" {
+		t.Errorf("expected evt_000001, got %s", evt.ID)
+	}
+	if evt.Type != "customer.created" {
+		t.Errorf("expected customer.created, got %s", evt.Type)
+	}
+	if evt.Payload["id"] != "cus_123" {
+		t.Errorf("unexpected payload: %+v", evt.Payload)
+	}
+
+	queued := d.QueuedEvents()
+	if len(queued) != 1 {
+		t.Fatalf("expected 1 queued event, got %d", len(queued))
+	}
+}
+
+func TestEnqueueMultiple(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.Enqueue("type.a", nil)
+	d.Enqueue("type.b", nil)
+	d.Enqueue("type.c", nil)
+
+	queued := d.QueuedEvents()
+	if len(queued) != 3 {
+		t.Fatalf("expected 3 queued events, got %d", len(queued))
+	}
+	if queued[0].ID != "evt_000001" || queued[2].ID != "evt_000003" {
+		t.Errorf("unexpected IDs: %s, %s", queued[0].ID, queued[2].ID)
+	}
+}
+
+func TestEnqueueAutoDeliver(t *testing.T) {
+	var received atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{
+		URL:         srv.URL,
+		AutoDeliver: true,
+		MaxRetries:  1,
+	})
+
+	d.Enqueue("test.event", nil)
+
+	// Wait for async delivery
+	time.Sleep(200 * time.Millisecond)
+
+	if received.Load() != 1 {
+		t.Errorf("expected 1 delivery for auto-deliver, got %d", received.Load())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flush – successful delivery
+// ---------------------------------------------------------------------------
+
+func TestFlushSuccess(t *testing.T) {
+	var receivedEvents []Event
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var evt Event
+		json.NewDecoder(r.Body).Decode(&evt)
+		receivedEvents = append(receivedEvents, evt)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{
+		URL:        srv.URL,
+		MaxRetries: 1,
+	})
+
+	d.Enqueue("order.created", map[string]any{"order_id": "ord_1"})
+	d.Enqueue("order.paid", map[string]any{"order_id": "ord_1"})
+
+	err := d.Flush()
+	if err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if len(receivedEvents) != 2 {
+		t.Fatalf("expected 2 delivered events, got %d", len(receivedEvents))
+	}
+	if receivedEvents[0].Type != "order.created" {
+		t.Errorf("expected order.created, got %s", receivedEvents[0].Type)
+	}
+	if receivedEvents[1].Type != "order.paid" {
+		t.Errorf("expected order.paid, got %s", receivedEvents[1].Type)
+	}
+
+	// After flush, queue should be empty.
+	if len(d.QueuedEvents()) != 0 {
+		t.Errorf("expected empty queue after flush, got %d", len(d.QueuedEvents()))
+	}
+
+	// Deliveries should be recorded.
+	deliveries := d.Deliveries()
+	if len(deliveries) != 2 {
+		t.Fatalf("expected 2 deliveries, got %d", len(deliveries))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flush – retry on failure
+// ---------------------------------------------------------------------------
+
+func TestFlushRetryOnFailure(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := attempts.Add(1)
+		if count <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{
+		URL:        srv.URL,
+		MaxRetries: 3,
+		RetryDelay: 1 * time.Millisecond, // fast retries for testing
+	})
+
+	d.Enqueue("test.retry", nil)
+
+	err := d.Flush()
+	if err != nil {
+		t.Fatalf("Flush should succeed after retries, got: %v", err)
+	}
+
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestFlushAllRetriesFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{
+		URL:        srv.URL,
+		MaxRetries: 2,
+		RetryDelay: 1 * time.Millisecond,
+	})
+
+	d.Enqueue("test.fail", nil)
+
+	err := d.Flush()
+	if err == nil {
+		t.Fatal("expected error when all retries fail")
+	}
+
+	deliveries := d.Deliveries()
+	if len(deliveries) != 2 {
+		t.Fatalf("expected 2 delivery records (one per attempt), got %d", len(deliveries))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flush – no URL configured
+// ---------------------------------------------------------------------------
+
+func TestFlushNoURL(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.Enqueue("test.event", nil)
+
+	err := d.Flush()
+	if err != nil {
+		t.Fatalf("expected no error when URL is empty, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flush with signer
+// ---------------------------------------------------------------------------
+
+func TestFlushWithSigner(t *testing.T) {
+	var signatureHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		signatureHeader = r.Header.Get("X-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{
+		URL:        srv.URL,
+		Secret:     "whsec_test",
+		Signer:     &mockSigner{},
+		MaxRetries: 1,
+	})
+
+	d.Enqueue("test.signed", nil)
+	err := d.Flush()
+	if err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if signatureHeader != "sig_whsec_test" {
+		t.Errorf("expected signature header sig_whsec_test, got %s", signatureHeader)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FlushWebhooks (alias)
+// ---------------------------------------------------------------------------
+
+func TestFlushWebhooks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{URL: srv.URL, MaxRetries: 1})
+	d.Enqueue("test", nil)
+
+	err := d.FlushWebhooks()
+	if err != nil {
+		t.Fatalf("FlushWebhooks error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetURL / SetSecret
+// ---------------------------------------------------------------------------
+
+func TestSetURL(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.SetURL("http://example.com/webhook")
+
+	// Enqueue and flush to verify URL is used.
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d.SetURL(srv.URL)
+	d.Enqueue("test", nil)
+	d.Flush()
+
+	if !called {
+		t.Error("expected webhook to be delivered to updated URL")
+	}
+}
+
+func TestSetSecret(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.SetSecret("new_secret")
+	// Just verify it doesn't panic; secret is used internally.
+}
+
+// ---------------------------------------------------------------------------
+// Deliveries
+// ---------------------------------------------------------------------------
+
+func TestDeliveriesReturnsCopy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{URL: srv.URL, MaxRetries: 1})
+	d.Enqueue("test", nil)
+	d.Flush()
+
+	deliveries := d.Deliveries()
+	if len(deliveries) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(deliveries))
+	}
+
+	deliveries[0].EventID = "mutated"
+	fresh := d.Deliveries()
+	if fresh[0].EventID == "mutated" {
+		t.Error("Deliveries did not return a copy; mutation leaked")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AllEvents / QueuedEvents
+// ---------------------------------------------------------------------------
+
+func TestAllEvents(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.Enqueue("a", nil)
+	d.Enqueue("b", nil)
+
+	all := d.AllEvents()
+	if len(all) != 2 {
+		t.Errorf("expected 2, got %d", len(all))
+	}
+}
+
+func TestQueuedEventsReturnsCopy(t *testing.T) {
+	d := NewDispatcher(Config{})
+	d.Enqueue("a", nil)
+
+	q := d.QueuedEvents()
+	q[0].Type = "mutated"
+
+	fresh := d.QueuedEvents()
+	if fresh[0].Type == "mutated" {
+		t.Error("QueuedEvents did not return a copy; mutation leaked")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+func TestReset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(Config{URL: srv.URL, MaxRetries: 1})
+	d.Enqueue("a", nil)
+	d.Flush()
+	d.Enqueue("b", nil)
+
+	d.Reset()
+
+	if len(d.QueuedEvents()) != 0 {
+		t.Errorf("expected 0 queued events after reset, got %d", len(d.QueuedEvents()))
+	}
+	if len(d.Deliveries()) != 0 {
+		t.Errorf("expected 0 deliveries after reset, got %d", len(d.Deliveries()))
+	}
+
+	// Counter should reset, so next event starts at 1.
+	evt := d.Enqueue("c", nil)
+	if evt.ID != "evt_000001" {
+		t.Errorf("expected evt_000001 after reset, got %s", evt.ID)
+	}
+}

--- a/twin-clerk/cmd/twin-clerk/main.go
+++ b/twin-clerk/cmd/twin-clerk/main.go
@@ -1,0 +1,66 @@
+// twin-clerk is a WonderTwin twin that simulates the Clerk auth API.
+// It implements the subset of Clerk's Backend API used for authentication,
+// with JSON request/response parsing compatible with clerk-sdk-go/v2.
+//
+// CRITICAL: This twin generates valid JWTs and exposes a JWKS endpoint so that
+// auth middleware (which calls jwt.Verify()) works correctly.
+//
+// SDK compatibility target: github.com/clerk/clerk-sdk-go/v2
+// Integration method: CLERK_API_URL env var
+// Default port: 12112
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-clerk")
+	if cfg.Port == 0 {
+		cfg.Port = 12112
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// JWT manager with RSA keypair for signing tokens
+	jwtMgr, err := api.NewJWTManager()
+	if err != nil {
+		log.Fatalf("failed to initialize JWT manager: %v", err)
+	}
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware(), jwtMgr)
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane (shared with all twins)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-clerk ready",
+		"port", cfg.Port,
+		"jwks_endpoint", "/.well-known/jwks.json",
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-clerk/go.mod
+++ b/twin-clerk/go.mod
@@ -1,0 +1,11 @@
+module github.com/wondertwin-ai/wondertwin/twin-clerk
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg

--- a/twin-clerk/go.sum
+++ b/twin-clerk/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/twin-clerk/internal/api/handlers_jwt.go
+++ b/twin-clerk/internal/api/handlers_jwt.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+)
+
+// JWTManager manages RSA key pairs and JWT generation for the Clerk twin.
+// It generates an RSA keypair at startup and exposes the public key via JWKS.
+type JWTManager struct {
+	mu         sync.RWMutex
+	privateKey *rsa.PrivateKey
+	publicKey  *rsa.PublicKey
+	keyID      string
+}
+
+// NewJWTManager creates a new JWTManager with a fresh RSA-2048 keypair.
+func NewJWTManager() (*JWTManager, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	// Generate a stable key ID from the public key modulus
+	hash := sha256.Sum256(key.PublicKey.N.Bytes())
+	kid := base64.RawURLEncoding.EncodeToString(hash[:8])
+
+	return &JWTManager{
+		privateKey: key,
+		publicKey:  &key.PublicKey,
+		keyID:      kid,
+	}, nil
+}
+
+// GenerateToken creates a signed JWT for the given user/session.
+// Claims match the Clerk JWT format used by clerk-sdk-go/v2's jwt.Verify().
+func (m *JWTManager) GenerateToken(userID, sessionID string, extraClaims map[string]any) (string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": "https://clerk.twin.wondertwin.dev",
+		"sub": userID,
+		"aud": "wondertwin",
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"sid": sessionID,
+		"azp": "wondertwin",
+	}
+
+	// Add extra claims if provided
+	for k, v := range extraClaims {
+		claims[k] = v
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = m.keyID
+
+	signed, err := token.SignedString(m.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+
+	return signed, nil
+}
+
+// JWKS represents a JSON Web Key Set.
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK represents a single JSON Web Key.
+type JWK struct {
+	KTY string `json:"kty"`
+	Use string `json:"use"`
+	KID string `json:"kid"`
+	ALG string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// GetJWKS returns the JWKS endpoint: the public key in JWK format.
+func (m *JWTManager) GetJWKS() JWKS {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return JWKS{
+		Keys: []JWK{
+			{
+				KTY: "RSA",
+				Use: "sig",
+				KID: m.keyID,
+				ALG: "RS256",
+				N:   base64.RawURLEncoding.EncodeToString(m.publicKey.N.Bytes()),
+				E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(m.publicKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+// GetJWKS handles GET /.well-known/jwks.json.
+// This is the endpoint that Clerk SDKs use to fetch the public key for JWT verification.
+func (h *Handler) GetJWKS(w http.ResponseWriter, r *http.Request) {
+	jwks := h.jwtMgr.GetJWKS()
+	twincore.JSON(w, http.StatusOK, jwks)
+}
+
+// generateJWTRequest is the JSON body for POST /admin/jwt/generate.
+type generateJWTRequest struct {
+	UserID      string         `json:"user_id"`
+	SessionID   string         `json:"session_id,omitempty"`
+	ExpiresIn   string         `json:"expires_in,omitempty"` // Go duration string, e.g., "1h"
+	ExtraClaims map[string]any `json:"extra_claims,omitempty"`
+}
+
+// GenerateJWT handles POST /admin/jwt/generate.
+// This is a test-only endpoint for generating JWTs for integration tests.
+func (h *Handler) GenerateJWT(w http.ResponseWriter, r *http.Request) {
+	var req generateJWTRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	if req.UserID == "" {
+		clerkError(w, http.StatusBadRequest, "form_param_missing",
+			"user_id is required.", "You must provide a user_id to generate a JWT.")
+		return
+	}
+
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID = "sess_sim_" + req.UserID
+	}
+
+	// Handle custom expiration
+	extraClaims := req.ExtraClaims
+	if req.ExpiresIn != "" {
+		d, err := time.ParseDuration(req.ExpiresIn)
+		if err != nil {
+			clerkError(w, http.StatusBadRequest, "form_param_invalid",
+				"Invalid expires_in duration.", err.Error())
+			return
+		}
+		if extraClaims == nil {
+			extraClaims = make(map[string]any)
+		}
+		extraClaims["exp"] = time.Now().Add(d).Unix()
+	}
+
+	token, err := h.jwtMgr.GenerateToken(req.UserID, sessionID, extraClaims)
+	if err != nil {
+		clerkError(w, http.StatusInternalServerError, "internal_error",
+			"Failed to generate JWT.", err.Error())
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"token":      token,
+		"user_id":    req.UserID,
+		"session_id": sessionID,
+	})
+}

--- a/twin-clerk/internal/api/handlers_organizations.go
+++ b/twin-clerk/internal/api/handlers_organizations.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+// createOrganizationRequest is the JSON body for POST /v1/organizations.
+type createOrganizationRequest struct {
+	Name                  string         `json:"name"`
+	Slug                  string         `json:"slug,omitempty"`
+	MaxAllowedMemberships int            `json:"max_allowed_memberships,omitempty"`
+	CreatedBy             string         `json:"created_by,omitempty"`
+	PublicMetadata        map[string]any `json:"public_metadata,omitempty"`
+	PrivateMetadata       map[string]any `json:"private_metadata,omitempty"`
+}
+
+// updateOrganizationRequest is the JSON body for PATCH /v1/organizations/{id}.
+type updateOrganizationRequest struct {
+	Name                  *string        `json:"name,omitempty"`
+	Slug                  *string        `json:"slug,omitempty"`
+	MaxAllowedMemberships *int           `json:"max_allowed_memberships,omitempty"`
+	PublicMetadata        map[string]any `json:"public_metadata,omitempty"`
+	PrivateMetadata       map[string]any `json:"private_metadata,omitempty"`
+}
+
+// CreateOrganization handles POST /v1/organizations.
+func (h *Handler) CreateOrganization(w http.ResponseWriter, r *http.Request) {
+	var req createOrganizationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	if req.Name == "" {
+		clerkError(w, http.StatusUnprocessableEntity, "form_param_missing",
+			"name is required.", "You must provide a name for the organization.")
+		return
+	}
+
+	id := h.store.Organizations.NextID()
+	now := store.Now()
+
+	slug := req.Slug
+	if slug == "" {
+		slug = strings.ToLower(strings.ReplaceAll(req.Name, " ", "-"))
+	}
+
+	maxMembers := req.MaxAllowedMemberships
+	if maxMembers == 0 {
+		maxMembers = 5
+	}
+
+	publicMeta := req.PublicMetadata
+	if publicMeta == nil {
+		publicMeta = make(map[string]any)
+	}
+
+	org := store.Organization{
+		ID:                    id,
+		Object:                "organization",
+		Name:                  req.Name,
+		Slug:                  slug,
+		MembersCount:          0,
+		MaxAllowedMemberships: maxMembers,
+		PublicMetadata:        publicMeta,
+		PrivateMetadata:       req.PrivateMetadata,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+
+	// If created_by is specified, add the creator as an admin member
+	if req.CreatedBy != "" {
+		if _, ok := h.store.Users.Get(req.CreatedBy); ok {
+			memID := h.store.OrgMembers.NextID()
+			membership := store.OrgMembership{
+				ID:           memID,
+				Object:       "organization_membership",
+				Role:         "admin",
+				Organization: &org,
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}
+			h.store.OrgMembers.Set(memID, membership)
+			org.MembersCount = 1
+		}
+	}
+
+	h.store.Organizations.Set(id, org)
+	twincore.JSON(w, http.StatusOK, org)
+}
+
+// GetOrganization handles GET /v1/organizations/{id}.
+func (h *Handler) GetOrganization(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Look up by ID first, then by slug
+	org, ok := h.store.Organizations.Get(id)
+	if !ok {
+		// Try finding by slug
+		orgs := h.store.Organizations.Filter(func(oid string, o store.Organization) bool {
+			return o.Slug == id
+		})
+		if len(orgs) > 0 {
+			org = orgs[0]
+			ok = true
+		}
+	}
+
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Organization not found.",
+			fmt.Sprintf("No organization was found with id or slug %s.", id))
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, org)
+}
+
+// UpdateOrganization handles PATCH /v1/organizations/{id}.
+func (h *Handler) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	org, ok := h.store.Organizations.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Organization not found.",
+			fmt.Sprintf("No organization was found with id %s.", id))
+		return
+	}
+
+	var req updateOrganizationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	if req.Name != nil {
+		org.Name = *req.Name
+	}
+	if req.Slug != nil {
+		org.Slug = *req.Slug
+	}
+	if req.MaxAllowedMemberships != nil {
+		org.MaxAllowedMemberships = *req.MaxAllowedMemberships
+	}
+	if req.PublicMetadata != nil {
+		org.PublicMetadata = req.PublicMetadata
+	}
+	if req.PrivateMetadata != nil {
+		org.PrivateMetadata = req.PrivateMetadata
+	}
+
+	org.UpdatedAt = store.Now()
+	h.store.Organizations.Set(id, org)
+
+	twincore.JSON(w, http.StatusOK, org)
+}
+
+// DeleteOrganization handles DELETE /v1/organizations/{id}.
+func (h *Handler) DeleteOrganization(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if !h.store.Organizations.Delete(id) {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Organization not found.",
+			fmt.Sprintf("No organization was found with id %s.", id))
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"object":  "organization",
+		"deleted": true,
+	})
+}
+
+// ListOrganizations handles GET /v1/organizations.
+func (h *Handler) ListOrganizations(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		fmt.Sscanf(o, "%d", &offset)
+	}
+
+	allOrgs := h.store.Organizations.List()
+
+	// Filter by query if provided
+	query := r.URL.Query().Get("query")
+	var filtered []store.Organization
+	for _, org := range allOrgs {
+		if query != "" {
+			if !strings.Contains(strings.ToLower(org.Name), strings.ToLower(query)) &&
+				!strings.Contains(strings.ToLower(org.Slug), strings.ToLower(query)) {
+				continue
+			}
+		}
+		filtered = append(filtered, org)
+	}
+
+	total := len(filtered)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	page := filtered[offset:end]
+
+	if page == nil {
+		page = []store.Organization{}
+	}
+
+	twincore.JSON(w, http.StatusOK, store.ClerkList[store.Organization]{
+		Data:       page,
+		TotalCount: total,
+	})
+}

--- a/twin-clerk/internal/api/handlers_sessions.go
+++ b/twin-clerk/internal/api/handlers_sessions.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+// adminCreateSessionRequest is the JSON body for POST /admin/sessions.
+type adminCreateSessionRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// AdminCreateSession creates a session for a user (admin/test endpoint).
+func (h *Handler) AdminCreateSession(w http.ResponseWriter, r *http.Request) {
+	var req adminCreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	if req.UserID == "" {
+		clerkError(w, http.StatusBadRequest, "form_param_missing",
+			"user_id is required.", "You must provide a user_id to create a session.")
+		return
+	}
+
+	// Verify user exists
+	if _, ok := h.store.Users.Get(req.UserID); !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"User not found.",
+			fmt.Sprintf("No user was found with id %s.", req.UserID))
+		return
+	}
+
+	id := h.store.Sessions.NextID()
+	now := store.Now()
+
+	// Session expires in 7 days, abandoned in 30 days
+	expireAt := now + 7*24*60*60*1000
+	abandonAt := now + 30*24*60*60*1000
+
+	session := store.Session{
+		ID:           id,
+		Object:       "session",
+		UserID:       req.UserID,
+		ClientID:     fmt.Sprintf("client_%s", id),
+		Status:       "active",
+		LastActiveAt: now,
+		ExpireAt:     expireAt,
+		AbandonAt:    abandonAt,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	h.store.Sessions.Set(id, session)
+	twincore.JSON(w, http.StatusOK, session)
+}
+
+// GetSession handles GET /v1/sessions/{id}.
+func (h *Handler) GetSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	session, ok := h.store.Sessions.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Session not found.",
+			fmt.Sprintf("No session was found with id %s.", id))
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, session)
+}
+
+// ListSessions handles GET /v1/sessions.
+func (h *Handler) ListSessions(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		fmt.Sscanf(o, "%d", &offset)
+	}
+
+	// Filter by user_id and status
+	userID := r.URL.Query().Get("user_id")
+	status := r.URL.Query().Get("status")
+
+	allSessions := h.store.Sessions.List()
+
+	var filtered []store.Session
+	for _, s := range allSessions {
+		if userID != "" && s.UserID != userID {
+			continue
+		}
+		if status != "" && s.Status != status {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	total := len(filtered)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	page := filtered[offset:end]
+
+	if page == nil {
+		page = []store.Session{}
+	}
+
+	twincore.JSON(w, http.StatusOK, store.ClerkList[store.Session]{
+		Data:       page,
+		TotalCount: total,
+	})
+}
+
+// verifySessionRequest is the JSON body for POST /v1/sessions/{id}/verify.
+type verifySessionRequest struct {
+	Token string `json:"token"`
+}
+
+// VerifySession handles POST /v1/sessions/{id}/verify.
+// In the real Clerk API, this verifies a session token. For the twin,
+// we just check the session exists and is active.
+func (h *Handler) VerifySession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	session, ok := h.store.Sessions.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Session not found.",
+			fmt.Sprintf("No session was found with id %s.", id))
+		return
+	}
+
+	if session.Status != "active" {
+		clerkError(w, http.StatusUnauthorized, "session_not_active",
+			"Session is not active.",
+			fmt.Sprintf("Session %s has status %s.", id, session.Status))
+		return
+	}
+
+	// Generate a fresh JWT for this session
+	token, err := h.jwtMgr.GenerateToken(session.UserID, session.ID, nil)
+	if err != nil {
+		clerkError(w, http.StatusInternalServerError, "internal_error",
+			"Failed to generate session token.", err.Error())
+		return
+	}
+
+	// Update last active
+	now := store.Now()
+	session.LastActiveAt = now
+	session.UpdatedAt = now
+	session.LastActiveToken = &store.TokenResponse{
+		Object: "token",
+		JWT:    token,
+	}
+	h.store.Sessions.Set(id, session)
+
+	twincore.JSON(w, http.StatusOK, session)
+}
+
+// RevokeSession handles POST /v1/sessions/{id}/revoke.
+func (h *Handler) RevokeSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	session, ok := h.store.Sessions.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"Session not found.",
+			fmt.Sprintf("No session was found with id %s.", id))
+		return
+	}
+
+	session.Status = "revoked"
+	session.UpdatedAt = store.Now()
+	h.store.Sessions.Set(id, session)
+
+	twincore.JSON(w, http.StatusOK, session)
+}

--- a/twin-clerk/internal/api/handlers_test.go
+++ b/twin-clerk/internal/api/handlers_test.go
@@ -1,0 +1,484 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+func setupClerk(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-clerk-test"}
+	twin := twincore.New(cfg)
+	jwtMgr, err := api.NewJWTManager()
+	if err != nil {
+		t.Fatalf("failed to create JWT manager: %v", err)
+	}
+	handler := api.NewHandler(memStore, twin.Middleware(), jwtMgr)
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// clerkAuth returns headers with Clerk-style Bearer auth.
+var clerkHeaders = map[string]string{
+	"Authorization": "Bearer sk_test_sim_123",
+}
+
+func clerkPost(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("POST", path, body, clerkHeaders)
+}
+
+func clerkGet(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, clerkHeaders)
+}
+
+func clerkPatch(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("PATCH", path, body, clerkHeaders)
+}
+
+func clerkDelete(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("DELETE", path, nil, clerkHeaders)
+}
+
+// --- Auth Tests ---
+
+func TestClerkAuthRequired(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := tc.Get("/v1/users")
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("authentication_invalid")
+}
+
+func TestClerkAuthInvalidPrefix(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := tc.DoWithHeaders("GET", "/v1/users", nil, map[string]string{
+		"Authorization": "Bearer bad_key_123",
+	})
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("authentication_invalid")
+}
+
+// --- User Tests ---
+
+func TestCreateAndGetUser(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/users", map[string]any{
+		"email_address": []string{"test@example.com"},
+		"first_name":    "Alice",
+		"last_name":     "Smith",
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatal("expected user id")
+	}
+	if m["object"] != "user" {
+		t.Errorf("expected object=user, got %v", m["object"])
+	}
+	if m["first_name"] != "Alice" {
+		t.Errorf("expected first_name=Alice, got %v", m["first_name"])
+	}
+
+	// Verify email address was attached
+	emails, _ := m["email_addresses"].([]any)
+	if len(emails) != 1 {
+		t.Fatalf("expected 1 email address, got %d", len(emails))
+	}
+
+	// Get user
+	resp = clerkGet(tc, "/v1/users/"+id)
+	resp.AssertStatus(200)
+	m = resp.JSONMap()
+	if m["id"] != id {
+		t.Errorf("expected id=%s, got %v", id, m["id"])
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	// Create user
+	resp := clerkPost(tc, "/v1/users", map[string]any{
+		"first_name": "Bob",
+		"last_name":  "Jones",
+	})
+	id := resp.JSONMap()["id"].(string)
+
+	// Update user
+	resp = clerkPatch(tc, "/v1/users/"+id, map[string]any{
+		"first_name": "Robert",
+	})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["first_name"] != "Robert" {
+		t.Errorf("expected first_name=Robert, got %v", m["first_name"])
+	}
+	// last_name should be unchanged
+	if m["last_name"] != "Jones" {
+		t.Errorf("expected last_name=Jones, got %v", m["last_name"])
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/users", map[string]any{
+		"first_name": "Delete",
+	})
+	id := resp.JSONMap()["id"].(string)
+
+	resp = clerkDelete(tc, "/v1/users/"+id)
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+
+	// Verify gone
+	clerkGet(tc, "/v1/users/"+id).AssertStatus(404)
+}
+
+func TestListUsers(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	clerkPost(tc, "/v1/users", map[string]any{"first_name": "User1"}).AssertStatus(200)
+	clerkPost(tc, "/v1/users", map[string]any{"first_name": "User2"}).AssertStatus(200)
+
+	resp := clerkGet(tc, "/v1/users")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if !ok || len(data) < 2 {
+		t.Fatalf("expected at least 2 users, got %v", m["data"])
+	}
+	count, ok := m["total_count"].(float64)
+	if !ok || count < 2 {
+		t.Errorf("expected total_count >= 2, got %v", m["total_count"])
+	}
+}
+
+func TestListUsersFilterByEmail(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	clerkPost(tc, "/v1/users", map[string]any{
+		"email_address": []string{"alice@example.com"},
+		"first_name":    "Alice",
+	}).AssertStatus(200)
+	clerkPost(tc, "/v1/users", map[string]any{
+		"email_address": []string{"bob@example.com"},
+		"first_name":    "Bob",
+	}).AssertStatus(200)
+
+	resp := clerkGet(tc, "/v1/users?email_address=alice@example.com")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	data := m["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(data))
+	}
+	user := data[0].(map[string]any)
+	if user["first_name"] != "Alice" {
+		t.Errorf("expected Alice, got %v", user["first_name"])
+	}
+}
+
+func TestUserNotFound(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkGet(tc, "/v1/users/user_nonexistent")
+	resp.AssertStatus(404)
+	resp.AssertBodyContains("resource_not_found")
+}
+
+// --- Session Tests ---
+
+func TestCreateAndGetSession(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	// Create a user first (sessions require user_id)
+	resp := clerkPost(tc, "/v1/users", map[string]any{"first_name": "SessionUser"})
+	userID := resp.JSONMap()["id"].(string)
+
+	// Create session via admin endpoint
+	resp = tc.Post("/admin/sessions", map[string]any{"user_id": userID})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	sessID, ok := m["id"].(string)
+	if !ok || sessID == "" {
+		t.Fatal("expected session id")
+	}
+	if m["object"] != "session" {
+		t.Errorf("expected object=session, got %v", m["object"])
+	}
+	if m["status"] != "active" {
+		t.Errorf("expected status=active, got %v", m["status"])
+	}
+
+	// Get session via authenticated endpoint
+	resp = clerkGet(tc, "/v1/sessions/"+sessID)
+	resp.AssertStatus(200)
+	m = resp.JSONMap()
+	if m["id"] != sessID {
+		t.Errorf("expected id=%s, got %v", sessID, m["id"])
+	}
+}
+
+func TestListSessions(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/users", map[string]any{"first_name": "Lister"})
+	userID := resp.JSONMap()["id"].(string)
+
+	tc.Post("/admin/sessions", map[string]any{"user_id": userID}).AssertStatus(200)
+	tc.Post("/admin/sessions", map[string]any{"user_id": userID}).AssertStatus(200)
+
+	resp = clerkGet(tc, "/v1/sessions")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	data := m["data"].([]any)
+	if len(data) < 2 {
+		t.Fatalf("expected at least 2 sessions, got %d", len(data))
+	}
+}
+
+func TestRevokeSession(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/users", map[string]any{"first_name": "RevokeMe"})
+	userID := resp.JSONMap()["id"].(string)
+
+	resp = tc.Post("/admin/sessions", map[string]any{"user_id": userID})
+	sessID := resp.JSONMap()["id"].(string)
+
+	resp = clerkPost(tc, "/v1/sessions/"+sessID+"/revoke", nil)
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["status"] != "revoked" {
+		t.Errorf("expected status=revoked, got %v", m["status"])
+	}
+}
+
+func TestVerifySession(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/users", map[string]any{"first_name": "VerifyMe"})
+	userID := resp.JSONMap()["id"].(string)
+
+	resp = tc.Post("/admin/sessions", map[string]any{"user_id": userID})
+	sessID := resp.JSONMap()["id"].(string)
+
+	resp = clerkPost(tc, "/v1/sessions/"+sessID+"/verify", map[string]any{"token": "ignored"})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["status"] != "active" {
+		t.Errorf("expected status=active, got %v", m["status"])
+	}
+	// Should have last_active_token
+	token, ok := m["last_active_token"].(map[string]any)
+	if !ok {
+		t.Fatal("expected last_active_token")
+	}
+	if token["jwt"] == nil || token["jwt"] == "" {
+		t.Error("expected JWT in last_active_token")
+	}
+}
+
+func TestSessionNotFound(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkGet(tc, "/v1/sessions/sess_nonexistent")
+	resp.AssertStatus(404)
+	resp.AssertBodyContains("resource_not_found")
+}
+
+// --- Organization Tests ---
+
+func TestCreateAndGetOrganization(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/organizations", map[string]any{
+		"name": "Acme Corp",
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatal("expected organization id")
+	}
+	if m["object"] != "organization" {
+		t.Errorf("expected object=organization, got %v", m["object"])
+	}
+	if m["name"] != "Acme Corp" {
+		t.Errorf("expected name=Acme Corp, got %v", m["name"])
+	}
+	if m["slug"] != "acme-corp" {
+		t.Errorf("expected slug=acme-corp, got %v", m["slug"])
+	}
+
+	// Get organization
+	resp = clerkGet(tc, "/v1/organizations/"+id)
+	resp.AssertStatus(200)
+	m = resp.JSONMap()
+	if m["id"] != id {
+		t.Errorf("expected id=%s, got %v", id, m["id"])
+	}
+}
+
+func TestGetOrganizationBySlug(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/organizations", map[string]any{
+		"name": "Slug Test Org",
+		"slug": "my-org",
+	})
+	resp.AssertStatus(200)
+
+	resp = clerkGet(tc, "/v1/organizations/my-org")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["slug"] != "my-org" {
+		t.Errorf("expected slug=my-org, got %v", m["slug"])
+	}
+}
+
+func TestUpdateOrganization(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/organizations", map[string]any{"name": "Old Name"})
+	id := resp.JSONMap()["id"].(string)
+
+	resp = clerkPatch(tc, "/v1/organizations/"+id, map[string]any{
+		"name": "New Name",
+	})
+	resp.AssertStatus(200)
+	if resp.JSONMap()["name"] != "New Name" {
+		t.Errorf("expected name=New Name, got %v", resp.JSONMap()["name"])
+	}
+}
+
+func TestDeleteOrganization(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/organizations", map[string]any{"name": "DeleteMe"})
+	id := resp.JSONMap()["id"].(string)
+
+	resp = clerkDelete(tc, "/v1/organizations/"+id)
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+
+	clerkGet(tc, "/v1/organizations/"+id).AssertStatus(404)
+}
+
+func TestListOrganizations(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	clerkPost(tc, "/v1/organizations", map[string]any{"name": "Org1"}).AssertStatus(200)
+	clerkPost(tc, "/v1/organizations", map[string]any{"name": "Org2"}).AssertStatus(200)
+
+	resp := clerkGet(tc, "/v1/organizations")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	data := m["data"].([]any)
+	if len(data) < 2 {
+		t.Fatalf("expected at least 2 organizations, got %d", len(data))
+	}
+}
+
+func TestOrganizationNameRequired(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := clerkPost(tc, "/v1/organizations", map[string]any{})
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("form_param_missing")
+}
+
+// --- JWKS Tests ---
+
+func TestJWKSEndpoint(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	// JWKS is public, no auth needed
+	resp := tc.Get("/.well-known/jwks.json")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	keys, ok := m["keys"].([]any)
+	if !ok || len(keys) == 0 {
+		t.Fatal("expected at least 1 key in JWKS")
+	}
+	key := keys[0].(map[string]any)
+	if key["kty"] != "RSA" {
+		t.Errorf("expected kty=RSA, got %v", key["kty"])
+	}
+	if key["alg"] != "RS256" {
+		t.Errorf("expected alg=RS256, got %v", key["alg"])
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminGenerateJWT(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	resp := tc.Post("/admin/jwt/generate", map[string]any{
+		"user_id":    "user_test123",
+		"session_id": "sess_test123",
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	token, ok := m["token"].(string)
+	if !ok || token == "" {
+		t.Fatal("expected JWT token")
+	}
+	if m["user_id"] != "user_test123" {
+		t.Errorf("expected user_id=user_test123, got %v", m["user_id"])
+	}
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupClerk(t)
+
+	// Create a user
+	clerkPost(tc, "/v1/users", map[string]any{"first_name": "Ghost"}).AssertStatus(200)
+
+	// Reset
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	// List should be empty
+	resp := clerkGet(tc, "/v1/users")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	count := m["total_count"].(float64)
+	if count != 0 {
+		t.Errorf("expected 0 users after reset, got %v", count)
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupClerk(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}

--- a/twin-clerk/internal/api/handlers_users.go
+++ b/twin-clerk/internal/api/handlers_users.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+// createUserRequest is the JSON body for POST /v1/users.
+type createUserRequest struct {
+	ExternalID      string         `json:"external_id,omitempty"`
+	EmailAddress    []string       `json:"email_address,omitempty"`
+	PhoneNumber     []string       `json:"phone_number,omitempty"`
+	Username        string         `json:"username,omitempty"`
+	FirstName       string         `json:"first_name,omitempty"`
+	LastName        string         `json:"last_name,omitempty"`
+	Password        string         `json:"password,omitempty"`
+	PublicMetadata  map[string]any `json:"public_metadata,omitempty"`
+	PrivateMetadata map[string]any `json:"private_metadata,omitempty"`
+	UnsafeMetadata  map[string]any `json:"unsafe_metadata,omitempty"`
+}
+
+// updateUserRequest is the JSON body for PATCH /v1/users/{id}.
+type updateUserRequest struct {
+	ExternalID      *string        `json:"external_id,omitempty"`
+	Username        *string        `json:"username,omitempty"`
+	FirstName       *string        `json:"first_name,omitempty"`
+	LastName        *string        `json:"last_name,omitempty"`
+	Password        *string        `json:"password,omitempty"`
+	PublicMetadata  map[string]any `json:"public_metadata,omitempty"`
+	PrivateMetadata map[string]any `json:"private_metadata,omitempty"`
+	UnsafeMetadata  map[string]any `json:"unsafe_metadata,omitempty"`
+}
+
+// CreateUser handles POST /v1/users.
+func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	id := h.store.Users.NextID()
+	now := store.Now()
+
+	// Build email addresses
+	emails := make([]store.EmailAddress, 0, len(req.EmailAddress))
+	var primaryEmailID string
+	for i, email := range req.EmailAddress {
+		emailID := fmt.Sprintf("idn_%s_%d", id, i)
+		emails = append(emails, store.EmailAddress{
+			ID:           emailID,
+			Object:       "email_address",
+			EmailAddress: email,
+			Verification: &store.Verification{
+				Status:   "verified",
+				Strategy: "from_oauth_google",
+			},
+			LinkedTo: []store.LinkedTo{
+				{ID: id, Type: "user"},
+			},
+		})
+		if i == 0 {
+			primaryEmailID = emailID
+		}
+	}
+
+	// Build phone numbers
+	phones := make([]store.PhoneNumber, 0, len(req.PhoneNumber))
+	var primaryPhoneID string
+	for i, phone := range req.PhoneNumber {
+		phoneID := fmt.Sprintf("phn_%s_%d", id, i)
+		phones = append(phones, store.PhoneNumber{
+			ID:          phoneID,
+			Object:      "phone_number",
+			PhoneNumber: phone,
+			Verification: &store.Verification{
+				Status:   "verified",
+				Strategy: "phone_code",
+			},
+		})
+		if i == 0 {
+			primaryPhoneID = phoneID
+		}
+	}
+
+	publicMeta := req.PublicMetadata
+	if publicMeta == nil {
+		publicMeta = make(map[string]any)
+	}
+
+	user := store.User{
+		ID:                  id,
+		Object:              "user",
+		ExternalID:          req.ExternalID,
+		PrimaryEmailAddress: primaryEmailID,
+		PrimaryPhoneNumber:  primaryPhoneID,
+		Username:            req.Username,
+		FirstName:           req.FirstName,
+		LastName:            req.LastName,
+		EmailAddresses:      emails,
+		PhoneNumbers:        phones,
+		PublicMetadata:      publicMeta,
+		PrivateMetadata:     req.PrivateMetadata,
+		UnsafeMetadata:      req.UnsafeMetadata,
+		PasswordEnabled:     req.Password != "",
+		TwoFactorEnabled:    false,
+		Banned:              false,
+		Locked:              false,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+
+	h.store.Users.Set(id, user)
+	twincore.JSON(w, http.StatusOK, user)
+}
+
+// GetUser handles GET /v1/users/{id}.
+func (h *Handler) GetUser(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	user, ok := h.store.Users.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"User not found.",
+			fmt.Sprintf("No user was found with id %s.", id))
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, user)
+}
+
+// UpdateUser handles PATCH /v1/users/{id}.
+func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	user, ok := h.store.Users.Get(id)
+	if !ok {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"User not found.",
+			fmt.Sprintf("No user was found with id %s.", id))
+		return
+	}
+
+	var req updateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clerkError(w, http.StatusBadRequest, "form_param_invalid",
+			"Invalid request body.", err.Error())
+		return
+	}
+
+	if req.ExternalID != nil {
+		user.ExternalID = *req.ExternalID
+	}
+	if req.Username != nil {
+		user.Username = *req.Username
+	}
+	if req.FirstName != nil {
+		user.FirstName = *req.FirstName
+	}
+	if req.LastName != nil {
+		user.LastName = *req.LastName
+	}
+	if req.Password != nil {
+		user.PasswordEnabled = *req.Password != ""
+	}
+	if req.PublicMetadata != nil {
+		user.PublicMetadata = req.PublicMetadata
+	}
+	if req.PrivateMetadata != nil {
+		user.PrivateMetadata = req.PrivateMetadata
+	}
+	if req.UnsafeMetadata != nil {
+		user.UnsafeMetadata = req.UnsafeMetadata
+	}
+
+	user.UpdatedAt = store.Now()
+	h.store.Users.Set(id, user)
+
+	twincore.JSON(w, http.StatusOK, user)
+}
+
+// DeleteUser handles DELETE /v1/users/{id}.
+func (h *Handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if !h.store.Users.Delete(id) {
+		clerkError(w, http.StatusNotFound, "resource_not_found",
+			"User not found.",
+			fmt.Sprintf("No user was found with id %s.", id))
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"object":  "user",
+		"deleted": true,
+	})
+}
+
+// ListUsers handles GET /v1/users.
+// Supports query params: limit, offset, email_address[], user_id[]
+func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		fmt.Sscanf(o, "%d", &offset)
+	}
+
+	// Filter by email_address[]
+	emailFilters := r.URL.Query()["email_address"]
+	// Filter by user_id[]
+	userIDFilters := r.URL.Query()["user_id"]
+
+	allUsers := h.store.Users.List()
+
+	// Apply filters
+	var filtered []store.User
+	for _, user := range allUsers {
+		if len(emailFilters) > 0 {
+			found := false
+			for _, email := range user.EmailAddresses {
+				for _, filter := range emailFilters {
+					if strings.EqualFold(email.EmailAddress, filter) {
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		if len(userIDFilters) > 0 {
+			found := false
+			for _, uid := range userIDFilters {
+				if user.ID == uid {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		filtered = append(filtered, user)
+	}
+
+	// Apply pagination
+	total := len(filtered)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	page := filtered[offset:end]
+
+	if page == nil {
+		page = []store.User{}
+	}
+
+	twincore.JSON(w, http.StatusOK, store.ClerkList[store.User]{
+		Data:       page,
+		TotalCount: total,
+	})
+}

--- a/twin-clerk/internal/api/router.go
+++ b/twin-clerk/internal/api/router.go
@@ -1,0 +1,107 @@
+// Package api implements the Clerk-compatible HTTP API handlers for the twin.
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-clerk/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store    *store.MemoryStore
+	mw       *twincore.Middleware
+	jwtMgr   *JWTManager
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware, jwtMgr *JWTManager) *Handler {
+	return &Handler{store: s, mw: mw, jwtMgr: jwtMgr}
+}
+
+// Routes mounts the Clerk API routes.
+func (h *Handler) Routes(r chi.Router) {
+	// Public endpoints (no auth required)
+	r.Get("/.well-known/jwks.json", h.GetJWKS)
+
+	// Clerk Backend API (requires Bearer auth with sk_test_* key)
+	r.Route("/v1", func(r chi.Router) {
+		r.Use(h.authMiddleware)
+		r.Use(h.mw.FaultInjection)
+
+		// Users
+		r.Post("/users", h.CreateUser)
+		r.Get("/users", h.ListUsers)
+		r.Get("/users/{id}", h.GetUser)
+		r.Patch("/users/{id}", h.UpdateUser)
+		r.Delete("/users/{id}", h.DeleteUser)
+
+		// Sessions
+		r.Get("/sessions", h.ListSessions)
+		r.Get("/sessions/{id}", h.GetSession)
+		r.Post("/sessions/{id}/verify", h.VerifySession)
+		r.Post("/sessions/{id}/revoke", h.RevokeSession)
+
+		// Organizations
+		r.Post("/organizations", h.CreateOrganization)
+		r.Get("/organizations", h.ListOrganizations)
+		r.Get("/organizations/{id}", h.GetOrganization)
+		r.Patch("/organizations/{id}", h.UpdateOrganization)
+		r.Delete("/organizations/{id}", h.DeleteOrganization)
+	})
+
+	// Admin-only JWT generation (not part of real Clerk API, used by tests)
+	r.Post("/admin/jwt/generate", h.GenerateJWT)
+	// Admin session creation (for seeding sessions tied to users)
+	r.Post("/admin/sessions", h.AdminCreateSession)
+}
+
+// authMiddleware validates Clerk-style Bearer token authentication.
+// Clerk uses "Authorization: Bearer sk_test_..." or "Authorization: Bearer sk_live_..."
+func (h *Handler) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			clerkError(w, http.StatusUnauthorized, "authentication_invalid",
+				"No authorization header provided.",
+				"You must provide a valid Bearer token in the Authorization header.")
+			return
+		}
+
+		key := strings.TrimPrefix(auth, "Bearer ")
+		if key == auth || key == "" {
+			clerkError(w, http.StatusUnauthorized, "authentication_invalid",
+				"Invalid authorization header format.",
+				"The Authorization header must use the Bearer scheme.")
+			return
+		}
+
+		// Accept any sk_test_*, sk_live_*, or sk_sim_* key
+		if !strings.HasPrefix(key, "sk_test_") &&
+			!strings.HasPrefix(key, "sk_live_") &&
+			!strings.HasPrefix(key, "sk_sim_") {
+			clerkError(w, http.StatusUnauthorized, "authentication_invalid",
+				"Invalid API key.",
+				"The provided API key is not valid. Use a key starting with sk_test_ or sk_live_.")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clerkError writes an error response in Clerk's error format.
+func clerkError(w http.ResponseWriter, status int, code, message, longMessage string) {
+	twincore.JSON(w, status, store.ClerkError{
+		Errors: []store.ClerkErrorEntry{
+			{
+				Code:        code,
+				Message:     message,
+				LongMessage: longMessage,
+			},
+		},
+	})
+}

--- a/twin-clerk/internal/store/memory.go
+++ b/twin-clerk/internal/store/memory.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"encoding/json"
+	"sync"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all Clerk twin state in memory.
+type MemoryStore struct {
+	mu sync.RWMutex
+
+	Users         *pkgstore.Store[User]
+	Sessions      *pkgstore.Store[Session]
+	Organizations *pkgstore.Store[Organization]
+	OrgMembers    *pkgstore.Store[OrgMembership]
+
+	Clock *pkgstore.Clock
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Users:         pkgstore.New[User]("user"),
+		Sessions:      pkgstore.New[Session]("sess"),
+		Organizations: pkgstore.New[Organization]("org"),
+		OrgMembers:    pkgstore.New[OrgMembership]("orgmem"),
+		Clock:         pkgstore.NewClock(),
+	}
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+type stateSnapshot struct {
+	Users         map[string]User         `json:"users"`
+	Sessions      map[string]Session      `json:"sessions"`
+	Organizations map[string]Organization `json:"organizations"`
+	OrgMembers    map[string]OrgMembership `json:"org_members"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Users:         s.Users.Snapshot(),
+		Sessions:      s.Sessions.Snapshot(),
+		Organizations: s.Organizations.Snapshot(),
+		OrgMembers:    s.OrgMembers.Snapshot(),
+	}
+}
+
+// LoadState replaces the full state from a JSON body.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+
+	s.Users.LoadSnapshot(snap.Users)
+	s.Sessions.LoadSnapshot(snap.Sessions)
+	s.Organizations.LoadSnapshot(snap.Organizations)
+	s.OrgMembers.LoadSnapshot(snap.OrgMembers)
+	return nil
+}
+
+// Reset clears all state.
+func (s *MemoryStore) Reset() {
+	s.Users.Reset()
+	s.Sessions.Reset()
+	s.Organizations.Reset()
+	s.OrgMembers.Reset()
+	s.Clock.Reset()
+}

--- a/twin-clerk/internal/store/types.go
+++ b/twin-clerk/internal/store/types.go
@@ -1,0 +1,130 @@
+// Package store defines the Clerk twin's state types.
+package store
+
+import "time"
+
+// User represents a Clerk user.
+type User struct {
+	ID                  string            `json:"id"`
+	Object              string            `json:"object"`
+	ExternalID          string            `json:"external_id,omitempty"`
+	PrimaryEmailAddress string            `json:"primary_email_address_id,omitempty"`
+	PrimaryPhoneNumber  string            `json:"primary_phone_number_id,omitempty"`
+	Username            string            `json:"username,omitempty"`
+	FirstName           string            `json:"first_name,omitempty"`
+	LastName            string            `json:"last_name,omitempty"`
+	ImageURL            string            `json:"image_url,omitempty"`
+	EmailAddresses      []EmailAddress    `json:"email_addresses"`
+	PhoneNumbers        []PhoneNumber     `json:"phone_numbers,omitempty"`
+	PublicMetadata      map[string]any    `json:"public_metadata"`
+	PrivateMetadata     map[string]any    `json:"private_metadata,omitempty"`
+	UnsafeMetadata      map[string]any    `json:"unsafe_metadata,omitempty"`
+	OrganizationMemberships []OrgMembership `json:"organization_memberships,omitempty"`
+	PasswordEnabled     bool              `json:"password_enabled"`
+	TwoFactorEnabled    bool              `json:"two_factor_enabled"`
+	Banned              bool              `json:"banned"`
+	Locked              bool              `json:"locked"`
+	LastSignInAt        *int64            `json:"last_sign_in_at"`
+	LastActiveAt        *int64            `json:"last_active_at"`
+	CreatedAt           int64             `json:"created_at"`
+	UpdatedAt           int64             `json:"updated_at"`
+}
+
+// EmailAddress represents a Clerk email address.
+type EmailAddress struct {
+	ID           string         `json:"id"`
+	Object       string         `json:"object"`
+	EmailAddress string         `json:"email_address"`
+	Verification *Verification  `json:"verification,omitempty"`
+	LinkedTo     []LinkedTo     `json:"linked_to,omitempty"`
+}
+
+// PhoneNumber represents a Clerk phone number.
+type PhoneNumber struct {
+	ID          string         `json:"id"`
+	Object      string         `json:"object"`
+	PhoneNumber string         `json:"phone_number"`
+	Verification *Verification `json:"verification,omitempty"`
+}
+
+// Verification tracks email/phone verification status.
+type Verification struct {
+	Status   string `json:"status"`
+	Strategy string `json:"strategy"`
+}
+
+// LinkedTo links an identifier to a user.
+type LinkedTo struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// Session represents a Clerk session.
+type Session struct {
+	ID              string `json:"id"`
+	Object          string `json:"object"`
+	UserID          string `json:"user_id"`
+	ClientID        string `json:"client_id"`
+	Status          string `json:"status"`
+	LastActiveAt    int64  `json:"last_active_at"`
+	ExpireAt        int64  `json:"expire_at"`
+	AbandonAt       int64  `json:"abandon_at"`
+	CreatedAt       int64  `json:"created_at"`
+	UpdatedAt       int64  `json:"updated_at"`
+	LastActiveToken *TokenResponse `json:"last_active_token,omitempty"`
+}
+
+// TokenResponse wraps a JWT token.
+type TokenResponse struct {
+	Object string `json:"object"`
+	JWT    string `json:"jwt"`
+}
+
+// Organization represents a Clerk organization.
+type Organization struct {
+	ID              string         `json:"id"`
+	Object          string         `json:"object"`
+	Name            string         `json:"name"`
+	Slug            string         `json:"slug"`
+	ImageURL        string         `json:"image_url,omitempty"`
+	MembersCount    int            `json:"members_count"`
+	MaxAllowedMemberships int     `json:"max_allowed_memberships"`
+	PublicMetadata  map[string]any `json:"public_metadata"`
+	PrivateMetadata map[string]any `json:"private_metadata,omitempty"`
+	CreatedAt       int64          `json:"created_at"`
+	UpdatedAt       int64          `json:"updated_at"`
+}
+
+// OrgMembership represents a user's membership in an organization.
+type OrgMembership struct {
+	ID             string         `json:"id"`
+	Object         string         `json:"object"`
+	Role           string         `json:"role"`
+	PublicMetadata map[string]any `json:"public_metadata,omitempty"`
+	Organization   *Organization  `json:"organization,omitempty"`
+	CreatedAt      int64          `json:"created_at"`
+	UpdatedAt      int64          `json:"updated_at"`
+}
+
+// ClerkError is the Clerk API error response format.
+type ClerkError struct {
+	Errors []ClerkErrorEntry `json:"errors"`
+}
+
+// ClerkErrorEntry is a single error in a Clerk error response.
+type ClerkErrorEntry struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	LongMessage string `json:"long_message,omitempty"`
+}
+
+// ClerkList wraps a paginated list response in Clerk's format.
+type ClerkList[T any] struct {
+	Data       []T `json:"data"`
+	TotalCount int `json:"total_count"`
+}
+
+// Now returns the current timestamp in milliseconds (Clerk uses ms).
+func Now() int64 {
+	return time.Now().UnixMilli()
+}

--- a/twin-logodev/cmd/twin-logodev/main.go
+++ b/twin-logodev/cmd/twin-logodev/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-logodev")
+	if cfg.Port == 0 {
+		cfg.Port = 12116
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	apiHandler := api.NewHandler(memStore)
+	apiHandler.Routes(twin.Router)
+
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+	}
+
+	twin.Logger.Info("twin-logodev ready", "port", cfg.Port)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-logodev/go.mod
+++ b/twin-logodev/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-logodev
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg

--- a/twin-logodev/go.sum
+++ b/twin-logodev/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-logodev/internal/api/handlers_test.go
+++ b/twin-logodev/internal/api/handlers_test.go
@@ -1,0 +1,158 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+)
+
+func setupLogodev(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-logodev-test"}
+	twin := twincore.New(cfg)
+	handler := api.NewHandler(memStore)
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// --- Logo Tests ---
+
+func TestGetLogo(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp := tc.Get("/example.com?token=test_token_123")
+	resp.AssertStatus(200)
+
+	// Should return SVG
+	ct := resp.Headers.Get("Content-Type")
+	if ct != "image/svg+xml" {
+		t.Errorf("expected Content-Type=image/svg+xml, got %s", ct)
+	}
+
+	body := string(resp.Body)
+	if !strings.Contains(body, "<svg") {
+		t.Error("expected SVG content in body")
+	}
+	// Should contain initials from "example"
+	if !strings.Contains(body, "EX") {
+		t.Error("expected initials 'EX' in SVG")
+	}
+}
+
+func TestGetLogoTokenRequired(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp := tc.Get("/example.com")
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("token required")
+}
+
+func TestGetLogoCustomSize(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp := tc.Get("/stripe.com?token=test&size=64")
+	resp.AssertStatus(200)
+
+	body := string(resp.Body)
+	if !strings.Contains(body, `width="64"`) {
+		t.Errorf("expected width=64 in SVG, got %s", body)
+	}
+}
+
+func TestGetLogoGreyscale(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp := tc.Get("/google.com?token=test&greyscale=true")
+	resp.AssertStatus(200)
+	// Just verify it returns valid SVG (greyscale is visual)
+	if !strings.Contains(string(resp.Body), "<svg") {
+		t.Error("expected SVG content")
+	}
+}
+
+func TestGetLogoDeterministic(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp1 := tc.Get("/deterministic.com?token=test")
+	resp2 := tc.Get("/deterministic.com?token=test")
+
+	if string(resp1.Body) != string(resp2.Body) {
+		t.Error("expected same SVG for same domain")
+	}
+}
+
+func TestGetLogoDifferentDomains(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	resp1 := tc.Get("/alpha.com?token=test")
+	resp2 := tc.Get("/beta.com?token=test")
+
+	// Different domains should produce different SVGs (different colors/initials)
+	if string(resp1.Body) == string(resp2.Body) {
+		t.Error("expected different SVGs for different domains")
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminListLogos(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	// Make some logo requests
+	tc.Get("/stripe.com?token=test").AssertStatus(200)
+	tc.Get("/stripe.com?token=test").AssertStatus(200)
+	tc.Get("/google.com?token=test").AssertStatus(200)
+
+	resp := tc.Get("/admin/logos")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+
+	domains, ok := m["domains"].(map[string]any)
+	if !ok {
+		t.Fatal("expected domains map")
+	}
+	if domains["stripe.com"] != float64(2) {
+		t.Errorf("expected stripe.com=2, got %v", domains["stripe.com"])
+	}
+	if domains["google.com"] != float64(1) {
+		t.Errorf("expected google.com=1, got %v", domains["google.com"])
+	}
+
+	total, _ := m["total_requests"].(float64)
+	if total < 3 {
+		t.Errorf("expected total_requests >= 3, got %v", total)
+	}
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	tc.Get("/test.com?token=test").AssertStatus(200)
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	resp := tc.Get("/admin/logos")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	total := m["total_requests"].(float64)
+	if total != 0 {
+		t.Errorf("expected 0 requests after reset, got %v", total)
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupLogodev(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}

--- a/twin-logodev/internal/api/router.go
+++ b/twin-logodev/internal/api/router.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+)
+
+// Handler holds logo API state.
+type Handler struct {
+	store *store.MemoryStore
+}
+
+// NewHandler creates a new logo API handler.
+func NewHandler(s *store.MemoryStore) *Handler {
+	return &Handler{store: s}
+}
+
+// Routes mounts the Logo.dev-compatible routes.
+func (h *Handler) Routes(r chi.Router) {
+	// Logo.dev uses GET /{domain} with ?token= param
+	r.Get("/{domain}", h.GetLogo)
+
+	// Admin extras
+	r.Get("/admin/logos", h.ListLogos)
+}
+
+// GetLogo handles GET /{domain} - returns a deterministic SVG placeholder.
+func (h *Handler) GetLogo(w http.ResponseWriter, r *http.Request) {
+	domain := chi.URLParam(r, "domain")
+
+	// Validate token (accept any non-empty token)
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		twincore.Error(w, http.StatusUnauthorized, "API token required")
+		return
+	}
+
+	size := 128
+	if s := r.URL.Query().Get("size"); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed > 0 {
+			size = parsed
+		}
+	}
+
+	format := r.URL.Query().Get("format")
+	greyscale := r.URL.Query().Get("greyscale") == "true"
+
+	// Record the request
+	h.store.RecordRequest(domain, size, format, greyscale)
+
+	// Check for custom logo
+	if custom, ok := h.store.CustomLogos[domain]; ok {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.WriteHeader(http.StatusOK)
+		w.Write(custom)
+		return
+	}
+
+	// Generate deterministic placeholder SVG
+	svg := generatePlaceholderSVG(domain, size, greyscale)
+	w.Header().Set("Content-Type", "image/svg+xml")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(svg))
+}
+
+// ListLogos handles GET /admin/logos - returns all requested domains.
+func (h *Handler) ListLogos(w http.ResponseWriter, r *http.Request) {
+	requests := h.store.Requests.List()
+	domains := make(map[string]int)
+	for _, req := range requests {
+		domains[req.Domain]++
+	}
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"domains":        domains,
+		"total_requests": len(requests),
+	})
+}
+
+// generatePlaceholderSVG creates a colored square with domain initials.
+func generatePlaceholderSVG(domain string, size int, greyscale bool) string {
+	// Generate deterministic color from domain
+	hash := md5.Sum([]byte(domain))
+	r, g, b := int(hash[0]), int(hash[1]), int(hash[2])
+
+	if greyscale {
+		avg := (r + g + b) / 3
+		r, g, b = avg, avg, avg
+	}
+
+	// Get initials from domain
+	parts := strings.Split(domain, ".")
+	name := parts[0]
+	initials := strings.ToUpper(name[:1])
+	if len(name) > 1 {
+		initials += strings.ToUpper(name[1:2])
+	}
+
+	color := fmt.Sprintf("#%02x%02x%02x", r, g, b)
+
+	// Calculate text color (white or black based on luminance)
+	luminance := 0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)
+	textColor := "#ffffff"
+	if luminance > 128 {
+		textColor = "#000000"
+	}
+
+	fontSize := size / 3
+
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">
+  <rect width="%d" height="%d" rx="%d" fill="%s"/>
+  <text x="50%%" y="50%%" dominant-baseline="central" text-anchor="middle" fill="%s" font-family="system-ui, sans-serif" font-size="%d" font-weight="600">%s</text>
+</svg>`,
+		size, size, size, size,
+		size, size, size/8, color,
+		textColor, fontSize, initials)
+}

--- a/twin-logodev/internal/store/memory.go
+++ b/twin-logodev/internal/store/memory.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"encoding/json"
+	"time"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all logo twin state.
+type MemoryStore struct {
+	Requests *pkgstore.Store[LogoRequest]
+	// CustomLogos maps domain -> SVG content for specific test domains
+	CustomLogos map[string][]byte
+	Clock       *pkgstore.Clock
+}
+
+// New creates a new MemoryStore.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Requests:    pkgstore.New[LogoRequest]("logo"),
+		CustomLogos: make(map[string][]byte),
+		Clock:       pkgstore.NewClock(),
+	}
+}
+
+// RecordRequest logs a logo request.
+func (s *MemoryStore) RecordRequest(domain string, size int, format string, greyscale bool) {
+	id := s.Requests.NextID()
+	s.Requests.Set(id, LogoRequest{
+		Domain:    domain,
+		Size:      size,
+		Format:    format,
+		Greyscale: greyscale,
+		Timestamp: time.Now(),
+	})
+}
+
+type stateSnapshot struct {
+	Requests    map[string]LogoRequest `json:"requests"`
+	CustomLogos map[string]string      `json:"custom_logos,omitempty"` // domain -> base64 SVG
+}
+
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Requests: s.Requests.Snapshot(),
+	}
+}
+
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	s.Requests.LoadSnapshot(snap.Requests)
+	return nil
+}
+
+func (s *MemoryStore) Reset() {
+	s.Requests.Reset()
+	s.CustomLogos = make(map[string][]byte)
+	s.Clock.Reset()
+}

--- a/twin-logodev/internal/store/types.go
+++ b/twin-logodev/internal/store/types.go
@@ -1,0 +1,12 @@
+package store
+
+import "time"
+
+// LogoRequest records a request for a logo.
+type LogoRequest struct {
+	Domain    string    `json:"domain"`
+	Size      int       `json:"size,omitempty"`
+	Format    string    `json:"format,omitempty"`
+	Greyscale bool      `json:"greyscale,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/twin-posthog/cmd/twin-posthog/main.go
+++ b/twin-posthog/cmd/twin-posthog/main.go
@@ -1,0 +1,55 @@
+// twin-posthog is a WonderTwin twin that simulates the PostHog event capture API.
+// It captures analytics events and provides admin endpoints
+// for inspecting captured events and managing feature flags.
+//
+// SDK compatibility target: PostHog JS/Go SDK
+// Integration method: Override API host
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-posthog")
+	if cfg.Port == 0 {
+		cfg.Port = 12114
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-posthog ready",
+		"port", cfg.Port,
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-posthog/go.mod
+++ b/twin-posthog/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-posthog
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg

--- a/twin-posthog/go.sum
+++ b/twin-posthog/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-posthog/internal/api/handlers_capture.go
+++ b/twin-posthog/internal/api/handlers_capture.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
+)
+
+// captureRequest represents a PostHog capture request body.
+type captureRequest struct {
+	APIKey     string         `json:"api_key"`
+	Event      string         `json:"event"`
+	DistinctID string         `json:"distinct_id"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Timestamp  string         `json:"timestamp,omitempty"`
+}
+
+// batchRequest represents a PostHog batch capture request body.
+type batchRequest struct {
+	APIKey string           `json:"api_key"`
+	Batch  []captureRequest `json:"batch"`
+}
+
+// decideRequest represents a PostHog /decide request body.
+type decideRequest struct {
+	APIKey     string `json:"api_key"`
+	DistinctID string `json:"distinct_id"`
+	Token      string `json:"token"`
+}
+
+// CaptureEvent handles POST /capture, POST /e
+func (h *Handler) CaptureEvent(w http.ResponseWriter, r *http.Request) {
+	var req captureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	// Check for API key in body or header
+	apiKey := req.APIKey
+	if apiKey == "" {
+		apiKey = apiKeyFromRequest(r)
+	}
+	// Also check properties.$token (JS SDK)
+	if apiKey == "" && req.Properties != nil {
+		if token, ok := req.Properties["$token"].(string); ok {
+			apiKey = token
+		}
+	}
+
+	if req.Event == "" {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "event field is required",
+		})
+		return
+	}
+
+	h.storeEvent(req)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"status": 1,
+	})
+}
+
+// BatchCapture handles POST /batch
+func (h *Handler) BatchCapture(w http.ResponseWriter, r *http.Request) {
+	var req batchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	for _, event := range req.Batch {
+		if event.APIKey == "" {
+			event.APIKey = req.APIKey
+		}
+		h.storeEvent(event)
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"status": 1,
+	})
+}
+
+// Decide handles POST /decide/?v=3 (feature flag evaluation)
+func (h *Handler) Decide(w http.ResponseWriter, r *http.Request) {
+	var req decideRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	flags := h.store.GetFeatureFlags()
+
+	// Build feature flag response
+	featureFlags := make(map[string]any, len(flags))
+	featureFlagPayloads := make(map[string]any, len(flags))
+
+	for key, flag := range flags {
+		if flag.Enabled {
+			if flag.Variant != "" {
+				featureFlags[key] = flag.Variant
+			} else {
+				featureFlags[key] = true
+			}
+		} else {
+			featureFlags[key] = false
+		}
+		featureFlagPayloads[key] = nil
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"featureFlags":        featureFlags,
+		"featureFlagPayloads": featureFlagPayloads,
+		"errorsWhileComputingFlags": false,
+	})
+}
+
+// storeEvent saves a captured event to the store.
+func (h *Handler) storeEvent(req captureRequest) {
+	now := h.store.Clock.Now()
+
+	ts := req.Timestamp
+	if ts == "" {
+		ts = now.Format(time.RFC3339)
+	}
+
+	id := h.store.Events.NextID()
+
+	evt := store.CapturedEvent{
+		UUID:       id,
+		Event:      req.Event,
+		DistinctID: req.DistinctID,
+		Properties: req.Properties,
+		Timestamp:  ts,
+	}
+
+	h.store.Events.Set(id, evt)
+}
+
+// AdminListEvents handles GET /admin/events
+// Supports ?event={name} and ?distinct_id={id} query parameters.
+func (h *Handler) AdminListEvents(w http.ResponseWriter, r *http.Request) {
+	eventFilter := r.URL.Query().Get("event")
+	distinctIDFilter := r.URL.Query().Get("distinct_id")
+
+	events := h.store.Events.List()
+
+	if eventFilter != "" || distinctIDFilter != "" {
+		var filtered []store.CapturedEvent
+		for _, evt := range events {
+			if eventFilter != "" && evt.Event != eventFilter {
+				continue
+			}
+			if distinctIDFilter != "" && evt.DistinctID != distinctIDFilter {
+				continue
+			}
+			filtered = append(filtered, evt)
+		}
+		events = filtered
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"events": events,
+		"total":  len(events),
+	})
+}
+
+// AdminSetFeatureFlags handles POST /admin/feature-flags
+func (h *Handler) AdminSetFeatureFlags(w http.ResponseWriter, r *http.Request) {
+	var flags []store.FeatureFlag
+	if err := json.NewDecoder(r.Body).Decode(&flags); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	h.store.SetFeatureFlags(flags)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"status": "set",
+		"flags":  h.store.GetFeatureFlags(),
+	})
+}
+
+// AdminGetFeatureFlags handles GET /admin/feature-flags
+func (h *Handler) AdminGetFeatureFlags(w http.ResponseWriter, r *http.Request) {
+	twincore.JSON(w, http.StatusOK, h.store.GetFeatureFlags())
+}

--- a/twin-posthog/internal/api/handlers_test.go
+++ b/twin-posthog/internal/api/handlers_test.go
@@ -1,0 +1,216 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
+)
+
+func setupPostHog(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-posthog-test"}
+	twin := twincore.New(cfg)
+	handler := api.NewHandler(memStore, twin.Middleware())
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// --- Capture Tests ---
+
+func TestCaptureEvent(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	resp := tc.Post("/capture", map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "page_view",
+		"distinct_id": "user_123",
+		"properties": map[string]any{
+			"$current_url": "https://example.com/home",
+		},
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["status"] != float64(1) {
+		t.Errorf("expected status=1, got %v", m["status"])
+	}
+
+	// Verify event was stored via admin
+	resp = tc.Get("/admin/events?event=page_view")
+	resp.AssertStatus(200)
+	adminM := resp.JSONMap()
+	events, ok := adminM["events"].([]any)
+	if !ok || len(events) != 1 {
+		t.Fatalf("expected 1 event, got %v", adminM["events"])
+	}
+	evt := events[0].(map[string]any)
+	if evt["event"] != "page_view" {
+		t.Errorf("expected event=page_view, got %v", evt["event"])
+	}
+	if evt["distinct_id"] != "user_123" {
+		t.Errorf("expected distinct_id=user_123, got %v", evt["distinct_id"])
+	}
+}
+
+func TestCaptureEventMissingEvent(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	resp := tc.Post("/capture", map[string]any{
+		"api_key":     "phc_test_key",
+		"distinct_id": "user_123",
+	})
+	resp.AssertStatus(400)
+	resp.AssertBodyContains("event field is required")
+}
+
+func TestBatchCapture(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	resp := tc.Post("/batch", map[string]any{
+		"api_key": "phc_test_key",
+		"batch": []map[string]any{
+			{"event": "signup", "distinct_id": "user_1"},
+			{"event": "login", "distinct_id": "user_2"},
+			{"event": "purchase", "distinct_id": "user_1"},
+		},
+	})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["status"] != float64(1) {
+		t.Errorf("expected status=1, got %v", m["status"])
+	}
+
+	// Verify all events stored
+	resp = tc.Get("/admin/events")
+	resp.AssertStatus(200)
+	adminM := resp.JSONMap()
+	events := adminM["events"].([]any)
+	if len(events) < 3 {
+		t.Fatalf("expected at least 3 events, got %d", len(events))
+	}
+}
+
+// --- Decide Tests ---
+
+func TestDecideNoFlags(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	resp := tc.Post("/decide", map[string]any{
+		"api_key":     "phc_test_key",
+		"distinct_id": "user_123",
+	})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	flags, ok := m["featureFlags"].(map[string]any)
+	if !ok {
+		t.Fatal("expected featureFlags in response")
+	}
+	if len(flags) != 0 {
+		t.Errorf("expected 0 flags, got %d", len(flags))
+	}
+}
+
+func TestDecideWithFlags(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	// Set feature flags via admin
+	tc.Post("/admin/feature-flags", []map[string]any{
+		{"key": "new-checkout", "enabled": true},
+		{"key": "dark-mode", "enabled": false},
+		{"key": "variant-test", "enabled": true, "variant": "control"},
+	}).AssertStatus(200)
+
+	resp := tc.Post("/decide", map[string]any{
+		"api_key":     "phc_test_key",
+		"distinct_id": "user_123",
+	})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	flags := m["featureFlags"].(map[string]any)
+
+	if flags["new-checkout"] != true {
+		t.Errorf("expected new-checkout=true, got %v", flags["new-checkout"])
+	}
+	if flags["dark-mode"] != false {
+		t.Errorf("expected dark-mode=false, got %v", flags["dark-mode"])
+	}
+	if flags["variant-test"] != "control" {
+		t.Errorf("expected variant-test=control, got %v", flags["variant-test"])
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminListEventsFilter(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	tc.Post("/capture", map[string]any{
+		"api_key": "phc_test_key", "event": "click", "distinct_id": "u1",
+	}).AssertStatus(200)
+	tc.Post("/capture", map[string]any{
+		"api_key": "phc_test_key", "event": "view", "distinct_id": "u2",
+	}).AssertStatus(200)
+
+	resp := tc.Get("/admin/events?distinct_id=u1")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	events := m["events"].([]any)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event for u1, got %d", len(events))
+	}
+}
+
+func TestAdminSetAndGetFeatureFlags(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	tc.Post("/admin/feature-flags", []map[string]any{
+		{"key": "beta", "enabled": true},
+	}).AssertStatus(200)
+
+	resp := tc.Get("/admin/feature-flags")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	beta, ok := m["beta"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'beta' flag in response")
+	}
+	if beta["enabled"] != true {
+		t.Errorf("expected beta enabled=true, got %v", beta["enabled"])
+	}
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupPostHog(t)
+
+	tc.Post("/capture", map[string]any{
+		"api_key": "phc_test_key", "event": "test", "distinct_id": "u1",
+	}).AssertStatus(200)
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	resp := tc.Get("/admin/events")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	events := m["events"]
+	if events != nil {
+		if arr, ok := events.([]any); ok && len(arr) > 0 {
+			t.Errorf("expected 0 events after reset, got %d", len(arr))
+		}
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupPostHog(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}

--- a/twin-posthog/internal/api/router.go
+++ b/twin-posthog/internal/api/router.go
@@ -1,0 +1,71 @@
+// Package api implements the PostHog-compatible HTTP API handlers for the twin.
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store *store.MemoryStore
+	mw    *twincore.Middleware
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
+	return &Handler{store: s, mw: mw}
+}
+
+// Routes mounts the PostHog API routes and admin extras.
+func (h *Handler) Routes(r chi.Router) {
+	// PostHog capture API routes (minimal auth - accept api_key in body/header)
+	r.Group(func(r chi.Router) {
+		r.Use(h.mw.FaultInjection)
+
+		r.Post("/capture", h.CaptureEvent)
+		r.Post("/capture/", h.CaptureEvent)
+		r.Post("/batch", h.BatchCapture)
+		r.Post("/batch/", h.BatchCapture)
+		r.Post("/e", h.CaptureEvent)   // JS SDK alternative endpoint
+		r.Post("/e/", h.CaptureEvent)
+		r.Post("/decide/", h.Decide)    // Feature flag evaluation
+		r.Post("/decide", h.Decide)
+	})
+
+	// Admin extras (no auth required)
+	r.Get("/admin/events", h.AdminListEvents)
+	r.Post("/admin/feature-flags", h.AdminSetFeatureFlags)
+	r.Get("/admin/feature-flags", h.AdminGetFeatureFlags)
+}
+
+// apiKeyFromRequest extracts the PostHog api_key from the request.
+// PostHog accepts it via header, query param, or request body.
+// In sim mode we accept any non-empty key.
+func apiKeyFromRequest(r *http.Request) string {
+	// Check header
+	if key := r.Header.Get("X-PostHog-Api-Key"); key != "" {
+		return key
+	}
+	// Check Authorization header
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		return auth
+	}
+	// Check query param
+	if key := r.URL.Query().Get("api_key"); key != "" {
+		return key
+	}
+	return ""
+}
+
+// noKeyError writes a PostHog-style auth error.
+func noKeyError(w http.ResponseWriter) {
+	twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+		"type":   "authentication_error",
+		"code":   "invalid_api_key",
+		"detail": "Project API key invalid. You can find your project API key in PostHog project settings.",
+	})
+}

--- a/twin-posthog/internal/store/memory.go
+++ b/twin-posthog/internal/store/memory.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"encoding/json"
+	"sync"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all PostHog twin state in memory.
+type MemoryStore struct {
+	Events *pkgstore.Store[CapturedEvent]
+	Clock  *pkgstore.Clock
+
+	mu           sync.RWMutex
+	FeatureFlags map[string]FeatureFlag
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Events:       pkgstore.New[CapturedEvent]("evt"),
+		Clock:        pkgstore.NewClock(),
+		FeatureFlags: make(map[string]FeatureFlag),
+	}
+}
+
+// GetFeatureFlags returns a copy of all feature flags.
+func (s *MemoryStore) GetFeatureFlags() map[string]FeatureFlag {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]FeatureFlag, len(s.FeatureFlags))
+	for k, v := range s.FeatureFlags {
+		out[k] = v
+	}
+	return out
+}
+
+// SetFeatureFlag sets or updates a feature flag.
+func (s *MemoryStore) SetFeatureFlag(flag FeatureFlag) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FeatureFlags[flag.Key] = flag
+}
+
+// SetFeatureFlags replaces all feature flags.
+func (s *MemoryStore) SetFeatureFlags(flags []FeatureFlag) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FeatureFlags = make(map[string]FeatureFlag, len(flags))
+	for _, f := range flags {
+		s.FeatureFlags[f.Key] = f
+	}
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+type stateSnapshot struct {
+	Events       map[string]CapturedEvent `json:"events"`
+	FeatureFlags map[string]FeatureFlag   `json:"feature_flags"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Events:       s.Events.Snapshot(),
+		FeatureFlags: s.GetFeatureFlags(),
+	}
+}
+
+// LoadState replaces the full state from a JSON body.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	s.Events.LoadSnapshot(snap.Events)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if snap.FeatureFlags != nil {
+		s.FeatureFlags = snap.FeatureFlags
+	}
+	return nil
+}
+
+// Reset clears all state.
+func (s *MemoryStore) Reset() {
+	s.Events.Reset()
+	s.Clock.Reset()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FeatureFlags = make(map[string]FeatureFlag)
+}

--- a/twin-posthog/internal/store/types.go
+++ b/twin-posthog/internal/store/types.go
@@ -1,0 +1,18 @@
+// Package store defines the PostHog twin's state types and in-memory store.
+package store
+
+// CapturedEvent represents a PostHog analytics event.
+type CapturedEvent struct {
+	UUID       string         `json:"uuid"`
+	Event      string         `json:"event"`
+	DistinctID string         `json:"distinct_id"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Timestamp  string         `json:"timestamp"`
+}
+
+// FeatureFlag represents a PostHog feature flag configuration.
+type FeatureFlag struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
+	Variant string `json:"variant,omitempty"` // optional multivariate variant
+}

--- a/twin-resend/cmd/twin-resend/main.go
+++ b/twin-resend/cmd/twin-resend/main.go
@@ -1,0 +1,55 @@
+// twin-resend is a WonderTwin twin that simulates the Resend email API.
+// It captures email send calls and provides admin endpoints
+// for inspecting sent emails.
+//
+// SDK compatibility target: github.com/resend/resend-go/v2
+// Integration method: Override base URL
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-resend")
+	if cfg.Port == 0 {
+		cfg.Port = 12115
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-resend ready",
+		"port", cfg.Port,
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-resend/go.mod
+++ b/twin-resend/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-resend
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg

--- a/twin-resend/go.sum
+++ b/twin-resend/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-resend/internal/api/handlers_emails.go
+++ b/twin-resend/internal/api/handlers_emails.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
+)
+
+// sendEmailRequest matches the Resend send email API request body.
+type sendEmailRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html,omitempty"`
+	Text    string   `json:"text,omitempty"`
+	CC      []string `json:"cc,omitempty"`
+	BCC     []string `json:"bcc,omitempty"`
+	ReplyTo []string `json:"reply_to,omitempty"`
+}
+
+// SendEmail handles POST /emails
+func (h *Handler) SendEmail(w http.ResponseWriter, r *http.Request) {
+	var req sendEmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"statusCode": 422,
+			"message":    "Invalid request body: " + err.Error(),
+			"name":       "validation_error",
+		})
+		return
+	}
+
+	if req.From == "" {
+		twincore.JSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"statusCode": 422,
+			"message":    "The 'from' field is required.",
+			"name":       "validation_error",
+		})
+		return
+	}
+
+	if len(req.To) == 0 {
+		twincore.JSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"statusCode": 422,
+			"message":    "The 'to' field is required and must contain at least one email address.",
+			"name":       "validation_error",
+		})
+		return
+	}
+
+	if req.Subject == "" {
+		twincore.JSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"statusCode": 422,
+			"message":    "The 'subject' field is required.",
+			"name":       "validation_error",
+		})
+		return
+	}
+
+	email := h.createEmail(req)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id": email.ID,
+	})
+}
+
+// GetEmail handles GET /emails/{id}
+func (h *Handler) GetEmail(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	email, ok := h.store.Emails.Get(id)
+	if !ok {
+		twincore.JSON(w, http.StatusNotFound, map[string]any{
+			"statusCode": 404,
+			"message":    "Email not found",
+			"name":       "not_found",
+		})
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, email)
+}
+
+// SendBatch handles POST /emails/batch
+func (h *Handler) SendBatch(w http.ResponseWriter, r *http.Request) {
+	var reqs []sendEmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqs); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"statusCode": 422,
+			"message":    "Invalid request body: " + err.Error(),
+			"name":       "validation_error",
+		})
+		return
+	}
+
+	var results []map[string]any
+	for _, req := range reqs {
+		email := h.createEmail(req)
+		results = append(results, map[string]any{
+			"id": email.ID,
+		})
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"data": results,
+	})
+}
+
+// createEmail is a shared helper that creates and stores an email from a request.
+func (h *Handler) createEmail(req sendEmailRequest) store.Email {
+	now := h.store.Clock.Now()
+	id := h.store.Emails.NextID()
+
+	email := store.Email{
+		ID:        id,
+		Object:    "email",
+		From:      req.From,
+		To:        req.To,
+		Subject:   req.Subject,
+		HTML:      req.HTML,
+		Text:      req.Text,
+		CC:        req.CC,
+		BCC:       req.BCC,
+		ReplyTo:   req.ReplyTo,
+		Status:    store.EmailStatusDelivered, // Sim: instantly delivered
+		CreatedAt: now.Format(time.RFC3339),
+		LastEvent: "delivered",
+	}
+
+	h.store.Emails.Set(id, email)
+	return email
+}
+
+// AdminListEmails handles GET /admin/emails
+// Supports ?to={email} and ?subject={q} query parameters.
+func (h *Handler) AdminListEmails(w http.ResponseWriter, r *http.Request) {
+	toFilter := r.URL.Query().Get("to")
+	subjectFilter := r.URL.Query().Get("subject")
+
+	emails := h.store.Emails.List()
+
+	if toFilter != "" || subjectFilter != "" {
+		var filtered []store.Email
+		for _, email := range emails {
+			if toFilter != "" {
+				found := false
+				for _, addr := range email.To {
+					if addr == toFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+			if subjectFilter != "" {
+				if !strings.Contains(strings.ToLower(email.Subject), strings.ToLower(subjectFilter)) {
+					continue
+				}
+			}
+			filtered = append(filtered, email)
+		}
+		emails = filtered
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"emails": emails,
+		"total":  len(emails),
+	})
+}

--- a/twin-resend/internal/api/handlers_test.go
+++ b/twin-resend/internal/api/handlers_test.go
@@ -1,0 +1,237 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
+)
+
+func setupResend(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-resend-test"}
+	twin := twincore.New(cfg)
+	handler := api.NewHandler(memStore, twin.Middleware())
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+var resendHeaders = map[string]string{
+	"Authorization": "Bearer re_sim_test_123",
+}
+
+func resendPost(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("POST", path, body, resendHeaders)
+}
+
+func resendGet(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, resendHeaders)
+}
+
+// --- Auth Tests ---
+
+func TestResendAuthRequired(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := tc.Post("/emails", map[string]any{})
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("missing_api_key")
+}
+
+func TestResendAuthInvalidFormat(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := tc.DoWithHeaders("POST", "/emails", map[string]any{}, map[string]string{
+		"Authorization": "InvalidNoBearer",
+	})
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("invalid_api_key")
+}
+
+// --- Email Tests ---
+
+func TestSendAndGetEmail(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendPost(tc, "/emails", map[string]any{
+		"from":    "sender@example.com",
+		"to":      []string{"recipient@example.com"},
+		"subject": "Test Email",
+		"html":    "<p>Hello</p>",
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatal("expected email id in response")
+	}
+
+	// Get email
+	resp = resendGet(tc, "/emails/"+id)
+	resp.AssertStatus(200)
+	got := resp.JSONMap()
+	if got["id"] != id {
+		t.Errorf("expected id=%s, got %v", id, got["id"])
+	}
+	if got["from"] != "sender@example.com" {
+		t.Errorf("expected from=sender@example.com, got %v", got["from"])
+	}
+	if got["subject"] != "Test Email" {
+		t.Errorf("expected subject=Test Email, got %v", got["subject"])
+	}
+	if got["status"] != "delivered" {
+		t.Errorf("expected status=delivered, got %v", got["status"])
+	}
+}
+
+func TestSendEmailMissingFrom(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendPost(tc, "/emails", map[string]any{
+		"to":      []string{"recipient@example.com"},
+		"subject": "No From",
+	})
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("validation_error")
+}
+
+func TestSendEmailMissingTo(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendPost(tc, "/emails", map[string]any{
+		"from":    "sender@example.com",
+		"subject": "No To",
+	})
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("validation_error")
+}
+
+func TestSendEmailMissingSubject(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendPost(tc, "/emails", map[string]any{
+		"from": "sender@example.com",
+		"to":   []string{"recipient@example.com"},
+	})
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("validation_error")
+}
+
+func TestEmailNotFound(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendGet(tc, "/emails/email_nonexistent")
+	resp.AssertStatus(404)
+	resp.AssertBodyContains("not_found")
+}
+
+func TestSendBatchEmails(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resp := resendPost(tc, "/emails/batch", []map[string]any{
+		{
+			"from":    "sender@example.com",
+			"to":      []string{"a@example.com"},
+			"subject": "Batch 1",
+			"html":    "<p>A</p>",
+		},
+		{
+			"from":    "sender@example.com",
+			"to":      []string{"b@example.com"},
+			"subject": "Batch 2",
+			"html":    "<p>B</p>",
+		},
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if !ok || len(data) != 2 {
+		t.Fatalf("expected 2 batch results, got %v", m["data"])
+	}
+	for i, item := range data {
+		entry := item.(map[string]any)
+		if entry["id"] == nil || entry["id"] == "" {
+			t.Errorf("batch item %d missing id", i)
+		}
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminListEmails(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resendPost(tc, "/emails", map[string]any{
+		"from":    "sender@example.com",
+		"to":      []string{"alice@example.com"},
+		"subject": "Hello Alice",
+		"html":    "<p>Hi</p>",
+	}).AssertStatus(200)
+
+	resp := tc.Get("/admin/emails?to=alice@example.com")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	emails, ok := m["emails"].([]any)
+	if !ok || len(emails) != 1 {
+		t.Fatalf("expected 1 email, got %v", m["emails"])
+	}
+}
+
+func TestAdminListEmailsBySubject(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resendPost(tc, "/emails", map[string]any{
+		"from":    "sender@example.com",
+		"to":      []string{"bob@example.com"},
+		"subject": "Password Reset",
+		"html":    "<p>Reset your password</p>",
+	}).AssertStatus(200)
+
+	resp := tc.Get("/admin/emails?subject=password")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	emails := m["emails"].([]any)
+	if len(emails) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(emails))
+	}
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupResend(t)
+
+	resendPost(tc, "/emails", map[string]any{
+		"from":    "sender@example.com",
+		"to":      []string{"ghost@example.com"},
+		"subject": "Ghost",
+		"html":    "<p>boo</p>",
+	}).AssertStatus(200)
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	resp := tc.Get("/admin/emails")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	emails := m["emails"]
+	if emails != nil {
+		if arr, ok := emails.([]any); ok && len(arr) > 0 {
+			t.Errorf("expected 0 emails after reset, got %d", len(arr))
+		}
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupResend(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}

--- a/twin-resend/internal/api/router.go
+++ b/twin-resend/internal/api/router.go
@@ -1,0 +1,67 @@
+// Package api implements the Resend-compatible HTTP API handlers for the twin.
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store *store.MemoryStore
+	mw    *twincore.Middleware
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
+	return &Handler{store: s, mw: mw}
+}
+
+// Routes mounts the Resend API routes and admin extras.
+func (h *Handler) Routes(r chi.Router) {
+	// Resend API routes (Bearer token auth required)
+	r.Route("/emails", func(r chi.Router) {
+		r.Use(h.bearerAuthMiddleware)
+		r.Use(h.mw.FaultInjection)
+
+		r.Post("/", h.SendEmail)
+		r.Get("/{id}", h.GetEmail)
+		r.Post("/batch", h.SendBatch)
+	})
+
+	// Admin extras (no auth required)
+	r.Get("/admin/emails", h.AdminListEmails)
+}
+
+// bearerAuthMiddleware validates Resend-style Bearer token auth.
+// Accepts any token starting with "re_" in sim mode.
+func (h *Handler) bearerAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+				"statusCode": 401,
+				"message":    "Missing API key in the authorization header. Include the following header 'Authorization: Bearer re_123' in the request.",
+				"name":       "missing_api_key",
+			})
+			return
+		}
+
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if token == auth || token == "" {
+			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+				"statusCode": 401,
+				"message":    "Invalid authorization header format. Use 'Authorization: Bearer re_123'.",
+				"name":       "invalid_api_key",
+			})
+			return
+		}
+
+		// In sim mode, accept any non-empty token (preferably starting with "re_")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/twin-resend/internal/store/memory.go
+++ b/twin-resend/internal/store/memory.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"encoding/json"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all Resend twin state in memory.
+type MemoryStore struct {
+	Emails *pkgstore.Store[Email]
+	Clock  *pkgstore.Clock
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Emails: pkgstore.New[Email]("email"),
+		Clock:  pkgstore.NewClock(),
+	}
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+type stateSnapshot struct {
+	Emails map[string]Email `json:"emails"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Emails: s.Emails.Snapshot(),
+	}
+}
+
+// LoadState replaces the full state from a JSON body.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	s.Emails.LoadSnapshot(snap.Emails)
+	return nil
+}
+
+// Reset clears all state.
+func (s *MemoryStore) Reset() {
+	s.Emails.Reset()
+	s.Clock.Reset()
+}

--- a/twin-resend/internal/store/types.go
+++ b/twin-resend/internal/store/types.go
@@ -1,0 +1,26 @@
+// Package store defines the Resend twin's state types and in-memory store.
+package store
+
+// Email represents a Resend email.
+type Email struct {
+	ID        string   `json:"id"`
+	Object    string   `json:"object"`
+	From      string   `json:"from"`
+	To        []string `json:"to"`
+	Subject   string   `json:"subject"`
+	HTML      string   `json:"html,omitempty"`
+	Text      string   `json:"text,omitempty"`
+	CC        []string `json:"cc,omitempty"`
+	BCC       []string `json:"bcc,omitempty"`
+	ReplyTo   []string `json:"reply_to,omitempty"`
+	Status    string   `json:"status"`
+	CreatedAt string   `json:"created_at"`
+	LastEvent string   `json:"last_event"`
+}
+
+// Email status constants matching Resend's lifecycle.
+const (
+	EmailStatusSent      = "sent"
+	EmailStatusDelivered = "delivered"
+	EmailStatusBounced   = "bounced"
+)

--- a/twin-stripe/Dockerfile
+++ b/twin-stripe/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /build
+COPY ../pkg/ ./pkg/
+COPY twin-stripe/ ./twin-stripe/
+WORKDIR /build/twin-stripe
+RUN go build -o /twin-stripe ./cmd/twin-stripe/
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /twin-stripe /usr/local/bin/twin-stripe
+EXPOSE 12111
+ENTRYPOINT ["twin-stripe"]

--- a/twin-stripe/cmd/twin-stripe/main.go
+++ b/twin-stripe/cmd/twin-stripe/main.go
@@ -1,0 +1,76 @@
+// twin-stripe is a WonderTwin twin that simulates the Stripe Connect API.
+// It implements the subset of Stripe's API used for settlement,
+// with form-encoded request parsing and JSON responses compatible with stripe-go/v76.
+//
+// SDK compatibility target: github.com/stripe/stripe-go/v76
+// Integration method: stripe.SetBackend() to override API URL
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	pkgwebhook "github.com/wondertwin-ai/wondertwin/pkg/webhook"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	stripewh "github.com/wondertwin-ai/wondertwin/twin-stripe/internal/webhook"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-stripe")
+	if cfg.Port == 0 {
+		cfg.Port = 12111
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// Webhook secret from env or default
+	webhookSecret := os.Getenv("STRIPE_WEBHOOK_SECRET")
+	if webhookSecret == "" {
+		webhookSecret = "whsec_sim_test_secret"
+	}
+
+	// Webhook dispatcher with Stripe v1 signing
+	dispatcher := pkgwebhook.NewDispatcher(pkgwebhook.Config{
+		URL:         cfg.WebhookURL,
+		Secret:      webhookSecret,
+		Signer:      stripewh.NewStripeSigner(),
+		Logger:      twin.Logger,
+		EventPrefix: "evt",
+		AutoDeliver: cfg.WebhookURL != "",
+	})
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, dispatcher, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetFlusher(dispatcher)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-stripe ready",
+		"port", cfg.Port,
+		"webhook_url", cfg.WebhookURL,
+		"webhook_secret", webhookSecret[:10]+"...",
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-stripe/go.mod
+++ b/twin-stripe/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-stripe
+
+go 1.25.7
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0-00010101000000-000000000000
+)

--- a/twin-stripe/go.sum
+++ b/twin-stripe/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-stripe/internal/api/handlers_accounts.go
+++ b/twin-stripe/internal/api/handlers_accounts.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// CreateAccount handles POST /v1/accounts.
+// Stripe SDK: account.New(params)
+func (h *Handler) CreateAccount(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	id := h.store.Accounts.NextID()
+	now := store.Now()
+
+	acctType := r.FormValue("type")
+	if acctType == "" {
+		acctType = "custom"
+	}
+
+	country := r.FormValue("country")
+	if country == "" {
+		country = "US"
+	}
+
+	currency := r.FormValue("default_currency")
+	if currency == "" {
+		currency = "usd"
+	}
+
+	acct := store.Account{
+		ID:               id,
+		Object:           "account",
+		Type:             acctType,
+		BusinessType:     r.FormValue("business_type"),
+		Email:            r.FormValue("email"),
+		Country:          country,
+		DefaultCurrency:  currency,
+		ChargesEnabled:   false,
+		PayoutsEnabled:   false,
+		DetailsSubmitted: false,
+		Capabilities:     make(map[string]string),
+		Requirements: &store.Requirements{
+			CurrentlyDue:  []string{"business_type", "external_account", "tos_acceptance.date", "tos_acceptance.ip"},
+			EventuallyDue: []string{"business_type", "external_account", "tos_acceptance.date", "tos_acceptance.ip"},
+			PastDue:       []string{},
+		},
+		Metadata: extractMetadata(r),
+		Created:  now,
+	}
+
+	// Parse capabilities from form
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "capabilities[") && strings.HasSuffix(key, "][requested]") {
+			capName := strings.TrimPrefix(key, "capabilities[")
+			capName = strings.TrimSuffix(capName, "][requested]")
+			if len(values) > 0 && values[0] == "true" {
+				acct.Capabilities[capName] = "inactive"
+			}
+		}
+	}
+
+	// Parse business_profile
+	if r.FormValue("business_profile[url]") != "" || r.FormValue("business_profile[mcc]") != "" {
+		acct.BusinessProfile = map[string]any{
+			"url": r.FormValue("business_profile[url]"),
+			"mcc": r.FormValue("business_profile[mcc]"),
+		}
+	}
+
+	// Parse tos_acceptance
+	if r.FormValue("tos_acceptance[date]") != "" || r.FormValue("tos_acceptance[ip]") != "" {
+		acct.TOSAcceptance = map[string]any{
+			"date": r.FormValue("tos_acceptance[date]"),
+			"ip":   r.FormValue("tos_acceptance[ip]"),
+		}
+	}
+
+	acct.ExternalAccounts = &store.ExternalAccounts{
+		Object:  "list",
+		Data:    []store.ExternalAccount{},
+		HasMore: false,
+		URL:     "/v1/accounts/" + id + "/external_accounts",
+	}
+
+	h.store.Accounts.Set(id, acct)
+	h.store.GetOrCreateBalance(id)
+
+	// Emit account.updated event
+	h.emitEvent("account.updated", accountToMap(acct))
+
+	twincore.JSON(w, http.StatusOK, acct)
+}
+
+// GetAccount handles GET /v1/accounts/{id}.
+// Stripe SDK: account.GetByID(id, nil)
+func (h *Handler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	acct, ok := h.store.Accounts.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such account: '"+id+"'")
+		return
+	}
+
+	// Attach external accounts
+	acct.ExternalAccounts = h.getExternalAccountsForAccount(id)
+
+	twincore.JSON(w, http.StatusOK, acct)
+}
+
+// UpdateAccount handles POST /v1/accounts/{id}.
+// Stripe SDK: account.Update(id, params)
+func (h *Handler) UpdateAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	acct, ok := h.store.Accounts.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such account: '"+id+"'")
+		return
+	}
+
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	// Update fields from form
+	if v := r.FormValue("email"); v != "" {
+		acct.Email = v
+	}
+	if v := r.FormValue("business_type"); v != "" {
+		acct.BusinessType = v
+	}
+
+	// Parse business_profile updates
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "business_profile[") && len(values) > 0 {
+			if acct.BusinessProfile == nil {
+				acct.BusinessProfile = make(map[string]any)
+			}
+			field := strings.TrimPrefix(key, "business_profile[")
+			field = strings.TrimSuffix(field, "]")
+			acct.BusinessProfile[field] = values[0]
+		}
+	}
+
+	// Parse individual updates (KYB fields)
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "individual[") && len(values) > 0 {
+			if acct.Individual == nil {
+				acct.Individual = make(map[string]any)
+			}
+			field := strings.TrimPrefix(key, "individual[")
+			field = strings.TrimSuffix(field, "]")
+			acct.Individual[field] = values[0]
+		}
+	}
+
+	// Parse company updates
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "company[") && len(values) > 0 {
+			if acct.Company == nil {
+				acct.Company = make(map[string]any)
+			}
+			field := strings.TrimPrefix(key, "company[")
+			field = strings.TrimSuffix(field, "]")
+			acct.Company[field] = values[0]
+		}
+	}
+
+	// Parse tos_acceptance
+	if r.FormValue("tos_acceptance[date]") != "" || r.FormValue("tos_acceptance[ip]") != "" {
+		acct.TOSAcceptance = map[string]any{
+			"date": r.FormValue("tos_acceptance[date]"),
+			"ip":   r.FormValue("tos_acceptance[ip]"),
+		}
+	}
+
+	// Parse capability requests
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "capabilities[") && strings.HasSuffix(key, "][requested]") {
+			capName := strings.TrimPrefix(key, "capabilities[")
+			capName = strings.TrimSuffix(capName, "][requested]")
+			if len(values) > 0 && values[0] == "true" {
+				if acct.Capabilities == nil {
+					acct.Capabilities = make(map[string]string)
+				}
+				// If not already active, set to inactive (pending verification)
+				if _, exists := acct.Capabilities[capName]; !exists {
+					acct.Capabilities[capName] = "inactive"
+				}
+			}
+		}
+	}
+
+	// Update metadata
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "metadata[") && len(values) > 0 {
+			if acct.Metadata == nil {
+				acct.Metadata = make(map[string]string)
+			}
+			field := strings.TrimPrefix(key, "metadata[")
+			field = strings.TrimSuffix(field, "]")
+			if values[0] == "" {
+				delete(acct.Metadata, field)
+			} else {
+				acct.Metadata[field] = values[0]
+			}
+		}
+	}
+
+	// Simulate KYB verification progress:
+	// If business_type, tos_acceptance, and some individual/company info is provided,
+	// mark requirements as satisfied and enable capabilities.
+	if acct.BusinessType != "" && acct.TOSAcceptance != nil {
+		hasDetails := (acct.Individual != nil && len(acct.Individual) > 0) ||
+			(acct.Company != nil && len(acct.Company) > 0)
+		if hasDetails {
+			acct.DetailsSubmitted = true
+			acct.Requirements.CurrentlyDue = []string{}
+			acct.Requirements.EventuallyDue = []string{}
+			// Enable capabilities
+			for cap := range acct.Capabilities {
+				acct.Capabilities[cap] = "active"
+			}
+			acct.ChargesEnabled = true
+			acct.PayoutsEnabled = true
+		}
+	}
+
+	acct.Updated = store.Now()
+	h.store.Accounts.Set(id, acct)
+
+	// Emit account.updated event
+	h.emitEvent("account.updated", accountToMap(acct))
+
+	acct.ExternalAccounts = h.getExternalAccountsForAccount(id)
+	twincore.JSON(w, http.StatusOK, acct)
+}
+
+// DeleteAccount handles DELETE /v1/accounts/{id}.
+func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if !h.store.Accounts.Delete(id) {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such account: '"+id+"'")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"object":  "account",
+		"deleted": true,
+	})
+}
+
+// ListAccounts handles GET /v1/accounts.
+func (h *Handler) ListAccounts(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+
+	page := h.store.Accounts.Paginate(cursor, limit)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/accounts",
+		"data":     page.Data,
+		"has_more": page.HasMore,
+	})
+}
+
+// getExternalAccountsForAccount returns the external accounts list for an account.
+func (h *Handler) getExternalAccountsForAccount(accountID string) *store.ExternalAccounts {
+	extAccts := h.store.ExternalAccts.Filter(func(id string, ea store.ExternalAccount) bool {
+		return ea.AccountID == accountID
+	})
+	return &store.ExternalAccounts{
+		Object:  "list",
+		Data:    extAccts,
+		HasMore: false,
+		URL:     "/v1/accounts/" + accountID + "/external_accounts",
+	}
+}
+
+// extractMetadata extracts metadata[key]=value from form data.
+func extractMetadata(r *http.Request) map[string]string {
+	meta := make(map[string]string)
+	for key, values := range r.Form {
+		if strings.HasPrefix(key, "metadata[") && strings.HasSuffix(key, "]") && len(values) > 0 {
+			field := strings.TrimPrefix(key, "metadata[")
+			field = strings.TrimSuffix(field, "]")
+			meta[field] = values[0]
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+// accountToMap converts an Account to a map for event payloads.
+func accountToMap(acct store.Account) map[string]any {
+	// Quick and dirty: marshal to JSON and back to map
+	data, _ := json.Marshal(acct)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m
+}
+

--- a/twin-stripe/internal/api/handlers_balance.go
+++ b/twin-stripe/internal/api/handlers_balance.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+)
+
+// GetBalance handles GET /v1/balance.
+// Stripe SDK: balance.Get(params)
+// Uses Stripe-Account header to determine which account's balance to return.
+func (h *Handler) GetBalance(w http.ResponseWriter, r *http.Request) {
+	accountID := stripeAccountFromRequest(r)
+	balance := h.store.GetBalance(accountID)
+	twincore.JSON(w, http.StatusOK, balance)
+}

--- a/twin-stripe/internal/api/handlers_events.go
+++ b/twin-stripe/internal/api/handlers_events.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// emitEvent creates a Stripe event and optionally enqueues a webhook.
+func (h *Handler) emitEvent(eventType string, objectData map[string]any) {
+	id := h.store.Events.NextID()
+	evt := store.Event{
+		ID:              id,
+		Object:          "event",
+		Type:            eventType,
+		Data:            store.EventData{Object: objectData},
+		APIVersion:      "2024-04-10",
+		Created:         store.Now(),
+		Livemode:        false,
+		PendingWebhooks: 1,
+	}
+	h.store.Events.Set(id, evt)
+
+	// Enqueue webhook delivery
+	if h.dispatcher != nil {
+		h.dispatcher.Enqueue(eventType, map[string]any{
+			"id":               evt.ID,
+			"object":           "event",
+			"type":             evt.Type,
+			"data":             evt.Data,
+			"api_version":      evt.APIVersion,
+			"created":          evt.Created,
+			"livemode":         evt.Livemode,
+			"pending_webhooks": evt.PendingWebhooks,
+		})
+	}
+}
+
+// GetEvent handles GET /v1/events/{id}.
+func (h *Handler) GetEvent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	evt, ok := h.store.Events.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such event: '"+id+"'")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, evt)
+}
+
+// ListEvents handles GET /v1/events.
+func (h *Handler) ListEvents(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	eventType := r.URL.Query().Get("type")
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+
+	if eventType != "" {
+		// Filter by event type
+		filtered := h.store.Events.Filter(func(id string, evt store.Event) bool {
+			return evt.Type == eventType
+		})
+		data := filtered
+		if len(data) > limit {
+			data = data[:limit]
+		}
+		twincore.JSON(w, http.StatusOK, map[string]any{
+			"object":   "list",
+			"url":      "/v1/events",
+			"data":     data,
+			"has_more": len(filtered) > limit,
+		})
+		return
+	}
+
+	page := h.store.Events.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/events",
+		"data":     page.Data,
+		"has_more": page.HasMore,
+	})
+}

--- a/twin-stripe/internal/api/handlers_external_accounts.go
+++ b/twin-stripe/internal/api/handlers_external_accounts.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// CreateExternalAccount handles POST /v1/accounts/{account_id}/external_accounts.
+func (h *Handler) CreateExternalAccount(w http.ResponseWriter, r *http.Request) {
+	accountID := chi.URLParam(r, "account_id")
+
+	if _, ok := h.store.Accounts.Get(accountID); !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such account: '"+accountID+"'")
+		return
+	}
+
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	id := h.store.ExternalAccts.NextID()
+
+	routingNumber := r.FormValue("external_account[routing_number]")
+	if routingNumber == "" {
+		routingNumber = r.FormValue("routing_number")
+	}
+	accountNumber := r.FormValue("external_account[account_number]")
+	if accountNumber == "" {
+		accountNumber = r.FormValue("account_number")
+	}
+	country := r.FormValue("external_account[country]")
+	if country == "" {
+		country = r.FormValue("country")
+		if country == "" {
+			country = "US"
+		}
+	}
+	currency := r.FormValue("external_account[currency]")
+	if currency == "" {
+		currency = r.FormValue("currency")
+		if currency == "" {
+			currency = "usd"
+		}
+	}
+
+	// Generate last4 from account number
+	last4 := "0000"
+	if len(accountNumber) >= 4 {
+		last4 = accountNumber[len(accountNumber)-4:]
+	}
+
+	// Generate fingerprint
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(routingNumber+accountNumber)))[:16]
+
+	ea := store.ExternalAccount{
+		ID:                 id,
+		Object:             "bank_account",
+		AccountID:          accountID,
+		BankName:           "STRIPE TEST BANK",
+		Country:            country,
+		Currency:           currency,
+		Last4:              last4,
+		RoutingNumber:      routingNumber,
+		Status:             "new",
+		DefaultForCurrency: true,
+		Fingerprint:        fingerprint,
+		Metadata:           extractMetadata(r),
+	}
+
+	h.store.ExternalAccts.Set(id, ea)
+
+	twincore.JSON(w, http.StatusOK, ea)
+}
+
+// GetExternalAccount handles GET /v1/accounts/{account_id}/external_accounts/{id}.
+func (h *Handler) GetExternalAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	ea, ok := h.store.ExternalAccts.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such external account: '"+id+"'")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, ea)
+}
+
+// UpdateExternalAccount handles POST /v1/accounts/{account_id}/external_accounts/{id}.
+func (h *Handler) UpdateExternalAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	ea, ok := h.store.ExternalAccts.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such external account: '"+id+"'")
+		return
+	}
+
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	if v := r.FormValue("default_for_currency"); v == "true" {
+		ea.DefaultForCurrency = true
+	}
+
+	// Update metadata
+	for key, values := range r.Form {
+		if len(values) > 0 && len(key) > 9 && key[:9] == "metadata[" {
+			if ea.Metadata == nil {
+				ea.Metadata = make(map[string]string)
+			}
+			field := key[9 : len(key)-1]
+			ea.Metadata[field] = values[0]
+		}
+	}
+
+	h.store.ExternalAccts.Set(id, ea)
+
+	twincore.JSON(w, http.StatusOK, ea)
+}
+
+// DeleteExternalAccount handles DELETE /v1/accounts/{account_id}/external_accounts/{id}.
+func (h *Handler) DeleteExternalAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if !h.store.ExternalAccts.Delete(id) {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such external account: '"+id+"'")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"object":  "bank_account",
+		"deleted": true,
+	})
+}

--- a/twin-stripe/internal/api/handlers_payouts.go
+++ b/twin-stripe/internal/api/handlers_payouts.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// Payout transition timing (in simulated seconds from creation).
+const (
+	payoutInTransitDelay = 3600     // 1 hour: pending → in_transit
+	payoutPaidDelay      = 3600 * 2 // 2 hours: pending → paid (via in_transit)
+)
+
+// CreatePayout handles POST /v1/payouts.
+func (h *Handler) CreatePayout(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	amountStr := r.FormValue("amount")
+	if amountStr == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing",
+			"Missing required param: amount.")
+		return
+	}
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_invalid",
+			"Invalid integer: "+amountStr)
+		return
+	}
+
+	currency := r.FormValue("currency")
+	if currency == "" {
+		currency = "usd"
+	}
+
+	// Get account from Stripe-Account header
+	accountID := stripeAccountFromRequest(r)
+
+	id := h.store.Payouts.NextID()
+	now := h.store.Clock.Now().Unix()
+
+	payout := store.Payout{
+		ID:          id,
+		Object:      "payout",
+		Amount:      amount,
+		Currency:    currency,
+		Description: r.FormValue("description"),
+		Method:      "standard",
+		Status:      store.PayoutStatusPending,
+		Type:        "bank_account",
+		Metadata:    extractMetadata(r),
+		ArrivalDate: now + 86400*2, // +2 days
+		Created:     now,
+	}
+
+	if method := r.FormValue("method"); method != "" {
+		payout.Method = method
+	}
+
+	// Debit balance if account specified
+	if accountID != "" {
+		if err := h.store.DebitBalance(accountID, currency, amount); err != nil {
+			twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "balance_insufficient",
+				"You have insufficient funds in your Stripe account.")
+			return
+		}
+	}
+
+	h.store.Payouts.Set(id, payout)
+
+	// Emit payout.created webhook
+	h.emitEvent("payout.created", payoutToMap(payout))
+
+	twincore.JSON(w, http.StatusOK, payout)
+}
+
+// GetPayout handles GET /v1/payouts/{id}.
+// Checks simulated clock to advance payout status before returning.
+func (h *Handler) GetPayout(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	payout, ok := h.store.Payouts.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such payout: '"+id+"'")
+		return
+	}
+
+	// Advance state based on simulated clock
+	h.advancePayoutState(&payout)
+	h.store.Payouts.Set(id, payout)
+
+	twincore.JSON(w, http.StatusOK, payout)
+}
+
+// ListPayouts handles GET /v1/payouts.
+func (h *Handler) ListPayouts(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+
+	// Advance all payout states before listing
+	h.advanceAllPayoutStates()
+
+	page := h.store.Payouts.Paginate(cursor, limit)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/payouts",
+		"data":     page.Data,
+		"has_more": page.HasMore,
+	})
+}
+
+// AdminFailPayout handles POST /admin/payouts/{id}/fail
+// Forces a payout to the failed state.
+func (h *Handler) AdminFailPayout(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	payout, ok := h.store.Payouts.Get(id)
+	if !ok {
+		twincore.Error(w, http.StatusNotFound, "No such payout: "+id)
+		return
+	}
+
+	if payout.Status == store.PayoutStatusPaid {
+		twincore.Error(w, http.StatusBadRequest, "Payout already paid, cannot fail")
+		return
+	}
+
+	payout.Status = store.PayoutStatusFailed
+	payout.FailureCode = "could_not_process"
+	payout.FailureMessage = "The bank could not process this payout."
+	h.store.Payouts.Set(id, payout)
+
+	h.emitEvent("payout.failed", payoutToMap(payout))
+
+	twincore.JSON(w, http.StatusOK, payout)
+}
+
+// advancePayoutState checks the simulated clock and transitions a single payout.
+func (h *Handler) advancePayoutState(p *store.Payout) {
+	now := h.store.Clock.Now().Unix()
+	elapsed := now - p.Created
+
+	switch p.Status {
+	case store.PayoutStatusPending:
+		if elapsed >= payoutPaidDelay {
+			p.Status = store.PayoutStatusPaid
+			h.emitEvent("payout.paid", payoutToMap(*p))
+		} else if elapsed >= payoutInTransitDelay {
+			p.Status = store.PayoutStatusInTransit
+			h.emitEvent("payout.updated", payoutToMap(*p))
+		}
+	case store.PayoutStatusInTransit:
+		if elapsed >= payoutPaidDelay {
+			p.Status = store.PayoutStatusPaid
+			h.emitEvent("payout.paid", payoutToMap(*p))
+		}
+	}
+}
+
+// advanceAllPayoutStates processes all payouts in the store.
+func (h *Handler) advanceAllPayoutStates() {
+	ids := h.store.Payouts.ListIDs()
+	for _, id := range ids {
+		p, ok := h.store.Payouts.Get(id)
+		if !ok {
+			continue
+		}
+		oldStatus := p.Status
+		h.advancePayoutState(&p)
+		if p.Status != oldStatus {
+			h.store.Payouts.Set(id, p)
+		}
+	}
+}
+
+func payoutToMap(p store.Payout) map[string]any {
+	data, _ := json.Marshal(p)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m
+}

--- a/twin-stripe/internal/api/handlers_test.go
+++ b/twin-stripe/internal/api/handlers_test.go
@@ -1,0 +1,240 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/pkg/webhook"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func setupStripe(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-stripe-test"}
+	twin := twincore.New(cfg)
+	dispatcher := webhook.NewDispatcher(webhook.Config{})
+	handler := api.NewHandler(memStore, dispatcher, twin.Middleware())
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// stripePost sends a POST with Stripe auth header.
+func stripePost(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("POST", path, body, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+}
+
+func stripeGet(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+}
+
+
+func TestStripeAuthRequired(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// No auth header → 401
+	resp := tc.Get("/v1/accounts")
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("api_key_required")
+}
+
+func TestCreateAndGetAccount(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create account
+	resp := tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+		"Content-Type":  "application/x-www-form-urlencoded",
+	})
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatal("expected account id")
+	}
+	if m["object"] != "account" {
+		t.Errorf("expected object=account, got %v", m["object"])
+	}
+
+	// Get account
+	resp = stripeGet(tc, "/v1/accounts/"+id)
+	resp.AssertStatus(200)
+	m = resp.JSONMap()
+	if m["id"] != id {
+		t.Errorf("expected id=%s, got %v", id, m["id"])
+	}
+}
+
+func TestListAccounts(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create two accounts
+	tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	}).AssertStatus(200)
+	tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	}).AssertStatus(200)
+
+	resp := stripeGet(tc, "/v1/accounts")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if !ok || len(data) < 2 {
+		t.Fatalf("expected at least 2 accounts, got %v", m["data"])
+	}
+}
+
+func TestDeleteAccount(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create
+	resp := tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+	id := resp.JSONMap()["id"].(string)
+
+	// Delete
+	resp = tc.DoWithHeaders("DELETE", "/v1/accounts/"+id, nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+
+	// Verify gone
+	stripeGet(tc, "/v1/accounts/"+id).AssertStatus(404)
+}
+
+func TestCreateTransfer(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create destination account first
+	resp := tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+	acctID := resp.JSONMap()["id"].(string)
+
+	// Create transfer
+	resp = tc.PostForm("/v1/transfers", map[string]string{
+		"amount":      "50000",
+		"currency":    "usd",
+		"destination": acctID,
+	})
+	// PostForm doesn't add auth; use DoWithHeaders instead
+	// Actually, let me fix the approach:
+	resp = tc.DoWithHeaders("POST", "/v1/transfers", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+	// This won't have form data. Need to test differently.
+	// The form data needs to be in the body. Let's just check that the endpoint responds.
+	// A proper form-encoded test would require building the request manually.
+	// For now, verify auth works and the endpoint exists.
+	resp.AssertStatus(400) // Missing required param: amount
+	resp.AssertBodyContains("amount")
+}
+
+func TestGetBalance(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	resp := stripeGet(tc, "/v1/balance")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["object"] != "balance" {
+		t.Errorf("expected object=balance, got %v", m["object"])
+	}
+	avail, ok := m["available"].([]any)
+	if !ok || len(avail) == 0 {
+		t.Fatal("expected available balance array")
+	}
+}
+
+func TestCreatePayout(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create payout (will fail without form data, but tests endpoint existence)
+	resp := tc.DoWithHeaders("POST", "/v1/payouts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	})
+	resp.AssertStatus(400)
+	resp.AssertBodyContains("amount")
+}
+
+func TestListEvents(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create an account to generate an event
+	tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	}).AssertStatus(200)
+
+	resp := stripeGet(tc, "/v1/events")
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if !ok || len(data) == 0 {
+		t.Fatal("expected at least 1 event after account creation")
+	}
+}
+
+func TestAccountNotFound(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	resp := stripeGet(tc, "/v1/accounts/acct_nonexistent")
+	resp.AssertStatus(404)
+	resp.AssertBodyContains("resource_missing")
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create an account
+	tc.DoWithHeaders("POST", "/v1/accounts", nil, map[string]string{
+		"Authorization": "Bearer sk_test_sim_123",
+	}).AssertStatus(200)
+
+	// Reset
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	// List should be empty
+	resp := stripeGet(tc, "/v1/accounts")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	data := m["data"].([]any)
+	if len(data) != 0 {
+		t.Errorf("expected 0 accounts after reset, got %d", len(data))
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupStripe(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}
+
+func TestAdminFailPayout(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// We need to create a payout directly via admin/state since form posting is tricky
+	// Instead, test the admin endpoint with a non-existent payout
+	resp := tc.Post("/admin/payouts/po_nonexistent/fail", nil)
+	resp.AssertStatus(404)
+}

--- a/twin-stripe/internal/api/handlers_transfers.go
+++ b/twin-stripe/internal/api/handlers_transfers.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// CreateTransfer handles POST /v1/transfers.
+// Stripe SDK: transfer.New(params)
+func (h *Handler) CreateTransfer(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", err.Error())
+		return
+	}
+
+	amountStr := r.FormValue("amount")
+	if amountStr == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing",
+			"Missing required param: amount.")
+		return
+	}
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_invalid",
+			"Invalid integer: "+amountStr)
+		return
+	}
+
+	destination := r.FormValue("destination")
+	if destination == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing",
+			"Missing required param: destination.")
+		return
+	}
+
+	// Verify destination account exists
+	if _, ok := h.store.Accounts.Get(destination); !ok {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "resource_missing",
+			"No such account: '"+destination+"'")
+		return
+	}
+
+	currency := r.FormValue("currency")
+	if currency == "" {
+		currency = "usd"
+	}
+
+	id := h.store.Transfers.NextID()
+	transfer := store.Transfer{
+		ID:                id,
+		Object:            "transfer",
+		Amount:            amount,
+		Currency:          currency,
+		Description:       r.FormValue("description"),
+		Destination:       destination,
+		TransferGroup:     r.FormValue("transfer_group"),
+		SourceTransaction: r.FormValue("source_transaction"),
+		Metadata:          extractMetadata(r),
+		Livemode:          false,
+		Created:           store.Now(),
+	}
+
+	h.store.Transfers.Set(id, transfer)
+
+	// Credit the destination account balance
+	h.store.CreditBalance(destination, currency, amount)
+
+	// Emit transfer.created event
+	h.emitEvent("transfer.created", transferToMap(transfer))
+
+	// Emit transfer.paid event (in sim, transfers complete instantly)
+	h.emitEvent("transfer.paid", transferToMap(transfer))
+
+	twincore.JSON(w, http.StatusOK, transfer)
+}
+
+// GetTransfer handles GET /v1/transfers/{id}.
+// Stripe SDK: transfer.Get(id, nil)
+func (h *Handler) GetTransfer(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	transfer, ok := h.store.Transfers.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound,
+			"invalid_request_error", "resource_missing",
+			"No such transfer: '"+id+"'")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, transfer)
+}
+
+// ListTransfers handles GET /v1/transfers.
+func (h *Handler) ListTransfers(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+
+	page := h.store.Transfers.Paginate(cursor, limit)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/transfers",
+		"data":     page.Data,
+		"has_more": page.HasMore,
+	})
+}
+
+func transferToMap(t store.Transfer) map[string]any {
+	data, _ := json.Marshal(t)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m
+}

--- a/twin-stripe/internal/api/router.go
+++ b/twin-stripe/internal/api/router.go
@@ -1,0 +1,111 @@
+// Package api implements the Stripe-compatible HTTP API handlers for the twin.
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/pkg/webhook"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store      *store.MemoryStore
+	dispatcher *webhook.Dispatcher
+	mw         *twincore.Middleware
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, d *webhook.Dispatcher, mw *twincore.Middleware) *Handler {
+	return &Handler{store: s, dispatcher: d, mw: mw}
+}
+
+// Routes mounts the Stripe v1 API routes.
+func (h *Handler) Routes(r chi.Router) {
+	r.Route("/v1", func(r chi.Router) {
+		// Auth middleware for all v1 routes
+		r.Use(h.authMiddleware)
+		// Fault injection for API routes (not admin)
+		r.Use(h.mw.FaultInjection)
+
+		// Accounts
+		r.Post("/accounts", h.CreateAccount)
+		r.Get("/accounts/{id}", h.GetAccount)
+		r.Post("/accounts/{id}", h.UpdateAccount)
+		r.Delete("/accounts/{id}", h.DeleteAccount)
+		r.Get("/accounts", h.ListAccounts)
+
+		// External Accounts
+		r.Post("/accounts/{account_id}/external_accounts", h.CreateExternalAccount)
+		r.Get("/accounts/{account_id}/external_accounts/{id}", h.GetExternalAccount)
+		r.Post("/accounts/{account_id}/external_accounts/{id}", h.UpdateExternalAccount)
+		r.Delete("/accounts/{account_id}/external_accounts/{id}", h.DeleteExternalAccount)
+
+		// Transfers
+		r.Post("/transfers", h.CreateTransfer)
+		r.Get("/transfers/{id}", h.GetTransfer)
+		r.Get("/transfers", h.ListTransfers)
+
+		// Balance
+		r.Get("/balance", h.GetBalance)
+
+		// Payouts
+		r.Post("/payouts", h.CreatePayout)
+		r.Get("/payouts/{id}", h.GetPayout)
+		r.Get("/payouts", h.ListPayouts)
+
+		// Events
+		r.Get("/events", h.ListEvents)
+		r.Get("/events/{id}", h.GetEvent)
+	})
+
+	// Stripe-specific admin endpoints (outside /v1, no auth)
+	r.Post("/admin/payouts/{id}/fail", h.AdminFailPayout)
+}
+
+// authMiddleware validates Stripe-style Bearer token authentication.
+func (h *Handler) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			twincore.StripeError(w, http.StatusUnauthorized,
+				"invalid_request_error", "api_key_required",
+				"You did not provide an API key.")
+			return
+		}
+
+		// Accept "Bearer sk_test_*" or "Bearer sk_sim_*" or just "Bearer <anything>"
+		key := strings.TrimPrefix(auth, "Bearer ")
+		if key == auth {
+			// No "Bearer " prefix, also check for raw key
+			key = auth
+		}
+		if key == "" {
+			twincore.StripeError(w, http.StatusUnauthorized,
+				"invalid_request_error", "api_key_required",
+				"You did not provide an API key.")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// stripeAccountFromRequest extracts the Stripe-Account header for connected account context.
+func stripeAccountFromRequest(r *http.Request) string {
+	return r.Header.Get("Stripe-Account")
+}
+
+// parseFormOrJSON extracts form values from either form-encoded or JSON body.
+// Stripe's API uses form-encoded requests.
+func parseFormOrJSON(r *http.Request) error {
+	ct := r.Header.Get("Content-Type")
+	if strings.Contains(ct, "application/x-www-form-urlencoded") || strings.Contains(ct, "multipart/form-data") {
+		return r.ParseForm()
+	}
+	// Also parse form for requests without explicit content type (Stripe SDK default)
+	return r.ParseForm()
+}

--- a/twin-stripe/internal/store/memory.go
+++ b/twin-stripe/internal/store/memory.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all Stripe twin state in memory.
+type MemoryStore struct {
+	mu sync.RWMutex
+
+	Accounts         *pkgstore.Store[Account]
+	ExternalAccts    *pkgstore.Store[ExternalAccount]
+	Transfers        *pkgstore.Store[Transfer]
+	Payouts          *pkgstore.Store[Payout]
+	Events           *pkgstore.Store[Event]
+
+	// Per-account balances (account ID -> balance)
+	Balances         map[string]*AccountBalance
+
+	// Platform balance (the main Stripe account)
+	PlatformBalance  *AccountBalance
+
+	Clock            *pkgstore.Clock
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Accounts:        pkgstore.New[Account]("acct"),
+		ExternalAccts:   pkgstore.New[ExternalAccount]("ba"),
+		Transfers:       pkgstore.New[Transfer]("tr"),
+		Payouts:         pkgstore.New[Payout]("po"),
+		Events:          pkgstore.New[Event]("evt"),
+		Balances:        make(map[string]*AccountBalance),
+		PlatformBalance: NewAccountBalance(),
+		Clock:           pkgstore.NewClock(),
+	}
+}
+
+// GetOrCreateBalance returns the balance for an account, creating it if needed.
+func (s *MemoryStore) GetOrCreateBalance(accountID string) *AccountBalance {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if b, ok := s.Balances[accountID]; ok {
+		return b
+	}
+	b := NewAccountBalance()
+	s.Balances[accountID] = b
+	return b
+}
+
+// GetBalance returns the balance for an account or the platform balance.
+func (s *MemoryStore) GetBalance(accountID string) *Balance {
+	var ab *AccountBalance
+	if accountID == "" {
+		ab = s.PlatformBalance
+	} else {
+		ab = s.GetOrCreateBalance(accountID)
+	}
+
+	balance := &Balance{
+		Object:   "balance",
+		Livemode: false,
+	}
+	for currency, amount := range ab.Available {
+		balance.Available = append(balance.Available, BalanceAmount{Amount: amount, Currency: currency})
+	}
+	for currency, amount := range ab.Pending {
+		balance.Pending = append(balance.Pending, BalanceAmount{Amount: amount, Currency: currency})
+	}
+	if len(balance.Available) == 0 {
+		balance.Available = []BalanceAmount{{Amount: 0, Currency: "usd"}}
+	}
+	if len(balance.Pending) == 0 {
+		balance.Pending = []BalanceAmount{{Amount: 0, Currency: "usd"}}
+	}
+	return balance
+}
+
+// CreditBalance adds to an account's available balance.
+func (s *MemoryStore) CreditBalance(accountID string, currency string, amount int64) {
+	b := s.GetOrCreateBalance(accountID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b.Available[currency] += amount
+}
+
+// DebitBalance subtracts from an account's available balance.
+func (s *MemoryStore) DebitBalance(accountID string, currency string, amount int64) error {
+	b := s.GetOrCreateBalance(accountID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if b.Available[currency] < amount {
+		return fmt.Errorf("insufficient funds: available %d, requested %d", b.Available[currency], amount)
+	}
+	b.Available[currency] -= amount
+	return nil
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+type stateSnapshot struct {
+	Accounts        map[string]Account          `json:"accounts"`
+	ExternalAccts   map[string]ExternalAccount  `json:"external_accounts"`
+	Transfers       map[string]Transfer         `json:"transfers"`
+	Payouts         map[string]Payout           `json:"payouts"`
+	Events          map[string]Event            `json:"events"`
+	Balances        map[string]*AccountBalance  `json:"balances"`
+	PlatformBalance *AccountBalance             `json:"platform_balance"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Accounts:        s.Accounts.Snapshot(),
+		ExternalAccts:   s.ExternalAccts.Snapshot(),
+		Transfers:       s.Transfers.Snapshot(),
+		Payouts:         s.Payouts.Snapshot(),
+		Events:          s.Events.Snapshot(),
+		Balances:        s.snapshotBalances(),
+		PlatformBalance: s.PlatformBalance,
+	}
+}
+
+func (s *MemoryStore) snapshotBalances() map[string]*AccountBalance {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]*AccountBalance, len(s.Balances))
+	for k, v := range s.Balances {
+		out[k] = v
+	}
+	return out
+}
+
+// LoadState replaces the full state from a JSON body.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+
+	s.Accounts.LoadSnapshot(snap.Accounts)
+	s.ExternalAccts.LoadSnapshot(snap.ExternalAccts)
+	s.Transfers.LoadSnapshot(snap.Transfers)
+	s.Payouts.LoadSnapshot(snap.Payouts)
+	s.Events.LoadSnapshot(snap.Events)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if snap.Balances != nil {
+		s.Balances = snap.Balances
+	}
+	if snap.PlatformBalance != nil {
+		s.PlatformBalance = snap.PlatformBalance
+	}
+	return nil
+}
+
+// Reset clears all state.
+func (s *MemoryStore) Reset() {
+	s.Accounts.Reset()
+	s.ExternalAccts.Reset()
+	s.Transfers.Reset()
+	s.Payouts.Reset()
+	s.Events.Reset()
+	s.Clock.Reset()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Balances = make(map[string]*AccountBalance)
+	s.PlatformBalance = NewAccountBalance()
+}

--- a/twin-stripe/internal/store/types.go
+++ b/twin-stripe/internal/store/types.go
@@ -1,0 +1,164 @@
+// Package store defines the Stripe twin's state types and in-memory store.
+package store
+
+import "time"
+
+// Account represents a Stripe Connect account.
+type Account struct {
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	Type               string            `json:"type"`
+	BusinessType       string            `json:"business_type,omitempty"`
+	Email              string            `json:"email,omitempty"`
+	Country            string            `json:"country"`
+	DefaultCurrency    string            `json:"default_currency"`
+	ChargesEnabled     bool              `json:"charges_enabled"`
+	PayoutsEnabled     bool              `json:"payouts_enabled"`
+	DetailsSubmitted   bool              `json:"details_submitted"`
+	Capabilities       map[string]string `json:"capabilities,omitempty"`
+	Requirements       *Requirements     `json:"requirements,omitempty"`
+	Individual         map[string]any    `json:"individual,omitempty"`
+	Company            map[string]any    `json:"company,omitempty"`
+	ExternalAccounts   *ExternalAccounts `json:"external_accounts,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	TOSAcceptance      map[string]any    `json:"tos_acceptance,omitempty"`
+	BusinessProfile    map[string]any    `json:"business_profile,omitempty"`
+	Settings           map[string]any    `json:"settings,omitempty"`
+	Created            int64             `json:"created"`
+	Updated            int64             `json:"updated,omitempty"`
+}
+
+// Requirements tracks KYB/KYC verification requirements.
+type Requirements struct {
+	CurrentlyDue  []string `json:"currently_due"`
+	EventuallyDue []string `json:"eventually_due"`
+	PastDue       []string `json:"past_due"`
+	Alternatives  []any    `json:"alternatives,omitempty"`
+	DisabledReason string  `json:"disabled_reason,omitempty"`
+}
+
+// ExternalAccounts wraps the external accounts list.
+type ExternalAccounts struct {
+	Object  string            `json:"object"`
+	Data    []ExternalAccount `json:"data"`
+	HasMore bool              `json:"has_more"`
+	URL     string            `json:"url"`
+}
+
+// ExternalAccount represents a bank account or card attached to a Connect account.
+type ExternalAccount struct {
+	ID                string `json:"id"`
+	Object            string `json:"object"`
+	AccountID         string `json:"account"`
+	BankName          string `json:"bank_name,omitempty"`
+	Country           string `json:"country"`
+	Currency          string `json:"currency"`
+	Last4             string `json:"last4"`
+	RoutingNumber     string `json:"routing_number,omitempty"`
+	Status            string `json:"status"`
+	DefaultForCurrency bool  `json:"default_for_currency"`
+	Fingerprint       string `json:"fingerprint,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}
+
+// Transfer represents a Stripe transfer to a connected account.
+type Transfer struct {
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	Amount             int64             `json:"amount"`
+	AmountReversed     int64             `json:"amount_reversed"`
+	Currency           string            `json:"currency"`
+	Description        string            `json:"description,omitempty"`
+	Destination        string            `json:"destination"`
+	DestinationPayment string            `json:"destination_payment,omitempty"`
+	Livemode           bool              `json:"livemode"`
+	Reversed           bool              `json:"reversed"`
+	SourceTransaction  string            `json:"source_transaction,omitempty"`
+	TransferGroup      string            `json:"transfer_group,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Created            int64             `json:"created"`
+}
+
+// Balance represents a Stripe account balance.
+type Balance struct {
+	Object    string          `json:"object"`
+	Available []BalanceAmount `json:"available"`
+	Pending   []BalanceAmount `json:"pending"`
+	Livemode  bool            `json:"livemode"`
+}
+
+// BalanceAmount is a currency-specific balance entry.
+type BalanceAmount struct {
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// Payout represents a payout from a connected account to a bank.
+type Payout struct {
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	Amount             int64             `json:"amount"`
+	Currency           string            `json:"currency"`
+	ArrivalDate        int64             `json:"arrival_date"`
+	Description        string            `json:"description,omitempty"`
+	Destination        string            `json:"destination,omitempty"`
+	Method             string            `json:"method"`
+	Status             string            `json:"status"`
+	Type               string            `json:"type"`
+	FailureCode        string            `json:"failure_code,omitempty"`
+	FailureMessage     string            `json:"failure_message,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Created            int64             `json:"created"`
+}
+
+// Event represents a Stripe webhook event.
+type Event struct {
+	ID             string    `json:"id"`
+	Object         string    `json:"object"`
+	Type           string    `json:"type"`
+	Data           EventData `json:"data"`
+	APIVersion     string    `json:"api_version"`
+	Created        int64     `json:"created"`
+	Livemode       bool      `json:"livemode"`
+	PendingWebhooks int      `json:"pending_webhooks"`
+	Request        *EventReq `json:"request,omitempty"`
+}
+
+// EventData wraps the event's object.
+type EventData struct {
+	Object map[string]any `json:"object"`
+}
+
+// EventReq tracks the API request that triggered the event.
+type EventReq struct {
+	ID             string `json:"id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+// AccountBalance tracks per-account balance (available and pending).
+type AccountBalance struct {
+	Available map[string]int64 // currency -> amount
+	Pending   map[string]int64 // currency -> amount
+}
+
+// NewAccountBalance creates a zero balance.
+func NewAccountBalance() *AccountBalance {
+	return &AccountBalance{
+		Available: map[string]int64{"usd": 0},
+		Pending:   map[string]int64{"usd": 0},
+	}
+}
+
+// PayoutStatus constants.
+const (
+	PayoutStatusPending   = "pending"
+	PayoutStatusInTransit = "in_transit"
+	PayoutStatusPaid      = "paid"
+	PayoutStatusFailed    = "failed"
+	PayoutStatusCanceled  = "canceled"
+)
+
+// Default timestamps for testing.
+func Now() int64 {
+	return time.Now().Unix()
+}

--- a/twin-stripe/internal/webhook/signer.go
+++ b/twin-stripe/internal/webhook/signer.go
@@ -1,0 +1,56 @@
+// Package webhook implements Stripe v1 webhook signature signing.
+// The signature format must be compatible with stripe.webhook.ConstructEvent().
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// StripeSigner implements the Stripe v1 webhook signature scheme.
+// This is HMAC-SHA256 with a timestamp, compatible with webhook.ConstructEvent().
+//
+// The signature header format is:
+//
+//	Stripe-Signature: t={timestamp},v1={signature}
+//
+// Where signature = HMAC-SHA256(secret, "{timestamp}.{payload}")
+type StripeSigner struct{}
+
+// NewStripeSigner creates a new Stripe webhook signer.
+func NewStripeSigner() *StripeSigner {
+	return &StripeSigner{}
+}
+
+// Sign produces the Stripe-Signature header value.
+// Implements pkg/webhook.Signer interface.
+func (s *StripeSigner) Sign(payload []byte, secret string) map[string]string {
+	timestamp := time.Now().Unix()
+	return s.SignWithTimestamp(payload, secret, timestamp)
+}
+
+// SignWithTimestamp produces the Stripe-Signature header with a specific timestamp.
+// Useful for testing.
+func (s *StripeSigner) SignWithTimestamp(payload []byte, secret string, timestamp int64) map[string]string {
+	sig := ComputeSignature(timestamp, payload, secret)
+	headerValue := fmt.Sprintf("t=%d,v1=%s", timestamp, sig)
+
+	return map[string]string{
+		"Stripe-Signature": headerValue,
+	}
+}
+
+// ComputeSignature computes the Stripe v1 HMAC-SHA256 signature.
+// This matches the algorithm in stripe-go/webhook.computeSignature().
+func ComputeSignature(timestamp int64, payload []byte, secret string) string {
+	// The signed content is "{timestamp}.{payload}"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(strconv.FormatInt(timestamp, 10)))
+	mac.Write([]byte("."))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/twin-twilio/cmd/twin-twilio/main.go
+++ b/twin-twilio/cmd/twin-twilio/main.go
@@ -1,0 +1,55 @@
+// twin-twilio is a WonderTwin twin that simulates the Twilio SMS API.
+// It captures CreateMessage calls and provides admin endpoints
+// for inspecting messages and extracting OTP codes.
+//
+// SDK compatibility target: github.com/twilio/twilio-go
+// Integration method: Override base URL
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-twilio")
+	if cfg.Port == 0 {
+		cfg.Port = 12113
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-twilio ready",
+		"port", cfg.Port,
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-twilio/go.mod
+++ b/twin-twilio/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-twilio
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/pkg v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/pkg => ../pkg

--- a/twin-twilio/go.sum
+++ b/twin-twilio/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-twilio/internal/api/handlers_messages.go
+++ b/twin-twilio/internal/api/handlers_messages.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+// otpRegex matches 4-6 digit OTP codes in message bodies.
+var otpRegex = regexp.MustCompile(`\b(\d{4,6})\b`)
+
+// CreateMessage handles POST /2010-04-01/Accounts/{AccountSid}/Messages.json
+// Twilio sends form-encoded requests and returns JSON.
+func (h *Handler) CreateMessage(w http.ResponseWriter, r *http.Request) {
+	accountSID := chi.URLParam(r, "AccountSid")
+
+	if err := r.ParseForm(); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"code":    21601,
+			"message": "Unable to parse form data: " + err.Error(),
+			"status":  400,
+		})
+		return
+	}
+
+	to := r.FormValue("To")
+	from := r.FormValue("From")
+	body := r.FormValue("Body")
+
+	if to == "" {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"code":    21604,
+			"message": "A 'To' phone number is required.",
+			"status":  400,
+		})
+		return
+	}
+
+	if from == "" && r.FormValue("MessagingServiceSid") == "" {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"code":    21603,
+			"message": "A 'From' phone number is required.",
+			"status":  400,
+		})
+		return
+	}
+
+	if body == "" {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"code":    21602,
+			"message": "Message body is required.",
+			"status":  400,
+		})
+		return
+	}
+
+	now := h.store.Clock.Now()
+	sid := h.store.Messages.NextID()
+
+	msg := store.Message{
+		SID:         sid,
+		AccountSID:  accountSID,
+		To:          to,
+		From:        from,
+		Body:        body,
+		Status:      store.MessageStatusDelivered, // Sim: instantly delivered
+		Direction:   "outbound-api",
+		NumSegments: "1",
+		NumMedia:    "0",
+		PriceUnit:   "USD",
+		ErrorCode:   nil,
+		DateCreated: now.Format(time.RFC1123Z),
+		DateUpdated: now.Format(time.RFC1123Z),
+		DateSent:    now.Format(time.RFC1123Z),
+		URI:         fmt.Sprintf("/2010-04-01/Accounts/%s/Messages/%s.json", accountSID, sid),
+	}
+
+	h.store.Messages.Set(sid, msg)
+
+	twincore.JSON(w, http.StatusCreated, msg)
+}
+
+// GetMessage handles GET /2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json
+func (h *Handler) GetMessage(w http.ResponseWriter, r *http.Request) {
+	sid := chi.URLParam(r, "MessageSid")
+
+	msg, ok := h.store.Messages.Get(sid)
+	if !ok {
+		twincore.JSON(w, http.StatusNotFound, map[string]any{
+			"code":    20404,
+			"message": fmt.Sprintf("The requested resource /Messages/%s was not found", sid),
+			"status":  404,
+		})
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, msg)
+}
+
+// ListMessages handles GET /2010-04-01/Accounts/{AccountSid}/Messages.json
+func (h *Handler) ListMessages(w http.ResponseWriter, r *http.Request) {
+	to := r.URL.Query().Get("To")
+	from := r.URL.Query().Get("From")
+
+	messages := h.store.Messages.List()
+
+	// Filter if query params provided
+	if to != "" || from != "" {
+		var filtered []store.Message
+		for _, msg := range messages {
+			if to != "" && msg.To != to {
+				continue
+			}
+			if from != "" && msg.From != from {
+				continue
+			}
+			filtered = append(filtered, msg)
+		}
+		messages = filtered
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"messages":         messages,
+		"end":              len(messages) - 1,
+		"first_page_uri":  "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
+		"next_page_uri":   nil,
+		"page":            0,
+		"page_size":       50,
+		"previous_page_uri": nil,
+		"start":           0,
+		"uri":             "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
+	})
+}
+
+// AdminListMessages handles GET /admin/messages
+// Supports ?to={phone} query parameter for filtering.
+func (h *Handler) AdminListMessages(w http.ResponseWriter, r *http.Request) {
+	to := r.URL.Query().Get("to")
+
+	messages := h.store.Messages.List()
+
+	if to != "" {
+		var filtered []store.Message
+		for _, msg := range messages {
+			if msg.To == to {
+				filtered = append(filtered, msg)
+			}
+		}
+		messages = filtered
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"messages": messages,
+		"total":    len(messages),
+	})
+}
+
+// AdminGetOTP handles GET /admin/otp?to={phone}
+// Returns the last OTP code sent to that phone number.
+func (h *Handler) AdminGetOTP(w http.ResponseWriter, r *http.Request) {
+	to := r.URL.Query().Get("to")
+	if to == "" {
+		twincore.Error(w, http.StatusBadRequest, "'to' query parameter is required")
+		return
+	}
+
+	// Search messages in reverse order (most recent first)
+	messages := h.store.Messages.List()
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.To != to {
+			continue
+		}
+
+		// Extract OTP code from body
+		matches := otpRegex.FindAllString(msg.Body, -1)
+		if len(matches) > 0 {
+			// Return the last match in the most recent matching message
+			code := matches[len(matches)-1]
+			twincore.JSON(w, http.StatusOK, map[string]any{
+				"to":          to,
+				"code":        code,
+				"message_sid": msg.SID,
+				"body":        msg.Body,
+				"found":       true,
+			})
+			return
+		}
+	}
+
+	// No OTP found
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"to":    to,
+		"found": false,
+	})
+}
+
+// extractOTP finds OTP codes (4-6 digit numbers) in a message body.
+func extractOTP(body string) []string {
+	return otpRegex.FindAllString(body, -1)
+}

--- a/twin-twilio/internal/api/handlers_test.go
+++ b/twin-twilio/internal/api/handlers_test.go
@@ -1,0 +1,361 @@
+package api_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/pkg/admin"
+	"github.com/wondertwin-ai/wondertwin/pkg/testutil"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+const testAccountSID = "AC_test_sim"
+
+var basicAuthHeader = "Basic " + base64.StdEncoding.EncodeToString([]byte(testAccountSID+":auth_token_sim"))
+
+func setupTwilio(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-twilio-test"}
+	twin := twincore.New(cfg)
+	handler := api.NewHandler(memStore, twin.Middleware())
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// twilioPostForm sends a form-encoded POST with Twilio Basic Auth.
+// Returns status code and parsed JSON body.
+func twilioPostForm(t *testing.T, tc *testutil.TwinClient, path string, form map[string]string) (int, map[string]any) {
+	t.Helper()
+	values := url.Values{}
+	for k, v := range form {
+		values.Set(k, v)
+	}
+	req, err := http.NewRequest("POST", tc.BaseURL+path, strings.NewReader(values.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", basicAuthHeader)
+
+	resp, err := tc.HTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var m map[string]any
+	json.Unmarshal(body, &m)
+	return resp.StatusCode, m
+}
+
+// twilioGet sends a GET with Twilio Basic Auth using DoWithHeaders (which works for GETs).
+func twilioGet(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, map[string]string{
+		"Authorization": basicAuthHeader,
+	})
+}
+
+func msgPath(path string) string {
+	return "/2010-04-01/Accounts/" + testAccountSID + path
+}
+
+func verifySvcPath(path string) string {
+	return "/v2/Services/VA_test_service" + path
+}
+
+// --- Auth Tests ---
+
+func TestTwilioAuthRequired(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	resp := tc.Get(msgPath("/Messages.json"))
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("Authenticate")
+}
+
+// --- Message Tests ---
+
+func TestCreateAndGetMessage(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	status, m := twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To":   "+15551234567",
+		"From": "+15559876543",
+		"Body": "Hello from test",
+	})
+	if status != 201 {
+		t.Fatalf("expected 201, got %d: %v", status, m)
+	}
+	sid, ok := m["sid"].(string)
+	if !ok || sid == "" {
+		t.Fatal("expected message SID")
+	}
+	if m["status"] != "delivered" {
+		t.Errorf("expected status=delivered, got %v", m["status"])
+	}
+	if m["to"] != "+15551234567" {
+		t.Errorf("expected to=+15551234567, got %v", m["to"])
+	}
+
+	// Get message
+	resp := twilioGet(tc, msgPath("/Messages/"+sid+".json"))
+	resp.AssertStatus(200)
+	got := resp.JSONMap()
+	if got["sid"] != sid {
+		t.Errorf("expected sid=%s, got %v", sid, got["sid"])
+	}
+}
+
+func TestListMessages(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To": "+15551111111", "From": "+15550000000", "Body": "msg1",
+	})
+	twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To": "+15552222222", "From": "+15550000000", "Body": "msg2",
+	})
+
+	resp := twilioGet(tc, msgPath("/Messages.json"))
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	msgs, ok := m["messages"].([]any)
+	if !ok || len(msgs) < 2 {
+		t.Fatalf("expected at least 2 messages, got %v", m["messages"])
+	}
+}
+
+func TestCreateMessageMissingTo(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	status, m := twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"From": "+15550000000",
+		"Body": "missing to",
+	})
+	if status != 400 {
+		t.Errorf("expected 400, got %d", status)
+	}
+	if code, _ := m["code"].(float64); code != 21604 {
+		t.Errorf("expected error code 21604, got %v", m["code"])
+	}
+}
+
+func TestCreateMessageMissingBody(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	status, m := twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To":   "+15551234567",
+		"From": "+15550000000",
+	})
+	if status != 400 {
+		t.Errorf("expected 400, got %d", status)
+	}
+	if code, _ := m["code"].(float64); code != 21602 {
+		t.Errorf("expected error code 21602, got %v", m["code"])
+	}
+}
+
+func TestMessageNotFound(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	resp := twilioGet(tc, msgPath("/Messages/SM_nonexistent.json"))
+	resp.AssertStatus(404)
+}
+
+// --- Verify Tests ---
+
+func TestCreateAndCheckVerification(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	// Create verification
+	status, m := twilioPostForm(t, tc, verifySvcPath("/Verifications"), map[string]string{
+		"To":      "+15551234567",
+		"Channel": "sms",
+	})
+	if status != 201 {
+		t.Fatalf("expected 201, got %d: %v", status, m)
+	}
+	if m["status"] != "pending" {
+		t.Errorf("expected status=pending, got %v", m["status"])
+	}
+	if m["to"] != "+15551234567" {
+		t.Errorf("expected to=+15551234567, got %v", m["to"])
+	}
+
+	// Get the code via admin endpoint (URL-encode + as %2B)
+	resp := tc.Get("/admin/verifications?to=%2B15551234567")
+	resp.AssertStatus(200)
+	adminData := resp.JSONMap()
+	verifications := adminData["verifications"].([]any)
+	if len(verifications) == 0 {
+		t.Fatal("expected at least 1 verification in admin list")
+	}
+	v := verifications[0].(map[string]any)
+	code := v["code"].(string)
+	if code == "" {
+		t.Fatal("expected non-empty code from admin endpoint")
+	}
+
+	// Check with correct code
+	status, m = twilioPostForm(t, tc, verifySvcPath("/VerificationCheck"), map[string]string{
+		"To":   "+15551234567",
+		"Code": code,
+	})
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %v", status, m)
+	}
+	if m["status"] != "approved" {
+		t.Errorf("expected status=approved, got %v", m["status"])
+	}
+	if m["valid"] != true {
+		t.Errorf("expected valid=true, got %v", m["valid"])
+	}
+}
+
+func TestCheckVerificationWrongCode(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	twilioPostForm(t, tc, verifySvcPath("/Verifications"), map[string]string{
+		"To":      "+15553333333",
+		"Channel": "sms",
+	})
+
+	status, m := twilioPostForm(t, tc, verifySvcPath("/VerificationCheck"), map[string]string{
+		"To":   "+15553333333",
+		"Code": "000000",
+	})
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %v", status, m)
+	}
+	if m["valid"] != false {
+		t.Errorf("expected valid=false, got %v", m["valid"])
+	}
+}
+
+func TestGetVerification(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	status, m := twilioPostForm(t, tc, verifySvcPath("/Verifications"), map[string]string{
+		"To":      "+15554444444",
+		"Channel": "sms",
+	})
+	if status != 201 {
+		t.Fatalf("expected 201, got %d", status)
+	}
+	sid := m["sid"].(string)
+
+	resp := twilioGet(tc, verifySvcPath("/Verifications/"+sid))
+	resp.AssertStatus(200)
+	got := resp.JSONMap()
+	if got["sid"] != sid {
+		t.Errorf("expected sid=%s, got %v", sid, got["sid"])
+	}
+}
+
+func TestCheckVerificationMissingTo(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	status, _ := twilioPostForm(t, tc, verifySvcPath("/VerificationCheck"), map[string]string{
+		"Code": "123456",
+	})
+	if status != 400 {
+		t.Errorf("expected 400, got %d", status)
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminListMessages(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To": "+15555555555", "From": "+15550000000", "Body": "admin test msg",
+	})
+
+	resp := tc.Get("/admin/messages?to=%2B15555555555")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	msgs, ok := m["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %v", m["messages"])
+	}
+}
+
+func TestAdminGetOTP(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To":   "+15556666666",
+		"From": "+15550000000",
+		"Body": "Your code is 123456. Use it now.",
+	})
+
+	resp := tc.Get("/admin/otp?to=%2B15556666666")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["found"] != true {
+		t.Error("expected found=true")
+	}
+	if m["code"] != "123456" {
+		t.Errorf("expected code=123456, got %v", m["code"])
+	}
+}
+
+func TestAdminExpireVerification(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	// Create a verification
+	_, m := twilioPostForm(t, tc, verifySvcPath("/Verifications"), map[string]string{
+		"To":      "+15557777777",
+		"Channel": "sms",
+	})
+	sid := m["sid"].(string)
+
+	// Expire it via admin
+	resp := tc.Post("/admin/verifications/"+sid+"/expire", nil)
+	resp.AssertStatus(200)
+	got := resp.JSONMap()
+	if got["status"] != "canceled" {
+		t.Errorf("expected status=canceled, got %v", got["status"])
+	}
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupTwilio(t)
+
+	twilioPostForm(t, tc, msgPath("/Messages.json"), map[string]string{
+		"To": "+15551111111", "From": "+15550000000", "Body": "reset test",
+	})
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	resp := tc.Get("/admin/messages")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	msgs := m["messages"]
+	// After reset, should be null or empty
+	if msgs != nil {
+		if arr, ok := msgs.([]any); ok && len(arr) > 0 {
+			t.Errorf("expected 0 messages after reset, got %d", len(arr))
+		}
+	}
+}
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupTwilio(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}

--- a/twin-twilio/internal/api/handlers_verify.go
+++ b/twin-twilio/internal/api/handlers_verify.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+// CreateVerification handles POST /v2/Services/{ServiceSid}/Verifications
+// Sends a verification code to the given phone number.
+func (h *Handler) CreateVerification(w http.ResponseWriter, r *http.Request) {
+	serviceSID := chi.URLParam(r, "ServiceSid")
+
+	if err := r.ParseForm(); err != nil {
+		twilioError(w, http.StatusBadRequest, 60200, "Unable to parse form data: "+err.Error())
+		return
+	}
+
+	to := r.FormValue("To")
+	channel := r.FormValue("Channel")
+	if to == "" {
+		twilioError(w, http.StatusBadRequest, 60200, "A 'To' phone number or email is required.")
+		return
+	}
+	if channel == "" {
+		channel = "sms"
+	}
+
+	now := h.store.Clock.Now()
+	sid := h.store.Verifications.NextID()
+	code := generateCode(6)
+	ttl := time.Duration(h.store.OTPTTLSeconds) * time.Second
+
+	v := store.Verification{
+		SID:        sid,
+		ServiceSID: serviceSID,
+		To:         to,
+		Channel:    channel,
+		Status:     store.VerificationStatusPending,
+		Code:       code,
+		Valid:      false,
+		CreatedAt:  now.Format(time.RFC3339),
+		UpdatedAt:  now.Format(time.RFC3339),
+		ExpiresAt:  now.Add(ttl).Format(time.RFC3339),
+		URL:        fmt.Sprintf("/v2/Services/%s/Verifications/%s", serviceSID, sid),
+	}
+
+	h.store.Verifications.Set(sid, v)
+
+	twincore.JSON(w, http.StatusCreated, verificationResponse(v))
+}
+
+// CheckVerification handles POST /v2/Services/{ServiceSid}/VerificationCheck
+// Checks a verification code against the stored verification.
+func (h *Handler) CheckVerification(w http.ResponseWriter, r *http.Request) {
+	serviceSID := chi.URLParam(r, "ServiceSid")
+
+	if err := r.ParseForm(); err != nil {
+		twilioError(w, http.StatusBadRequest, 60200, "Unable to parse form data: "+err.Error())
+		return
+	}
+
+	to := r.FormValue("To")
+	code := r.FormValue("Code")
+	if to == "" {
+		twilioError(w, http.StatusBadRequest, 60200, "A 'To' phone number or email is required.")
+		return
+	}
+	if code == "" {
+		twilioError(w, http.StatusBadRequest, 60200, "A 'Code' is required.")
+		return
+	}
+
+	now := h.store.Clock.Now()
+
+	// Find the most recent pending verification for this number + service
+	verifications := h.store.Verifications.List()
+	var found *store.Verification
+	for i := len(verifications) - 1; i >= 0; i-- {
+		v := verifications[i]
+		if v.To == to && v.ServiceSID == serviceSID && v.Status == store.VerificationStatusPending {
+			found = &v
+			break
+		}
+	}
+
+	if found == nil {
+		twilioError(w, http.StatusNotFound, 60200, "Verification not found or already consumed.")
+		return
+	}
+
+	// Check expiry
+	expiresAt, _ := time.Parse(time.RFC3339, found.ExpiresAt)
+	if now.After(expiresAt) {
+		found.Status = store.VerificationStatusExpired
+		found.UpdatedAt = now.Format(time.RFC3339)
+		h.store.Verifications.Set(found.SID, *found)
+		twilioError(w, http.StatusNotFound, 60202, "Verification code has expired.")
+		return
+	}
+
+	// Check code
+	if found.Code == code {
+		found.Status = store.VerificationStatusApproved
+		found.Valid = true
+	} else {
+		// Twilio returns the verification with valid=false, not an error
+		found.Valid = false
+	}
+	found.UpdatedAt = now.Format(time.RFC3339)
+	h.store.Verifications.Set(found.SID, *found)
+
+	twincore.JSON(w, http.StatusOK, verificationResponse(*found))
+}
+
+// GetVerification handles GET /v2/Services/{ServiceSid}/Verifications/{Sid}
+func (h *Handler) GetVerification(w http.ResponseWriter, r *http.Request) {
+	sid := chi.URLParam(r, "Sid")
+
+	v, ok := h.store.Verifications.Get(sid)
+	if !ok {
+		twilioError(w, http.StatusNotFound, 20404, "Verification not found.")
+		return
+	}
+
+	// Check if expired
+	now := h.store.Clock.Now()
+	expiresAt, _ := time.Parse(time.RFC3339, v.ExpiresAt)
+	if v.Status == store.VerificationStatusPending && now.After(expiresAt) {
+		v.Status = store.VerificationStatusExpired
+		v.UpdatedAt = now.Format(time.RFC3339)
+		h.store.Verifications.Set(v.SID, v)
+	}
+
+	twincore.JSON(w, http.StatusOK, verificationResponse(v))
+}
+
+// AdminListVerifications handles GET /admin/verifications
+// Supports ?to={phone} query parameter for filtering.
+func (h *Handler) AdminListVerifications(w http.ResponseWriter, r *http.Request) {
+	to := r.URL.Query().Get("to")
+
+	verifications := h.store.Verifications.List()
+
+	if to != "" {
+		var filtered []store.Verification
+		for _, v := range verifications {
+			if v.To == to {
+				filtered = append(filtered, v)
+			}
+		}
+		verifications = filtered
+	}
+
+	// Include codes in admin response
+	type adminVerification struct {
+		store.Verification
+		Code string `json:"code"`
+	}
+	result := make([]adminVerification, len(verifications))
+	for i, v := range verifications {
+		result[i] = adminVerification{Verification: v, Code: v.Code}
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"verifications": result,
+		"total":         len(result),
+	})
+}
+
+// AdminExpireVerification handles POST /admin/verifications/{sid}/expire
+func (h *Handler) AdminExpireVerification(w http.ResponseWriter, r *http.Request) {
+	sid := chi.URLParam(r, "sid")
+
+	v, ok := h.store.Verifications.Get(sid)
+	if !ok {
+		twincore.Error(w, http.StatusNotFound, "Verification not found: "+sid)
+		return
+	}
+
+	if v.Status != store.VerificationStatusPending {
+		twincore.Error(w, http.StatusBadRequest, "Verification is not pending, current status: "+v.Status)
+		return
+	}
+
+	v.Status = store.VerificationStatusCanceled
+	v.UpdatedAt = h.store.Clock.Now().Format(time.RFC3339)
+	h.store.Verifications.Set(sid, v)
+
+	twincore.JSON(w, http.StatusOK, verificationResponse(v))
+}
+
+// verificationResponse creates a Twilio-compatible verification response.
+// The code is never included in API responses.
+func verificationResponse(v store.Verification) map[string]any {
+	return map[string]any{
+		"sid":          v.SID,
+		"service_sid":  v.ServiceSID,
+		"account_sid":  "AC_sim_test",
+		"to":           v.To,
+		"channel":      v.Channel,
+		"status":       v.Status,
+		"valid":        v.Valid,
+		"date_created": v.CreatedAt,
+		"date_updated": v.UpdatedAt,
+		"url":          v.URL,
+	}
+}
+
+// twilioError writes a Twilio-style error response.
+func twilioError(w http.ResponseWriter, status int, code int, message string) {
+	resp := map[string]any{
+		"code":    code,
+		"message": message,
+		"status":  status,
+	}
+	data, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(data)
+}
+
+// generateCode generates a random numeric code of the given length.
+func generateCode(length int) string {
+	code := ""
+	for i := 0; i < length; i++ {
+		n, _ := rand.Int(rand.Reader, big.NewInt(10))
+		code += fmt.Sprintf("%d", n.Int64())
+	}
+	return code
+}

--- a/twin-twilio/internal/api/router.go
+++ b/twin-twilio/internal/api/router.go
@@ -1,0 +1,70 @@
+// Package api implements the Twilio-compatible HTTP API handlers for the twin.
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/pkg/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store *store.MemoryStore
+	mw    *twincore.Middleware
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
+	return &Handler{store: s, mw: mw}
+}
+
+// Routes mounts the Twilio API routes and admin extras.
+func (h *Handler) Routes(r chi.Router) {
+	// Twilio REST API routes (Basic Auth required)
+	r.Route("/2010-04-01/Accounts/{AccountSid}", func(r chi.Router) {
+		r.Use(h.basicAuthMiddleware)
+		r.Use(h.mw.FaultInjection)
+
+		// Messages
+		r.Post("/Messages.json", h.CreateMessage)
+		r.Get("/Messages/{MessageSid}.json", h.GetMessage)
+		r.Get("/Messages.json", h.ListMessages)
+	})
+
+	// Twilio Verify API (Basic Auth required)
+	r.Route("/v2/Services/{ServiceSid}", func(r chi.Router) {
+		r.Use(h.basicAuthMiddleware)
+		r.Use(h.mw.FaultInjection)
+
+		r.Post("/Verifications", h.CreateVerification)
+		r.Get("/Verifications/{Sid}", h.GetVerification)
+		r.Post("/VerificationCheck", h.CheckVerification)
+	})
+
+	// Admin extras (no auth required, same as other twins)
+	r.Get("/admin/messages", h.AdminListMessages)
+	r.Get("/admin/otp", h.AdminGetOTP)
+	r.Get("/admin/verifications", h.AdminListVerifications)
+	r.Post("/admin/verifications/{sid}/expire", h.AdminExpireVerification)
+}
+
+// basicAuthMiddleware validates Twilio-style HTTP Basic Auth (AccountSID:AuthToken).
+// In sim mode, we accept any non-empty credentials.
+func (h *Handler) basicAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user == "" || pass == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="Twilio API"`)
+			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+				"code":     20003,
+				"message":  "Authenticate",
+				"more_info": "https://www.twilio.com/docs/errors/20003",
+				"status":   401,
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/twin-twilio/internal/store/memory.go
+++ b/twin-twilio/internal/store/memory.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"encoding/json"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/pkg/store"
+)
+
+// MemoryStore holds all Twilio twin state in memory.
+type MemoryStore struct {
+	Messages      *pkgstore.Store[Message]
+	Verifications *pkgstore.Store[Verification]
+	Clock         *pkgstore.Clock
+	OTPTTLSeconds int // verification code TTL, default 600 (10 min)
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Messages:      pkgstore.New[Message]("SM"),
+		Verifications: pkgstore.New[Verification]("VE"),
+		Clock:         pkgstore.NewClock(),
+		OTPTTLSeconds: 600,
+	}
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+type stateSnapshot struct {
+	Messages      map[string]Verification `json:"messages"`
+	Verifications map[string]Verification `json:"verifications"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return struct {
+		Messages      map[string]Message      `json:"messages"`
+		Verifications map[string]Verification `json:"verifications"`
+	}{
+		Messages:      s.Messages.Snapshot(),
+		Verifications: s.Verifications.Snapshot(),
+	}
+}
+
+// LoadState replaces the full state from a JSON body.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap struct {
+		Messages      map[string]Message      `json:"messages"`
+		Verifications map[string]Verification `json:"verifications"`
+	}
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	if snap.Messages != nil {
+		s.Messages.LoadSnapshot(snap.Messages)
+	}
+	if snap.Verifications != nil {
+		s.Verifications.LoadSnapshot(snap.Verifications)
+	}
+	return nil
+}
+
+// Reset clears all state.
+func (s *MemoryStore) Reset() {
+	s.Messages.Reset()
+	s.Verifications.Reset()
+	s.Clock.Reset()
+}

--- a/twin-twilio/internal/store/types.go
+++ b/twin-twilio/internal/store/types.go
@@ -1,0 +1,55 @@
+// Package store defines the Twilio twin's state types and in-memory store.
+package store
+
+// Message represents a Twilio SMS message.
+type Message struct {
+	SID         string `json:"sid"`
+	AccountSID  string `json:"account_sid"`
+	To          string `json:"to"`
+	From        string `json:"from"`
+	Body        string `json:"body"`
+	Status      string `json:"status"`
+	Direction   string `json:"direction"`
+	NumSegments string `json:"num_segments"`
+	NumMedia    string `json:"num_media"`
+	Price       string `json:"price,omitempty"`
+	PriceUnit   string `json:"price_unit"`
+	ErrorCode   *int   `json:"error_code"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	DateCreated string `json:"date_created"`
+	DateUpdated string `json:"date_updated"`
+	DateSent    string `json:"date_sent,omitempty"`
+	URI         string `json:"uri"`
+}
+
+// Message status constants matching Twilio's lifecycle.
+const (
+	MessageStatusQueued    = "queued"
+	MessageStatusSending   = "sending"
+	MessageStatusSent      = "sent"
+	MessageStatusDelivered = "delivered"
+	MessageStatusFailed    = "failed"
+)
+
+// Verification represents a Twilio Verify verification attempt.
+type Verification struct {
+	SID        string `json:"sid"`
+	ServiceSID string `json:"service_sid"`
+	To         string `json:"to"`
+	Channel    string `json:"channel"`
+	Status     string `json:"status"`
+	Code       string `json:"-"` // hidden from API responses
+	Valid      bool   `json:"valid"`
+	CreatedAt  string `json:"date_created"`
+	UpdatedAt  string `json:"date_updated"`
+	ExpiresAt  string `json:"date_expires"`
+	URL        string `json:"url"`
+}
+
+// Verification status constants matching Twilio Verify lifecycle.
+const (
+	VerificationStatusPending  = "pending"
+	VerificationStatusApproved = "approved"
+	VerificationStatusCanceled = "canceled"
+	VerificationStatusExpired  = "expired"
+)

--- a/wondertwin.example.yaml
+++ b/wondertwin.example.yaml
@@ -16,18 +16,24 @@
 #   3. wt up
 
 twins:
-  # Version-based twin — downloaded from registry via `wt install`
   stripe:
-    version: "0.3.2"     # or "latest"
-    port: 9001
-    seed: /path/to/seed-data/shopper-signup-fixtures.json
-    env:
-      STRIPE_WEBHOOK_SECRET: "whsec_sim_test_secret"
-
-  # Binary path twin — use a local pre-compiled binary
+    binary: ./bin/twin-stripe
+    port: 4111
   twilio:
-    binary: /path/to/saltwyk-sim/bin/twin-twilio
-    port: 9005
+    binary: ./bin/twin-twilio
+    port: 4112
+  resend:
+    binary: ./bin/twin-resend
+    port: 4113
+  posthog:
+    binary: ./bin/twin-posthog
+    port: 4114
+  clerk:
+    binary: ./bin/twin-clerk
+    port: 4115
+  logodev:
+    binary: ./bin/twin-logodev
+    port: 4116
 
 settings:
   binary_dir: ~/.wondertwin/bin   # where `wt install` saves binaries


### PR DESCRIPTION
## Summary
- Migrate shared libraries (`pkg/twincore`, `pkg/store`, `pkg/admin`, `pkg/webhook`, `pkg/testutil`) from saltwyk-sim
- Migrate 6 twins: **stripe**, **twilio**, **resend**, **posthog**, **clerk**, **logodev** with full directory structures
- Update all import paths from `github.com/saltwyk/saltwyk-sim` to `github.com/wondertwin-ai/wondertwin`
- Add `go.work` for multi-module workspace, update Makefile with `build-twins` / `build-all` targets
- Update `wondertwin.example.yaml` with all 6 twins on ports 4111–4116
- Clean up all saltwyk/DTU references in comments and strings

## Test plan
- [x] `go build` compiles all packages (pkg, 6 twins, wt CLI)
- [x] `go vet ./...` passes clean
- [x] All tests pass across all modules
- [x] `make build-twins` produces 6 binaries in `bin/`
- [ ] Verify no remaining saltwyk references: `grep -ri saltwyk pkg/ twin-*/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)