### PR TITLE
docs: contribution guide, twin template, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_twin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_twin.md
@@ -1,0 +1,36 @@
+## New Twin: twin-{name}
+
+**Service:** {Service Name}
+**SDK target:** `{sdk_package}` ({language}, {version})
+**Category:** {category}
+
+### Description
+
+<!-- Brief description of what this twin does and which parts of the service it covers. -->
+
+### Resources Covered
+
+<!-- List the SDK resources this twin implements. -->
+
+-
+
+### Checklist
+
+- [ ] `twin-manifest.json` present and validates against `schemas/twin-manifest.schema.json`
+- [ ] `provenance.json` present and validates against `schemas/provenance.schema.json`
+- [ ] Standard directory structure followed (`cmd/`, `internal/api/`, `internal/store/`)
+- [ ] Admin API conformance passes (`wt conformance`)
+- [ ] Handler tests pass (`go test ./...`)
+- [ ] At least one seed data example exists (JSON file or inline in tests)
+- [ ] README documents covered resources and known limitations
+- [ ] Auth middleware matches the real service's auth pattern
+- [ ] Error responses match the real service's error format
+- [ ] SDK client works against the twin without modification
+
+### Testing Notes
+
+<!-- How did you verify SDK compatibility? What did you test manually vs. automated? -->
+
+### Known Limitations
+
+<!-- Any endpoints that are stubbed, partially implemented, or have known behavioral gaps. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,96 +1,215 @@
 # Contributing to WonderTwin
 
