### PR TITLE
Add multi-repo architecture foundation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,192 @@
+// Package config loads and manages the WonderTwin CLI configuration file
+// stored at ~/.wondertwin/config.yaml.
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultConfigDir is the directory under the user's home for CLI state.
+const DefaultConfigDir = ".wondertwin"
+
+// DefaultConfigFile is the config file name within the config directory.
+const DefaultConfigFile = "config.yaml"
+
+// RegistryEntry describes a named registry endpoint.
+type RegistryEntry struct {
+	URL   string `yaml:"url"`
+	Token string `yaml:"token,omitempty"` // Phase 2: auth token for private registries
+}
+
+// Config represents the contents of ~/.wondertwin/config.yaml.
+type Config struct {
+	LicenseKey string                   `yaml:"license_key"`
+	Registries map[string]RegistryEntry `yaml:"registries"`
+}
+
+// LicenseInfo holds parsed fields from a license key.
+type LicenseInfo struct {
+	Tier string // "com" or "ent"
+	Org  string // org slug
+	Raw  string // the full key
+}
+
+// configDir returns the path to the config directory.
+func configDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultConfigDir), nil
+}
+
+// configPath returns the full path to the config file.
+func configPath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, DefaultConfigFile), nil
+}
+
+// Load reads the config from ~/.wondertwin/config.yaml.
+// Returns a default config if the file doesn't exist.
+func Load() (*Config, error) {
+	path, err := configPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultConfig(), nil
+		}
+		return nil, fmt.Errorf("reading config %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	// Ensure registries always has the public entry
+	if cfg.Registries == nil {
+		cfg.Registries = make(map[string]RegistryEntry)
+	}
+	if _, ok := cfg.Registries["public"]; !ok {
+		cfg.Registries["public"] = RegistryEntry{
+			URL: "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.yaml",
+		}
+	}
+
+	return &cfg, nil
+}
+
+// Save writes the config to ~/.wondertwin/config.yaml.
+func Save(cfg *Config) error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+// ParseLicenseKey parses a license key of the format wt_{tier}_{org}_{random}_{check}.
+// Returns nil if the key is empty or invalid.
+func ParseLicenseKey(key string) *LicenseInfo {
+	if key == "" {
+		return nil
+	}
+
+	parts := strings.Split(key, "_")
+	if len(parts) < 5 {
+		return nil
+	}
+
+	if parts[0] != "wt" {
+		return nil
+	}
+
+	tier := parts[1]
+	if tier != "com" && tier != "ent" {
+		return nil
+	}
+
+	org := parts[2]
+	if org == "" {
+		return nil
+	}
+
+	// Validate checksum digit (last part)
+	check := parts[len(parts)-1]
+	if len(check) != 2 {
+		return nil
+	}
+
+	// Reconstruct the random portion (everything between org and check)
+	random := strings.Join(parts[3:len(parts)-1], "_")
+	if len(random) < 6 {
+		return nil
+	}
+
+	// Verify checksum: sum of bytes in "wt_{tier}_{org}_{random}" mod 256, as 2-char hex
+	payload := strings.Join(parts[:len(parts)-1], "_")
+	var sum byte
+	for _, b := range []byte(payload) {
+		sum += b
+	}
+	expected := fmt.Sprintf("%02x", sum)
+	if check != expected {
+		return nil
+	}
+
+	return &LicenseInfo{
+		Tier: tier,
+		Org:  org,
+		Raw:  key,
+	}
+}
+
+// HasValidLicense returns true if the config has a parseable license key.
+func (c *Config) HasValidLicense() bool {
+	return ParseLicenseKey(c.LicenseKey) != nil
+}
+
+// TierName returns a human-readable tier name from a license key tier code.
+func TierName(tier string) string {
+	switch tier {
+	case "com":
+		return "commercial"
+	case "ent":
+		return "enterprise"
+	default:
+		return "free"
+	}
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		Registries: map[string]RegistryEntry{
+			"public": {
+				URL: "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.yaml",
+			},
+		},
+	}
+}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,0 +1,271 @@
+// Package conformance implements the WonderTwin conformance test suite.
+// It validates that a twin binary correctly implements the admin API contract.
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Result represents the outcome of a single conformance check.
+type Result struct {
+	Name   string
+	Passed bool
+	Detail string
+}
+
+// Report holds the results of a full conformance run.
+type Report struct {
+	Binary  string
+	Port    int
+	Results []Result
+	Passed  int
+	Failed  int
+}
+
+// Run executes the full conformance suite against a twin binary.
+// It starts the binary, runs all checks, and returns a report.
+func Run(binaryPath string, port int) (*Report, error) {
+	report := &Report{
+		Binary: binaryPath,
+		Port:   port,
+	}
+
+	// Verify binary exists
+	if _, err := os.Stat(binaryPath); err != nil {
+		return nil, fmt.Errorf("binary not found: %s", binaryPath)
+	}
+
+	// Start the twin
+	cmd := exec.Command(binaryPath, "--port", fmt.Sprintf("%d", port))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting twin: %w", err)
+	}
+
+	// Ensure we clean up
+	defer func() {
+		cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			cmd.Process.Signal(syscall.SIGKILL)
+			<-done
+		}
+	}()
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+
+	// Check 1: Twin starts and becomes healthy within 5 seconds
+	report.addResult(checkHealth(baseURL))
+
+	// If health check failed, skip remaining checks
+	if report.Results[0].Passed {
+		// Check 2: POST /admin/reset returns 200
+		report.addResult(checkReset(baseURL))
+
+		// Check 3: POST /admin/state accepts JSON seed data
+		report.addResult(checkStatePost(baseURL))
+
+		// Check 4: GET /admin/state returns valid JSON snapshot
+		report.addResult(checkStateGet(baseURL))
+
+		// Check 5: Reset again to clear seeded state, then verify empty
+		report.addResult(checkResetClearsState(baseURL))
+
+		// Check 6: POST /admin/fault/{endpoint} injects faults
+		report.addResult(checkFaultInjection(baseURL))
+
+		// Check 7: POST /admin/time/advance advances simulated clock
+		report.addResult(checkTimeAdvance(baseURL))
+	}
+
+	// Check 8: Twin shuts down cleanly on SIGTERM within 5 seconds
+	report.addResult(checkCleanShutdown(cmd))
+
+	for _, r := range report.Results {
+		if r.Passed {
+			report.Passed++
+		} else {
+			report.Failed++
+		}
+	}
+
+	return report, nil
+}
+
+func (r *Report) addResult(res Result) {
+	r.Results = append(r.Results, res)
+}
+
+func checkHealth(baseURL string) Result {
+	name := "Twin starts and responds to health check within 5s"
+	deadline := time.Now().Add(5 * time.Second)
+
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/admin/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return Result{Name: name, Passed: true, Detail: "GET /admin/health returned 200"}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return Result{Name: name, Passed: false, Detail: "GET /admin/health did not return 200 within 5s"}
+}
+
+func checkReset(baseURL string) Result {
+	name := "POST /admin/reset returns 200"
+
+	resp, err := http.Post(baseURL+"/admin/reset", "application/json", nil)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "POST /admin/reset returned 200"}
+}
+
+func checkStatePost(baseURL string) Result {
+	name := "POST /admin/state accepts JSON seed data"
+
+	body := strings.NewReader(`{"test": true}`)
+	resp, err := http.Post(baseURL+"/admin/state", "application/json", body)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "POST /admin/state returned 200"}
+}
+
+func checkStateGet(baseURL string) Result {
+	name := "GET /admin/state returns valid JSON"
+
+	resp, err := http.Get(baseURL + "/admin/state")
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("failed to read body: %v", err)}
+	}
+
+	if !json.Valid(data) {
+		return Result{Name: name, Passed: false, Detail: "response body is not valid JSON"}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "GET /admin/state returned valid JSON"}
+}
+
+func checkResetClearsState(baseURL string) Result {
+	name := "POST /admin/reset clears state"
+
+	// Reset
+	resp, err := http.Post(baseURL+"/admin/reset", "application/json", nil)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("reset request failed: %v", err)}
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("reset expected 200, got %d", resp.StatusCode)}
+	}
+
+	// Verify state is returned (even if empty)
+	resp, err = http.Get(baseURL + "/admin/state")
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("state request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("state expected 200, got %d", resp.StatusCode)}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "reset + state check passed"}
+}
+
+func checkFaultInjection(baseURL string) Result {
+	name := "POST /admin/fault/{endpoint} injects faults"
+
+	body := strings.NewReader(`{"status": 500, "message": "test fault"}`)
+	req, _ := http.NewRequest("POST", baseURL+"/admin/fault/test-endpoint", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "POST /admin/fault returned 200"}
+}
+
+func checkTimeAdvance(baseURL string) Result {
+	name := "POST /admin/time/advance advances simulated clock"
+
+	body := strings.NewReader(`{"seconds": 3600}`)
+	resp, err := http.Post(baseURL+"/admin/time/advance", "application/json", body)
+	if err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+
+	return Result{Name: name, Passed: true, Detail: "POST /admin/time/advance returned 200"}
+}
+
+func checkCleanShutdown(cmd *exec.Cmd) Result {
+	name := "Twin shuts down cleanly on SIGTERM within 5s"
+
+	// Send SIGTERM
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return Result{Name: name, Passed: false, Detail: fmt.Sprintf("failed to send SIGTERM: %v", err)}
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+		return Result{Name: name, Passed: true, Detail: "twin exited cleanly after SIGTERM"}
+	case <-time.After(5 * time.Second):
+		cmd.Process.Signal(syscall.SIGKILL)
+		<-done
+		return Result{Name: name, Passed: false, Detail: "twin did not exit within 5s after SIGTERM"}
+	}
+}

