### PR TITLE
fix: align default ports across twins and example manifest

### DIFF
--- a/twin-clerk/cmd/twin-clerk/main.go
+++ b/twin-clerk/cmd/twin-clerk/main.go
@@ -7,7 +7,7 @@
 //
 // SDK compatibility target: github.com/clerk/clerk-sdk-go/v2
 // Integration method: CLERK_API_URL env var
-// Default port: 12112
+// Default port: 4115
 package main
 
 import (
@@ -23,7 +23,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-clerk")
 	if cfg.Port == 0 {
-		cfg.Port = 12112
+		cfg.Port = 4115
 	}
 
 	twin := twincore.New(cfg)

--- a/twin-logodev/cmd/twin-logodev/main.go
+++ b/twin-logodev/cmd/twin-logodev/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-logodev")
 	if cfg.Port == 0 {
-		cfg.Port = 12116
+		cfg.Port = 4116
 	}
 
 	twin := twincore.New(cfg)

--- a/twin-posthog/cmd/twin-posthog/main.go
+++ b/twin-posthog/cmd/twin-posthog/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-posthog")
 	if cfg.Port == 0 {
-		cfg.Port = 12114
+		cfg.Port = 4114
 	}
 
 	twin := twincore.New(cfg)

--- a/twin-resend/cmd/twin-resend/main.go
+++ b/twin-resend/cmd/twin-resend/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-resend")
 	if cfg.Port == 0 {
-		cfg.Port = 12115
+		cfg.Port = 4113
 	}
 
 	twin := twincore.New(cfg)

--- a/twin-stripe/cmd/twin-stripe/main.go
+++ b/twin-stripe/cmd/twin-stripe/main.go
@@ -21,7 +21,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-stripe")
 	if cfg.Port == 0 {
-		cfg.Port = 12111
+		cfg.Port = 4111
 	}
 
 	twin := twincore.New(cfg)

--- a/twin-twilio/cmd/twin-twilio/main.go
+++ b/twin-twilio/cmd/twin-twilio/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	cfg := twincore.ParseFlags("twin-twilio")
 	if cfg.Port == 0 {
-		cfg.Port = 12113
+		cfg.Port = 4112
 	}
 
 	twin := twincore.New(cfg)

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -45,9 +45,6 @@ func ParseFlags(twinName string) *Config {
 		if p := os.Getenv("PORT"); p != "" {
 			fmt.Sscanf(p, "%d", &cfg.Port)
 		}
-		if cfg.Port == 0 {
-			cfg.Port = 8080
-		}
 	}
 
 	return cfg


### PR DESCRIPTION
## Summary
- Updates all 6 twin default ports to match `wondertwin.example.yaml` (stripe:4111, twilio:4112, resend:4113, posthog:4114, clerk:4115, logodev:4116)
- Removes hardcoded 8080 fallback in `twinkit/twincore/server.go` that was overriding per-twin defaults

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `make build-twins` succeeds