### PR TITLE
Add private registry support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ const DefaultConfigFile = "config.yaml"
 // RegistryEntry describes a named registry endpoint.
 type RegistryEntry struct {
 	URL   string `yaml:"url"`
-	Token string `yaml:"token,omitempty"` // Phase 2: auth token for private registries
+	Token string `yaml:"token,omitempty"` // Bearer token for private registries
 }
 
 // Config represents the contents of ~/.wondertwin/config.yaml.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -42,10 +42,19 @@ type Version struct {
 }
 
 // FetchRegistry downloads and parses the registry YAML from the given URL.
-func FetchRegistry(url string) (*Registry, error) {
+// If token is non-empty, it is sent as a Bearer authorization header.
+func FetchRegistry(url, token string) (*Registry, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	resp, err := client.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating registry request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching registry: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **`wt registry add <name> <url> [--token <token>]`** — adds a named registry to `~/.wondertwin/config.yaml` with optional Bearer token for authenticated access
- **`wt registry remove <name>`** — removes a named registry (public registry cannot be removed)
- **`wt registry list`** — shows all configured registries with auth status
- **`FetchRegistry` now accepts a token** — sends `Authorization: Bearer` header when non-empty
- **`wt install` resolves per-twin registries** — each twin's `registry:` field in the manifest maps to a configured registry. Registries are cached so each is fetched at most once per install run.

## Usage

```bash
# Add a private registry
wt registry add mycompany https://raw.githubusercontent.com/mycompany/registry/main/registry.yaml --token ghp_xxx

# Reference it in wondertwin.yaml
# twins:
#   billing:
#     version: "latest"
#     registry: mycompany
#     port: 9010

# Install resolves from the correct registry
wt install
```

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `wt registry add myco https://example.com` adds entry to config
- [ ] `wt registry add myco https://example.com --token ghp_xxx` stores token
- [ ] `wt registry list` shows all registries with auth column
- [ ] `wt registry remove myco` removes the entry
- [ ] `wt registry remove public` returns error
- [ ] `wt install` with `registry: myco` in manifest fetches from configured URL
- [ ] `wt install` with unknown registry name gives clear error message
- [ ] `wt install stripe@latest` (ad-hoc) still uses public registry