--- a/wondertwin.example.yaml
+++ b/wondertwin.example.yaml
@@ -3,12 +3,17 @@
 # Declares which twins to run locally, their ports, and configuration.
 # The `wt` CLI reads this file to manage twin lifecycle.
 #
-# Twins can be configured in two ways:
+# Twins can be configured in three ways:
 #
 # 1. Version-based (recommended): Set `version` and run `wt install` to
 #    download pre-compiled binaries from the WonderTwin registry.
 #
-# 2. Binary path: Set `binary` to a local path for custom or pre-built twins.
+# 2. SDK-based: Set `version` to "sdk:<package>" to pin to a specific SDK
+#    package version (e.g., "sdk:github.com/stripe/stripe-go/v76").
+#
+# 3. Binary path: Set `binary` to a local path for custom or pre-built twins.
+#    Supports absolute paths, ~ paths, and relative paths (resolved against
+#    this file's directory).
 #
 # Quick start with registry twins:
 #   1. Copy this file to wondertwin.yaml
@@ -34,6 +39,22 @@ twins:
   logodev:
     binary: ./bin/twin-logodev
     port: 4116
+
+  # --- Alternative configurations ---
+
+  # Version-based twin — downloaded from registry via `wt install`
+  # stripe:
+  #   version: "latest"     # or "0.4.0" or "sdk:github.com/stripe/stripe-go/v76"
+  #   port: 4111
+  #   seed: ./fixtures/seed.json
+  #   env:
+  #     STRIPE_WEBHOOK_SECRET: "whsec_sim_test_secret"
+
+  # Registry twin from a specific registry (Phase 2: multi-registry support)
+  # internal-api:
+  #   version: "latest"
+  #   registry: mycompany      # looks up this registry in ~/.wondertwin/config.yaml
+  #   port: 9020
 
 settings:
   binary_dir: ~/.wondertwin/bin   # where `wt install` saves binaries


