### PR TITLE
Add Homebrew tap support to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,6 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}}
 
-# TODO: move twin-* artifact builds into a separate goreleaser config/workflow.
 archives:
   - id: binaries
     ids:
@@ -29,6 +28,36 @@ archives:
     formats:
       - binary
     name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+  - id: tarballs
+    ids:
+      - wt
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+brews:
+  - name: wt
+    ids:
+      - tarballs
+    repository:
+      owner: wondertwin-ai
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: wondertwin-bot
+      email: bot@wondertwin.ai
+    directory: Formula
+    homepage: https://wondertwin.dev
+    description: "CLI for WonderTwin — behavioral twins for third-party APIs"
+    license: MIT
+    test: |
+      system "#{bin}/wt", "version"
+    install: |
+      bin.install "wt"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Summary

- Add tarball archive format to goreleaser (Homebrew requires tarballs, not raw binaries)
- Add `brews:` section to automatically push formula to `wondertwin-ai/homebrew-tap`
- Pass `HOMEBREW_TAP_TOKEN` env var in release workflow

## Setup required before first release

1. Create a GitHub PAT (classic) with `repo` scope
2. Add it as `HOMEBREW_TAP_TOKEN` in **Settings > Secrets and variables > Actions** on the wondertwin repo
3. The `wondertwin-ai/homebrew-tap` repo needs to exist (already created)

## What happens on release

When you push a `v*` tag:
1. Goreleaser builds binaries + tarballs + checksums
2. Creates a GitHub Release with all artifacts
3. Automatically commits a Homebrew formula to `wondertwin-ai/homebrew-tap/Formula/wt.rb`
4. Users can then `brew install wondertwin-ai/tap/wt`

## Test plan

- [ ] Add `HOMEBREW_TAP_TOKEN` secret to repo
- [ ] Tag and push `v0.1.0` to trigger release
- [ ] Verify GitHub Release has both binary and tarball artifacts
- [ ] Verify formula appears in homebrew-tap repo
- [ ] `brew install wondertwin-ai/tap/wt && wt version` works