-WonderTwin is an open-source catalog of behavioral API twins. The most impactful way to contribute is to **add a twin for an API you use**.
+Welcome, and thank you for your interest in WonderTwin. This project is an open-source catalog of behavioral service twins -- local, in-memory replicas of third-party APIs that let official SDKs work against them unmodified. The most impactful way to contribute is to **add a twin for a service you use**.
+
+This guide covers everything you need to know to contribute a new twin or improve an existing one.
+
+---
+
+## Table of Contents
+
+- [Request a Twin](#request-a-twin)
+- [Build a Twin](#build-a-twin)
+  - [The SDK-First Approach](#the-sdk-first-approach)
+  - [What You Need](#what-you-need)
+  - [Directory Structure](#directory-structure)
+  - [Step-by-Step Process](#step-by-step-process)
+  - [Using the Twin Generator Skill](#using-the-twin-generator-skill)
+  - [The Manifest and Provenance Files](#the-manifest-and-provenance-files)
+  - [Quality Checklist](#quality-checklist)
+  - [Reporting Quirks](#reporting-quirks)
+- [Other Contributions](#other-contributions)
+- [Questions](#questions)
+
+---
 
 ## Request a Twin
 
-Don't see the API you need? [Open a twin request →](https://github.com/wondertwin-ai/wondertwin/issues/new?template=twin-request.yml)
+Don't see the service you need? [Open a twin request](https://github.com/wondertwin-ai/wondertwin/issues/new?template=twin-request.yml).
 
-Tell us which service, which endpoints matter, and how you're using the API. This helps us (and other contributors) prioritize what to build next.
+Tell us which service, which SDK operations matter, and how you use the service in your tests. This helps us (and other contributors) prioritize what to build next.
+
+---
 
 ## Build a Twin
 
-Every twin is a standalone Go binary that behaviorally clones a third-party API. Twins maintain state in memory, enforce business logic, fire webhooks, and expose the same endpoints the real API does — so official SDKs work against them unmodified.
+Every twin is a standalone Go binary that behaviorally clones a third-party service's API. Twins maintain state in memory, enforce business logic, fire webhooks, and expose the same endpoints the real service does -- so official SDKs work against them unmodified.
 
-### What you need
+### The SDK-First Approach
+
+WonderTwin twins are **SDK-first, not API-first**. This is the single most important design principle:
+
+- **Target SDK compatibility**, not just OpenAPI conformance. The goal is for the official SDK client library to work against the twin without any modification -- just point it at localhost.
+- **Study the SDK**, not just the API docs. SDKs often expect specific response shapes, headers, error formats, and pagination patterns that are not fully captured in OpenAPI specs.
+- **Test with the real SDK**. If the SDK does not work against your twin, the twin is not done. Passing an OpenAPI validator is necessary but not sufficient.
+- **Match behavioral details**. ID formats, timestamp formats, default values, sort orders, envelope structures -- these all matter because the SDK depends on them.
+
+This means when you build a twin for Stripe, you run the `stripe-go` SDK against it. When you build a twin for Resend, you run the `resend-go` SDK against it. The SDK is the spec.
+
+### What You Need
 
 - Go 1.21+
-- The target API's public docs or SDK reference
-- An AI coding agent (recommended — most twins are generated in 2-4 hours)
+- The target service's public docs or SDK reference
+- An AI coding agent (recommended -- most twins are generated in 2-4 hours)
 
-### The process
+### Directory Structure
 
-1. **Pick an API.** Check the [twin request issues](https://github.com/wondertwin-ai/wondertwin/issues?q=is%3Aissue+label%3Atwin-request) for popular requests, or build something you need yourself.
+Every twin follows the same layout. A copyable template is available at [`docs/TWIN_TEMPLATE/`](docs/TWIN_TEMPLATE/):
 
-2. **Scaffold the twin.** Every twin follows the same structure:
+```
+twin-{name}/
+├── cmd/twin-{name}/main.go          # Entry point: parse flags, wire up stores, serve
+├── internal/
+│   ├── api/
+│   │   ├── router.go                # Handler struct, Routes(), auth middleware
+│   │   ├── handlers_{resource}.go   # One file per API resource group
+│   │   └── handlers_test.go         # Handler tests using testutil.TwinClient
+│   └── store/
+│       ├── memory.go                # MemoryStore implementing admin.StateStore
+│       └── types.go                 # Domain structs with JSON tags
+├── twin-manifest.json               # Required: describes the twin's capabilities
+├── provenance.json                  # Required: records how the twin was generated
+├── go.mod                           # Module: github.com/wondertwin-ai/wondertwin/twin-{name}
+└── go.sum
+```
 
+**Required files:**
+
+| File | Purpose |
+|------|---------|
+| `twin-manifest.json` | Describes the twin, its SDK target, service surface, coverage, and generation method. Must validate against [`schemas/twin-manifest.schema.json`](schemas/twin-manifest.schema.json). |
+| `provenance.json` | Records how the twin was generated, what sources were used, and when. Must validate against [`schemas/provenance.schema.json`](schemas/provenance.schema.json). |
+| `cmd/twin-{name}/main.go` | Entry point that wires up the store, API handlers, and admin handlers. |
+| `internal/api/router.go` | Defines the `Handler` struct, `Routes()` method, and auth middleware. |
+| `internal/api/handlers_*.go` | One file per resource group with the actual endpoint logic. |
+| `internal/api/handlers_test.go` | Tests using `testutil.TwinClient` for all endpoints. |
+| `internal/store/types.go` | Domain types that match the real service's response shapes. |
+| `internal/store/memory.go` | `MemoryStore` with `Snapshot()`, `LoadState()`, and `Reset()` methods. |
+
+### Step-by-Step Process
+
+1. **Pick a service.** Check the [twin request issues](https://github.com/wondertwin-ai/wondertwin/issues?q=is%3Aissue+label%3Atwin-request) for popular requests, or build something you need yourself.
+
+2. **Copy the template.** Start from `docs/TWIN_TEMPLATE/`:
+   ```bash
+   cp -r docs/TWIN_TEMPLATE twin-{name}
    ```
-   twin-{name}/
-   ├── cmd/twin-{name}/main.go
-   ├── internal/
-   │   ├── api/
-   │   │   ├── router.go
-   │   │   └── handlers_{resource}.go
-   │   └── store/
-   │       ├── memory.go
-   │       └── types.go
-   ├── go.mod
-   └── go.sum
-   ```
+   Then find-and-replace `TEMPLATE` with your service name and update the placeholder values.
 
-3. **Use the shared libraries.** All twins import [`twinkit`](https://github.com/wondertwin-ai/twinkit) for server scaffolding, in-memory storage, admin endpoints, webhooks, and test helpers:
-
-   ```
+3. **Use the shared libraries.** All twins import `twinkit` for server scaffolding, in-memory storage, admin endpoints, webhooks, and test helpers:
+   ```bash
    go get github.com/wondertwin-ai/twinkit@latest
    ```
-
-4. **Follow the skill guide.** The detailed, step-by-step build guide lives at [`skills/twin-generator.md`](skills/twin-generator.md). It covers everything: router setup, store design, handler implementation, webhook wiring, seed data, testing, and common pitfalls. If you're using an AI coding agent, feed it this file along with the target API docs.
-
-5. **Test locally.** Build the binary and wire it into a `wondertwin.yaml`:
-
-   ```yaml
-   twins:
-     my-api:
-       binary: ./path/to/twin-my-api
-       port: 9020
+   Within the monorepo, the `go.mod` uses a replace directive:
+   ```
+   replace github.com/wondertwin-ai/wondertwin/twinkit => ../twinkit
    ```
 
+4. **Implement the handlers.** For each SDK resource:
+   - Study how the SDK client calls the API (request shape, headers, URL patterns).
+   - Implement the handler to return responses the SDK expects.
+   - Match error formats exactly -- SDKs parse error responses.
+   - Store state in the `MemoryStore` so create/read/update/delete cycles work.
+
+5. **Write tests.** Use `testutil.TwinClient` for clean HTTP test helpers:
+   ```go
+   srv, tc := setupTwin(t)
+   resp := tc.DoWithHeaders("POST", "/v1/resources", body, authHeaders)
+   resp.AssertStatus(201)
+   ```
+
+6. **Fill in the manifest and provenance files.** See [The Manifest and Provenance Files](#the-manifest-and-provenance-files) below.
+
+7. **Test locally.** Build the binary and wire it into a `wondertwin.yaml`:
+   ```yaml
+   twins:
+     my-service:
+       binary: ./path/to/twin-my-service
+       port: 9020
+   ```
    ```bash
    wt up
    wt status
-   wt test    # if you have test scenarios
+   wt conformance   # Verify admin API conformance
    ```
-
    No registry, no license key, no network. Fully offline.
 
-6. **Submit a PR.** Open a pull request to this repo with your twin. Include:
-   - The twin source code in `twin-{name}/`
-   - A brief description of which endpoints are covered
-   - Example seed data if applicable
+8. **Submit a PR.** Use the [new twin PR template](.github/PULL_REQUEST_TEMPLATE/new_twin.md) and work through the checklist.
 
-### Quality bar
+### Using the Twin Generator Skill
 
-Every twin must:
+The fastest way to build a twin is with the twin generator skill and an AI coding agent. The skill is documented in [`skills/twin-generator.md`](skills/twin-generator.md) and covers the full process: project setup, router design, store design, handler implementation, webhook wiring, testing, and common pitfalls.
 
-- **Start and respond to health checks.** `GET /admin/health` returns 200.
-- **Implement the admin API.** Reset, state snapshot/load, fault injection, and time simulation — all provided by `twinkit/admin`, so this is automatic if you wire it up.
-- **Work with the official SDK.** Point the SDK at your twin's port and run real operations. If the SDK doesn't work, the twin isn't done.
-- **Maintain state correctly.** Create a resource, retrieve it, verify the data matches. Reset, verify it's gone.
-- **Handle common error cases.** Missing required fields, duplicate IDs, not-found lookups. Return the same error format the real API uses.
+**Typical workflow:**
 
-### Using an AI coding agent
+1. Give your agent the skill guide (`skills/twin-generator.md`) plus the target service's API docs or SDK reference URL.
+2. The agent scaffolds the project, implements handlers, and writes tests.
+3. You review the output, build it, and test locally with `wt up`.
+4. Fill in `twin-manifest.json` and `provenance.json`.
+5. Submit the PR.
 
-This is the recommended path. The twin generator skill (`skills/twin-generator.md`) was designed to be fed directly to an AI agent alongside the target API's documentation. The skill handles the architecture decisions — your agent just needs to implement the endpoints.
+The skill is designed to produce twins that conform to the standard structure and quality bar from the start.
 
-Typical workflow:
-1. Give your agent the skill guide + the API docs URL
-2. The agent scaffolds the project, implements handlers, writes tests
-3. You review, build, test locally with `wt up`
-4. Submit the PR
+### The Manifest and Provenance Files
+
+#### `twin-manifest.json`
+
+Every twin must include a manifest file that describes its capabilities. The schema is at [`schemas/twin-manifest.schema.json`](schemas/twin-manifest.schema.json).
+
+Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `twin` | Machine-readable identifier (e.g., `resend`, `stripe`) |
+| `display_name` | Human-readable name (e.g., `Resend`, `Stripe`) |
+| `category` | Service category (e.g., `email`, `payments`, `auth`) |
+| `sdk_target.primary` | The SDK this twin targets: package, language, version, repo URL |
+| `service_surface` | Auth pattern, webhook support, resource count |
+| `coverage` | Which resources are implemented vs. not yet implemented |
+| `generation` | How the twin was built (skill, manual, or other) |
+
+#### `provenance.json`
+
+Every twin must include a provenance file that records how it was generated. The schema is at [`schemas/provenance.schema.json`](schemas/provenance.schema.json).
+
+This file tracks:
+- Which SDK version was targeted
+- When the twin was generated
+- What sources were used (OpenAPI spec, SDK analysis, Arazzo workflows)
+- Whether fallback methods were needed
+
+Provenance tracking ensures reproducibility and makes it possible to detect when a twin needs updating because the upstream SDK has changed.
+
+### Quality Checklist
+
+Before submitting your PR, verify:
+
+- [ ] **`twin-manifest.json` is present and valid.** Validates against the schema.
+- [ ] **`provenance.json` is present and valid.** Validates against the schema.
+- [ ] **Standard directory structure is followed.** `cmd/`, `internal/api/`, `internal/store/`.
+- [ ] **Admin API conformance passes.** Run `wt conformance` -- health, reset, state snapshot/load, fault injection, and time simulation must all work.
+- [ ] **Handler tests pass.** `go test ./...` in the twin directory.
+- [ ] **At least one seed data example exists.** Either as a JSON file or inline in tests.
+- [ ] **SDK client works.** Point the official SDK at the twin and run real operations.
+- [ ] **Error formats match.** The SDK parses error responses -- yours must match the real service.
+- [ ] **State is correct.** Create a resource, retrieve it, verify the data matches. Reset, verify it is gone.
+- [ ] **README documents coverage and limitations.** What works, what does not, what is known to differ.
+
+### Reporting Quirks
+
+Real-world services have undocumented behaviors, inconsistencies, and edge cases that do not appear in their API docs. When you discover these while building a twin, please document them:
+
+1. **In the twin's README**, add a "Known Quirks" section describing the behavior.
+2. **In code comments**, annotate the handler where you implement the quirk with a `// Quirk:` comment explaining what the real service does and why.
+3. **In the twin-manifest.json**, if the quirk means the twin intentionally differs from documented behavior, note it in the coverage section.
+
+These quirk reports are valuable to the entire community. They capture hard-won knowledge about how services actually behave versus how they are documented.
+
+---
 
 ## Other Contributions
 
-### Bug fixes and improvements
+### Bug Fixes and Improvements
 
 For bugs or improvements to the CLI, shared libraries, or existing twins:
 
@@ -99,10 +218,16 @@ For bugs or improvements to the CLI, shared libraries, or existing twins:
 3. Make your changes
 4. Open a PR with a clear description of what changed and why
 
-### Test scenarios
+### Test Scenarios
 
-Each twin can have YAML test scenarios in `scenarios/` that validate behavior using `wt test`. Adding test coverage for existing twins is valuable — especially edge cases and error paths.
+Each twin can have YAML test scenarios in `scenarios/` that validate behavior using `wt test`. Adding test coverage for existing twins is valuable -- especially edge cases and error paths.
+
+### Documentation
+
+Improvements to this guide, the skill guide, or individual twin READMEs are always welcome.
+
+---
 
 ## Questions?
 
-Open an issue or start a discussion. We're happy to help scope a twin or pair on tricky API behaviors.
+Open an issue or start a discussion. We are happy to help scope a twin or pair on tricky service behaviors.

--- a/docs/TWIN_TEMPLATE/README.md
+++ b/docs/TWIN_TEMPLATE/README.md
@@ -1,0 +1,47 @@
+# twin-TEMPLATE
+
+WonderTwin behavioral twin for the **Your Service** API.
+
+## Covered Resources
+
+| Resource | Create | Read | Update | Delete | List |
+|----------|--------|------|--------|--------|------|
+| Resources | Yes | Yes | Yes | Yes | Yes |
+
+## SDK Compatibility
+
+| SDK | Language | Version | Status |
+|-----|----------|---------|--------|
+| `github.com/your-org/your-sdk-go` | Go | v1 | Primary target |
+
+## Quick Start
+
+```bash
+# Build
+go build -o twin-TEMPLATE ./cmd/twin-TEMPLATE
+
+# Run
+./twin-TEMPLATE --port 4200
+
+# Or with seed data
+./twin-TEMPLATE --port 4200 --seed seed.json
+```
+
+Point the official SDK client at `http://localhost:4200` and use any API key.
+
+## Known Limitations
+
+- List any endpoints that are stubbed or partially implemented.
+- List any SDK behaviors that differ from production.
+- List any quirks discovered during development.
+
+## Admin Endpoints
+
+All twins expose the standard WonderTwin admin API:
+
+- `GET /admin/health` - Health check
+- `POST /admin/reset` - Reset all state
+- `GET /admin/state` - Snapshot current state
+- `POST /admin/state/load` - Load state from snapshot
+- `POST /admin/fault` - Configure fault injection
+- `POST /admin/time` - Simulate time advancement

--- a/docs/TWIN_TEMPLATE/cmd/twin-TEMPLATE/main.go
+++ b/docs/TWIN_TEMPLATE/cmd/twin-TEMPLATE/main.go
@@ -1,0 +1,55 @@
+// twin-TEMPLATE is a WonderTwin twin that simulates the TEMPLATE service API.
+// Replace TEMPLATE throughout with your service name (e.g., "acme").
+//
+// SDK compatibility target: github.com/your-org/your-sdk
+// Integration method: Override base URL
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-TEMPLATE")
+	if cfg.Port == 0 {
+		cfg.Port = 4200 // Choose a unique port for your twin
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-TEMPLATE ready",
+		"port", cfg.Port,
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/docs/TWIN_TEMPLATE/go.mod
+++ b/docs/TWIN_TEMPLATE/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-TEMPLATE
+
+go 1.25.7
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/twinkit v0.0.0
+)
+
+replace github.com/wondertwin-ai/wondertwin/twinkit => ../twinkit

--- a/docs/TWIN_TEMPLATE/internal/api/handlers_example.go
+++ b/docs/TWIN_TEMPLATE/internal/api/handlers_example.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+)
+
+// createResourceRequest matches the real service's create request body.
+// Use the exact same JSON field names and structure as the real API.
+type createResourceRequest struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// updateResourceRequest matches the real service's update request body.
+type updateResourceRequest struct {
+	Name        *string           `json:"name,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// CreateResource handles POST /v1/resources
+func (h *Handler) CreateResource(w http.ResponseWriter, r *http.Request) {
+	var req createResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Return errors in the same format the real service uses.
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"message": "Invalid request body: " + err.Error(),
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	// Validate required fields.
+	if req.Name == "" {
+		twincore.JSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"error": map[string]any{
+				"message": "The 'name' field is required.",
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	// Create the resource in the store.
+	now := h.store.Clock.Now()
+	id := h.store.Resources.NextID()
+
+	resource := store.Resource{
+		ID:          id,
+		Object:      "resource",
+		Name:        req.Name,
+		Description: req.Description,
+		Metadata:    req.Metadata,
+		CreatedAt:   now.Unix(),
+	}
+
+	h.store.Resources.Set(id, resource)
+
+	twincore.JSON(w, http.StatusCreated, resource)
+}
+
+// GetResource handles GET /v1/resources/{id}
+func (h *Handler) GetResource(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	resource, ok := h.store.Resources.Get(id)
+	if !ok {
+		twincore.JSON(w, http.StatusNotFound, map[string]any{
+			"error": map[string]any{
+				"message": "No such resource: " + id,
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, resource)
+}
+
+// ListResources handles GET /v1/resources
+func (h *Handler) ListResources(w http.ResponseWriter, r *http.Request) {
+	resources := h.store.Resources.List()
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"data":   resources,
+	})
+}
+
+// UpdateResource handles PATCH /v1/resources/{id}
+func (h *Handler) UpdateResource(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	resource, ok := h.store.Resources.Get(id)
+	if !ok {
+		twincore.JSON(w, http.StatusNotFound, map[string]any{
+			"error": map[string]any{
+				"message": "No such resource: " + id,
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	var req updateResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"message": "Invalid request body: " + err.Error(),
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	// Apply partial updates.
+	if req.Name != nil {
+		resource.Name = *req.Name
+	}
+	if req.Description != nil {
+		resource.Description = *req.Description
+	}
+	if req.Metadata != nil {
+		resource.Metadata = req.Metadata
+	}
+
+	h.store.Resources.Set(id, resource)
+
+	twincore.JSON(w, http.StatusOK, resource)
+}
+
+// DeleteResource handles DELETE /v1/resources/{id}
+func (h *Handler) DeleteResource(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	_, ok := h.store.Resources.Get(id)
+	if !ok {
+		twincore.JSON(w, http.StatusNotFound, map[string]any{
+			"error": map[string]any{
+				"message": "No such resource: " + id,
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	h.store.Resources.Delete(id)
+
+	// Return the same deletion response format as the real service.
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"object":  "resource",
+		"deleted": true,
+	})
+}

--- a/docs/TWIN_TEMPLATE/internal/api/handlers_test.go
+++ b/docs/TWIN_TEMPLATE/internal/api/handlers_test.go
@@ -1,0 +1,172 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+)
+
+// setupTwin creates a test server with the twin wired up.
+// Every test file should have a setup function like this.
+func setupTwin(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
+	t.Helper()
+	memStore := store.New()
+	cfg := &twincore.Config{Name: "twin-TEMPLATE-test"}
+	twin := twincore.New(cfg)
+	handler := api.NewHandler(memStore, twin.Middleware())
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	return srv, tc
+}
+
+// authHeaders returns the default auth headers for test requests.
+// Adjust the token format to match the real service's auth pattern.
+var authHeaders = map[string]string{
+	"Authorization": "Bearer test_key_123",
+}
+
+func authedPost(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("POST", path, body, authHeaders)
+}
+
+func authedGet(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, authHeaders)
+}
+
+func authedPatch(tc *testutil.TwinClient, path string, body any) *testutil.Response {
+	return tc.DoWithHeaders("PATCH", path, body, authHeaders)
+}
+
+func authedDelete(tc *testutil.TwinClient, path string) *testutil.Response {
+	return tc.DoWithHeaders("DELETE", path, nil, authHeaders)
+}
+
+// --- Auth Tests ---
+
+func TestAuthRequired(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	resp := tc.Post("/v1/resources", map[string]any{})
+	resp.AssertStatus(401)
+	resp.AssertBodyContains("authentication_error")
+}
+
+// --- CRUD Tests ---
+
+func TestCreateAndGetResource(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	// Create
+	resp := authedPost(tc, "/v1/resources", map[string]any{
+		"name":        "Test Resource",
+		"description": "A test resource for validation",
+	})
+	resp.AssertStatus(201)
+
+	m := resp.JSONMap()
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatal("expected resource id in response")
+	}
+
+	// Get
+	resp = authedGet(tc, "/v1/resources/"+id)
+	resp.AssertStatus(200)
+	got := resp.JSONMap()
+	if got["id"] != id {
+		t.Errorf("expected id=%s, got %v", id, got["id"])
+	}
+	if got["name"] != "Test Resource" {
+		t.Errorf("expected name=Test Resource, got %v", got["name"])
+	}
+}
+
+func TestCreateResourceMissingName(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	resp := authedPost(tc, "/v1/resources", map[string]any{
+		"description": "no name provided",
+	})
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("invalid_request_error")
+}
+
+func TestGetResourceNotFound(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	resp := authedGet(tc, "/v1/resources/nonexistent_id")
+	resp.AssertStatus(404)
+	resp.AssertBodyContains("invalid_request_error")
+}
+
+func TestListResources(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	authedPost(tc, "/v1/resources", map[string]any{
+		"name": "Resource A",
+	}).AssertStatus(201)
+
+	authedPost(tc, "/v1/resources", map[string]any{
+		"name": "Resource B",
+	}).AssertStatus(201)
+
+	resp := authedGet(tc, "/v1/resources")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if !ok || len(data) != 2 {
+		t.Fatalf("expected 2 resources, got %v", m["data"])
+	}
+}
+
+func TestDeleteResource(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	resp := authedPost(tc, "/v1/resources", map[string]any{
+		"name": "To Delete",
+	})
+	resp.AssertStatus(201)
+	id := resp.JSONMap()["id"].(string)
+
+	resp = authedDelete(tc, "/v1/resources/"+id)
+	resp.AssertStatus(200)
+	resp.AssertBodyContains("deleted")
+
+	// Verify it is gone.
+	resp = authedGet(tc, "/v1/resources/"+id)
+	resp.AssertStatus(404)
+}
+
+// --- Admin Tests ---
+
+func TestAdminHealth(t *testing.T) {
+	_, tc := setupTwin(t)
+	tc.Get("/admin/health").AssertStatus(200)
+}
+
+func TestAdminReset(t *testing.T) {
+	_, tc := setupTwin(t)
+
+	authedPost(tc, "/v1/resources", map[string]any{
+		"name": "Will Be Cleared",
+	}).AssertStatus(201)
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	resp := authedGet(tc, "/v1/resources")
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	data, ok := m["data"].([]any)
+	if ok && len(data) > 0 {
+		t.Errorf("expected 0 resources after reset, got %d", len(data))
+	}
+}

--- a/docs/TWIN_TEMPLATE/internal/api/router.go
+++ b/docs/TWIN_TEMPLATE/internal/api/router.go
@@ -1,0 +1,70 @@
+// Package api implements the TEMPLATE-compatible HTTP API handlers for the twin.
+// Replace TEMPLATE with your service name throughout this package.
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+)
+
+// Handler holds all API handler state.
+type Handler struct {
+	store *store.MemoryStore
+	mw    *twincore.Middleware
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
+	return &Handler{store: s, mw: mw}
+}
+
+// Routes mounts the service API routes.
+// Adjust the route structure to match the real service's URL patterns.
+func (h *Handler) Routes(r chi.Router) {
+	r.Route("/v1/resources", func(r chi.Router) {
+		r.Use(h.authMiddleware)
+		r.Use(h.mw.FaultInjection)
+
+		r.Post("/", h.CreateResource)
+		r.Get("/", h.ListResources)
+		r.Get("/{id}", h.GetResource)
+		r.Patch("/{id}", h.UpdateResource)
+		r.Delete("/{id}", h.DeleteResource)
+	})
+}
+
+// authMiddleware validates authentication.
+// Adapt this to match the real service's auth pattern (Bearer token, API key header, etc.).
+func (h *Handler) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			// Return the same error format the real service uses.
+			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+				"error": map[string]any{
+					"message": "Missing API key.",
+					"type":    "authentication_error",
+				},
+			})
+			return
+		}
+
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if token == auth || token == "" {
+			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
+				"error": map[string]any{
+					"message": "Invalid API key format.",
+					"type":    "authentication_error",
+				},
+			})
+			return
+		}
+
+		// In simulation mode, accept any non-empty token.
+		next.ServeHTTP(w, r)
+	})
+}

--- a/docs/TWIN_TEMPLATE/internal/store/memory.go
+++ b/docs/TWIN_TEMPLATE/internal/store/memory.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"encoding/json"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/twinkit/store"
+)
+
+// MemoryStore holds all twin state in memory.
+// Add a pkgstore.Store field for each resource type your twin implements.
+type MemoryStore struct {
+	Resources *pkgstore.Store[Resource]
+	Clock     *pkgstore.Clock
+}
+
+// New creates a new MemoryStore with empty state.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Resources: pkgstore.New[Resource]("res"), // Prefix for generated IDs (e.g., "res_abc123")
+		Clock:     pkgstore.NewClock(),
+	}
+}
+
+// stateSnapshot is the JSON-serializable state for admin endpoints.
+// Include every resource collection so snapshots are complete.
+type stateSnapshot struct {
+	Resources map[string]Resource `json:"resources"`
+}
+
+// Snapshot returns the full state as a JSON-serializable value.
+// Used by the admin /state endpoint.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Resources: s.Resources.Snapshot(),
+	}
+}
+
+// LoadState replaces the full state from a JSON body.
+// Used by admin /state/load and seed data loading.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	s.Resources.LoadSnapshot(snap.Resources)
+	return nil
+}
+
+// Reset clears all state.
+// Used by the admin /reset endpoint.
+func (s *MemoryStore) Reset() {
+	s.Resources.Reset()
+	s.Clock.Reset()
+}

--- a/docs/TWIN_TEMPLATE/internal/store/types.go
+++ b/docs/TWIN_TEMPLATE/internal/store/types.go
@@ -1,0 +1,14 @@
+// Package store defines the twin's state types and in-memory store.
+// Replace these types with the domain models for your target service.
+package store
+
+// Resource represents a single resource from the target service.
+// Use the exact same JSON field names as the real API's responses.
+type Resource struct {
+	ID          string            `json:"id"`
+	Object      string            `json:"object"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	CreatedAt   int64             `json:"created_at"`
+}

--- a/docs/TWIN_TEMPLATE/provenance.json
+++ b/docs/TWIN_TEMPLATE/provenance.json
@@ -1,0 +1,19 @@
+{
+  "twin": "your-service",
+  "sdk_target": {
+    "package": "github.com/your-org/your-sdk-go",
+    "language": "go",
+    "version": "v1"
+  },
+  "build": 1,
+  "generated_at": "2026-01-01T00:00:00Z",
+  "sources": {
+    "openapi": {
+      "origin": "unknown"
+    },
+    "sdk_analysis": {
+      "method": "manual",
+      "repo": "https://github.com/your-org/your-sdk-go"
+    }
+  }
+}

--- a/docs/TWIN_TEMPLATE/twin-manifest.json
+++ b/docs/TWIN_TEMPLATE/twin-manifest.json
@@ -1,0 +1,39 @@
+{
+  "twin": "your-service",
+  "display_name": "Your Service",
+  "category": "your-category",
+  "description": "Simulates the Your Service API, covering the core resource operations.",
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/your-org/your-sdk-go",
+      "language": "go",
+      "version": "v1",
+      "repo_url": "https://github.com/your-org/your-sdk-go",
+      "docs_url": "https://docs.your-service.com/api-reference"
+    },
+    "additional": []
+  },
+  "service_surface": {
+    "openapi_spec": {
+      "available": false
+    },
+    "auth_pattern": "api_key",
+    "has_webhooks": false,
+    "resource_count": 1
+  },
+  "coverage": {
+    "resources_implemented": [
+      "resources"
+    ],
+    "resources_not_implemented": [],
+    "estimated_coverage_pct": 0
+  },
+  "generation": {
+    "method": "manual",
+    "sources_used": {
+      "deepwiki": false,
+      "openapi": false,
+      "manual_docs": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Expands `CONTRIBUTING.md` with SDK-first philosophy, step-by-step twin contribution process, quality checklist, quirk reporting guidance
- Adds `docs/TWIN_TEMPLATE/` — a complete copyable template directory based on real twin structure:
  - Boilerplate `main.go`, router, CRUD handlers, test suite, memory store, types
  - Template `twin-manifest.json` and `provenance.json` with placeholder values
  - Template `go.mod` with correct `twinkit` module path
  - Per-twin `README.md` template
- Adds `.github/PULL_REQUEST_TEMPLATE/new_twin.md` with 10-item contribution checklist

## Test plan
- [x] All Go template files pass `gofmt` validation
- [x] All JSON template files are valid JSON
- [x] Template uses `twinkit` module paths (not `pkg`)
- [x] Manifest template uses `service_surface` (not `api_surface`)