### PR DESCRIPTION
## Summary

- **Registry v2 schema**: `SDKPackage`, `SDKVersion`, `Tier`, `Author` fields on registry types. SDK resolution via `sdk:package` version spec format with semver comparison.
- **CLI config** (`~/.wondertwin/config.yaml`): License key storage, registry entries. License key format `wt_{tier}_{org}_{random}_{check}` with local checksum validation.
- **`wt auth login/status/logout`**: License key management. Tier enforcement on `wt install` — commercial versions require a valid key.
- **Skip-existing**: `wt install` skips binaries that are already installed at the resolved version.
- **`wt conformance`**: 8-point conformance test suite validating the admin API contract (health, reset, state POST/GET, fault injection, time advance, clean SIGTERM shutdown).
- **Manifest improvements**: `Registry` field per twin (defaults `"public"`, wired in follow-up). Relative `binary:` paths resolved against manifest directory.
- **Twin generator skill**: Updated for twinkit module — all `pkg/` imports replaced with `github.com/wondertwin-ai/twinkit`. Added Phase 0 (template setup), Phase 8 (local testing with `wt`), Phase 9 (publish). Offline-first workflow emphasis.

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass clean
- [ ] `wt auth login` → enter key → `wt auth status` shows tier
- [ ] `wt auth logout` clears key
- [ ] `wt install stripe@latest` works without license key (free tier)
- [ ] `wt install` skips already-installed binaries
- [ ] `wt conformance ./bin/twin-stripe --port 9999` runs 8 checks
- [ ] Relative `binary: ./bin/twin-foo` resolves against manifest dir
- [ ] `sdk:github.com/stripe/stripe-go/v76` resolves to correct version