### PR TITLE
feat: add /admin/config and /admin/quirks endpoints

### DIFF
--- a/twin-clerk/cmd/twin-clerk/main.go
+++ b/twin-clerk/cmd/twin-clerk/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	// Admin control plane (shared with all twins)
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	// Load seed data if provided

--- a/twin-logodev/cmd/twin-logodev/main.go
+++ b/twin-logodev/cmd/twin-logodev/main.go
@@ -23,6 +23,7 @@ func main() {
 	apiHandler.Routes(twin.Router)
 
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	if cfg.SeedFile != "" {

--- a/twin-posthog/cmd/twin-posthog/main.go
+++ b/twin-posthog/cmd/twin-posthog/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Admin control plane
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	// Load seed data if provided

--- a/twin-resend/cmd/twin-resend/main.go
+++ b/twin-resend/cmd/twin-resend/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Admin control plane
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	// Load seed data if provided

--- a/twin-stripe/cmd/twin-stripe/main.go
+++ b/twin-stripe/cmd/twin-stripe/main.go
@@ -50,6 +50,7 @@ func main() {
 	// Admin control plane
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
 	adminHandler.SetFlusher(dispatcher)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	// Load seed data if provided

--- a/twin-twilio/cmd/twin-twilio/main.go
+++ b/twin-twilio/cmd/twin-twilio/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Admin control plane
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
 	adminHandler.Routes(twin.Router)
 
 	// Load seed data if provided

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -101,6 +101,65 @@ func (t *Twin) Middleware() *Middleware {
 	return t.mw
 }
 
+// GetConfig returns the current runtime configuration as a map.
+// This implements the admin.ConfigProvider interface.
+func (t *Twin) GetConfig() map[string]any {
+	return map[string]any{
+		"name":        t.Config.Name,
+		"port":        t.Config.Port,
+		"latency":     t.Config.Latency.String(),
+		"fail_rate":   t.Config.FailRate,
+		"webhook_url": t.Config.WebhookURL,
+		"verbose":     t.Config.Verbose,
+	}
+}
+
+// UpdateConfig updates runtime configuration fields from a map.
+// This implements the admin.ConfigProvider interface.
+// Only latency, fail_rate, verbose, and webhook_url can be updated at runtime.
+func (t *Twin) UpdateConfig(updates map[string]any) error {
+	for k, v := range updates {
+		switch k {
+		case "latency":
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("latency must be a duration string")
+			}
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("invalid latency duration: %w", err)
+			}
+			t.Config.Latency = d
+		case "fail_rate":
+			f, ok := v.(float64)
+			if !ok {
+				return fmt.Errorf("fail_rate must be a number")
+			}
+			if f < 0 || f > 1 {
+				return fmt.Errorf("fail_rate must be between 0.0 and 1.0")
+			}
+			t.Config.FailRate = f
+		case "verbose":
+			b, ok := v.(bool)
+			if !ok {
+				return fmt.Errorf("verbose must be a boolean")
+			}
+			t.Config.Verbose = b
+		case "webhook_url":
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("webhook_url must be a string")
+			}
+			t.Config.WebhookURL = s
+		case "name", "port":
+			return fmt.Errorf("%s cannot be changed at runtime", k)
+		default:
+			return fmt.Errorf("unknown config key: %s", k)
+		}
+	}
+	return nil
+}
+
 // Serve starts the HTTP server and blocks until shutdown signal.
 func (t *Twin) Serve() error {
 	addr := fmt.Sprintf(":%d", t.Config.Port)


### PR DESCRIPTION
## Summary
- Adds `GET/PUT /admin/config` for runtime config inspection and updates (latency, fail_rate, verbose, webhook_url)
- Adds `GET /admin/quirks`, `PUT/DELETE /admin/quirks/{quirk_id}` for quirk toggling
- New interfaces: `ConfigProvider` and `QuirkStore` (both optional — nil returns 404)
- Implements `ConfigProvider` on `Twin` struct with validation and wires it into all 6 twins
- `QuirkStore` remains nil by default (twins opt in later)
- 13 new tests in `twinkit/admin/admin_test.go`
- Conformance checks for new endpoints in `internal/conformance/conformance.go`
- MCP tools (`wt_config`, `wt_quirks`) in `internal/mcp/tools.go`

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./twinkit/admin/... -count=1` passes (32 tests)
- [x] `go test ./twinkit/... -count=1` passes
- [x] Existing admin API unchanged — all prior tests still pass