### PR TITLE
feat: add cmd/gen-registry tool for twin registry updates

### DIFF
--- a/cmd/gen-registry/main.go
+++ b/cmd/gen-registry/main.go
@@ -1,0 +1,230 @@
+// Command gen-registry updates a registry.json file with a single twin release.
+// It is called by CI after GoReleaser produces binaries and checksums.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Registry mirrors internal/registry.Registry for JSON serialisation.
+type Registry struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Twins         map[string]TwinEntry `json:"twins"`
+}
+
+// TwinEntry mirrors internal/registry.TwinEntry.
+type TwinEntry struct {
+	Description string             `json:"description"`
+	Repo        string             `json:"repo"`
+	Category    string             `json:"category"`
+	Author      string             `json:"author"`
+	Latest      string             `json:"latest"`
+	Versions    map[string]Version `json:"versions"`
+}
+
+// Version mirrors internal/registry.Version.
+type Version struct {
+	Released   string            `json:"released"`
+	SDKPackage string            `json:"sdk_package"`
+	SDKVersion string            `json:"sdk_version"`
+	Tier       string            `json:"tier"`
+	Checksums  map[string]string `json:"checksums"`
+	BinaryURLs map[string]string `json:"binary_urls"`
+}
+
+// TwinManifest represents the relevant fields from twin-manifest.json.
+type TwinManifest struct {
+	Twin        string `json:"twin"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	SDKTarget   struct {
+		Primary struct {
+			Package string `json:"package"`
+			Version string `json:"version"`
+		} `json:"primary"`
+	} `json:"sdk_target"`
+}
+
+// nowFunc is overridden in tests to produce deterministic dates.
+var nowFunc = time.Now
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "gen-registry: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("gen-registry", flag.ContinueOnError)
+	twin := fs.String("twin", "", "twin name (e.g. stripe)")
+	version := fs.String("version", "", "version string (e.g. 0.1.0)")
+	checksumsFile := fs.String("checksums-file", "", "path to checksums file")
+	registryFile := fs.String("registry-file", "", "path to registry.json")
+	repo := fs.String("repo", "wondertwin-ai/registry", "GitHub repo for download URLs")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *twin == "" || *version == "" || *checksumsFile == "" || *registryFile == "" {
+		return fmt.Errorf("--twin, --version, --checksums-file, and --registry-file are all required")
+	}
+
+	// 1. Read twin manifest
+	manifest, err := readManifest(*twin)
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+
+	// 2. Parse checksums
+	checksums, err := parseChecksums(*checksumsFile, *twin)
+	if err != nil {
+		return fmt.Errorf("parsing checksums: %w", err)
+	}
+
+	// 3. Load existing registry
+	reg, err := loadRegistry(*registryFile)
+	if err != nil {
+		return fmt.Errorf("loading registry: %w", err)
+	}
+
+	// 4. Build version entry
+	ver := buildVersion(*twin, *version, *repo, manifest, checksums)
+
+	// 5. Upsert into registry
+	upsert(reg, *twin, *version, manifest, ver)
+
+	// 6. Write back
+	if err := writeRegistry(*registryFile, reg); err != nil {
+		return fmt.Errorf("writing registry: %w", err)
+	}
+
+	fmt.Printf("Updated registry: %s v%s (%d platforms)\n", *twin, *version, len(checksums))
+	return nil
+}
+
+func readManifest(twin string) (*TwinManifest, error) {
+	path := filepath.Join(fmt.Sprintf("twin-%s", twin), "twin-manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m TwinManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// parseChecksums reads a checksums file in `<sha256hex>  <filename>` format.
+// It extracts the platform from filenames matching twin-{name}-{os}-{arch}.
+func parseChecksums(path, twin string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	prefix := fmt.Sprintf("twin-%s-", twin)
+	checksums := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		// Format: <hex>  <filename>  (two spaces between)
+		parts := strings.SplitN(line, "  ", 2)
+		if len(parts) != 2 {
+			// Also try single space (some tools use one space)
+			parts = strings.SplitN(line, " ", 2)
+			if len(parts) != 2 {
+				continue
+			}
+		}
+		hex := strings.TrimSpace(parts[0])
+		filename := strings.TrimSpace(parts[1])
+
+		// Extract platform from filename
+		if !strings.HasPrefix(filename, prefix) {
+			continue
+		}
+		platform := strings.TrimPrefix(filename, prefix)
+		checksums[platform] = fmt.Sprintf("sha256:%s", hex)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(checksums) == 0 {
+		return nil, fmt.Errorf("no checksums found for twin %q", twin)
+	}
+	return checksums, nil
+}
+
+func loadRegistry(path string) (*Registry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parsing registry: %w", err)
+	}
+	if reg.Twins == nil {
+		reg.Twins = make(map[string]TwinEntry)
+	}
+	return &reg, nil
+}
+
+func buildVersion(twin, version, repo string, manifest *TwinManifest, checksums map[string]string) Version {
+	platforms := []string{"darwin-amd64", "darwin-arm64", "linux-amd64", "linux-arm64"}
+	binaryURLs := make(map[string]string, len(platforms))
+	for _, p := range platforms {
+		binaryURLs[p] = fmt.Sprintf(
+			"https://github.com/%s/releases/download/twin-%s-v%s/twin-%s-%s",
+			repo, twin, version, twin, p,
+		)
+	}
+
+	return Version{
+		Released:   nowFunc().UTC().Format("2006-01-02"),
+		SDKPackage: manifest.SDKTarget.Primary.Package,
+		SDKVersion: manifest.SDKTarget.Primary.Version,
+		Tier:       "free",
+		Checksums:  checksums,
+		BinaryURLs: binaryURLs,
+	}
+}
+
+func upsert(reg *Registry, twin, version string, manifest *TwinManifest, ver Version) {
+	entry, exists := reg.Twins[twin]
+	if !exists {
+		entry = TwinEntry{
+			Description: manifest.Description,
+			Repo:        "https://github.com/wondertwin-ai/wondertwin",
+			Category:    manifest.Category,
+			Author:      "WonderTwin",
+			Versions:    make(map[string]Version),
+		}
+	}
+	entry.Latest = version
+	entry.Versions[version] = ver
+	reg.Twins[twin] = entry
+}
+
+func writeRegistry(path string, reg *Registry) error {
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/gen-registry/main_test.go
+++ b/cmd/gen-registry/main_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// setupManifest creates a twin-manifest.json in a temp twin directory and
+// changes to the parent so readManifest("stripe") can find it.
+func setupManifest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	twinDir := filepath.Join(dir, "twin-stripe")
+	if err := os.MkdirAll(twinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+  "twin": "stripe",
+  "display_name": "Stripe",
+  "category": "payments",
+  "description": "Stripe twin for testing",
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/stripe/stripe-go",
+      "language": "go",
+      "version": "v81"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(twinDir, "twin-manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeChecksums(t *testing.T, dir string) string {
+	t.Helper()
+	content := `abc123def456  twin-stripe-darwin-amd64
+789ghi012jkl  twin-stripe-darwin-arm64
+mno345pqr678  twin-stripe-linux-amd64
+stu901vwx234  twin-stripe-linux-arm64
+`
+	path := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeEmptyRegistry(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version": 1, "twins": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, 2, 17, 0, 0, 0, 0, time.UTC)
+}
+
+func TestCreateRegistryFromScratch(t *testing.T) {
+	dir := setupManifest(t)
+	// Change to the dir so readManifest finds twin-stripe/twin-manifest.json
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe",
+		"--version", "0.1.0",
+		"--checksums-file", checksumsPath,
+		"--registry-file", registryPath,
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if reg.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", reg.SchemaVersion)
+	}
+	entry, ok := reg.Twins["stripe"]
+	if !ok {
+		t.Fatal("missing twin 'stripe'")
+	}
+	if entry.Latest != "0.1.0" {
+		t.Errorf("latest = %q, want %q", entry.Latest, "0.1.0")
+	}
+	if entry.Description != "Stripe twin for testing" {
+		t.Errorf("description = %q", entry.Description)
+	}
+	if entry.Category != "payments" {
+		t.Errorf("category = %q", entry.Category)
+	}
+	if entry.Author != "WonderTwin" {
+		t.Errorf("author = %q", entry.Author)
+	}
+
+	ver, ok := entry.Versions["0.1.0"]
+	if !ok {
+		t.Fatal("missing version 0.1.0")
+	}
+	if ver.Released != "2026-02-17" {
+		t.Errorf("released = %q", ver.Released)
+	}
+	if ver.SDKPackage != "github.com/stripe/stripe-go" {
+		t.Errorf("sdk_package = %q", ver.SDKPackage)
+	}
+	if ver.SDKVersion != "v81" {
+		t.Errorf("sdk_version = %q", ver.SDKVersion)
+	}
+	if ver.Tier != "free" {
+		t.Errorf("tier = %q", ver.Tier)
+	}
+}
+
+func TestAddSecondVersion(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	// First version
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second version
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.2.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+
+	entry := reg.Twins["stripe"]
+	if entry.Latest != "0.2.0" {
+		t.Errorf("latest = %q, want %q", entry.Latest, "0.2.0")
+	}
+	if len(entry.Versions) != 2 {
+		t.Errorf("versions count = %d, want 2", len(entry.Versions))
+	}
+	if _, ok := entry.Versions["0.1.0"]; !ok {
+		t.Error("version 0.1.0 was removed")
+	}
+	if _, ok := entry.Versions["0.2.0"]; !ok {
+		t.Error("version 0.2.0 not added")
+	}
+}
+
+func TestAddSecondTwin(t *testing.T) {
+	dir := setupManifest(t)
+	// Also create a twilio manifest
+	twilioDir := filepath.Join(dir, "twin-twilio")
+	os.MkdirAll(twilioDir, 0o755)
+	twilioManifest := `{
+  "twin": "twilio",
+  "description": "Twilio twin",
+  "category": "messaging",
+  "sdk_target": { "primary": { "package": "github.com/twilio/twilio-go", "version": "v1" } }
+}`
+	os.WriteFile(filepath.Join(twilioDir, "twin-manifest.json"), []byte(twilioManifest), 0o644)
+
+	// Twilio checksums
+	twilioChecksums := `aaa111  twin-twilio-darwin-amd64
+bbb222  twin-twilio-darwin-arm64
+ccc333  twin-twilio-linux-amd64
+ddd444  twin-twilio-linux-arm64
+`
+	twilioChecksumsPath := filepath.Join(dir, "twilio-checksums.txt")
+	os.WriteFile(twilioChecksumsPath, []byte(twilioChecksums), 0o644)
+
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	// Add stripe
+	run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	})
+
+	// Add twilio
+	if err := run([]string{
+		"--twin", "twilio", "--version", "0.1.0",
+		"--checksums-file", twilioChecksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+
+	if len(reg.Twins) != 2 {
+		t.Fatalf("twins count = %d, want 2", len(reg.Twins))
+	}
+	if _, ok := reg.Twins["stripe"]; !ok {
+		t.Error("stripe twin missing")
+	}
+	if _, ok := reg.Twins["twilio"]; !ok {
+		t.Error("twilio twin missing")
+	}
+}
+
+func TestChecksumParsing(t *testing.T) {
+	dir := t.TempDir()
+	content := `abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890  twin-stripe-darwin-arm64
+1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef  twin-stripe-linux-amd64
+`
+	path := filepath.Join(dir, "checksums.txt")
+	os.WriteFile(path, []byte(content), 0o644)
+
+	checksums, err := parseChecksums(path, "stripe")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(checksums) != 2 {
+		t.Fatalf("got %d checksums, want 2", len(checksums))
+	}
+
+	expected := "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	if checksums["darwin-arm64"] != expected {
+		t.Errorf("darwin-arm64 checksum = %q, want %q", checksums["darwin-arm64"], expected)
+	}
+
+	expected2 := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	if checksums["linux-amd64"] != expected2 {
+		t.Errorf("linux-amd64 checksum = %q, want %q", checksums["linux-amd64"], expected2)
+	}
+}
+
+func TestOutputMatchesSchema(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	})
+
+	data, _ := os.ReadFile(registryPath)
+
+	// Verify all expected JSON keys exist by unmarshalling to a generic map
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check top-level keys
+	if _, ok := raw["schema_version"]; !ok {
+		t.Error("missing schema_version")
+	}
+	twins := raw["twins"].(map[string]interface{})
+	stripe := twins["stripe"].(map[string]interface{})
+
+	for _, key := range []string{"description", "repo", "category", "author", "latest", "versions"} {
+		if _, ok := stripe[key]; !ok {
+			t.Errorf("missing twin key %q", key)
+		}
+	}
+
+	versions := stripe["versions"].(map[string]interface{})
+	v010 := versions["0.1.0"].(map[string]interface{})
+
+	for _, key := range []string{"released", "sdk_package", "sdk_version", "tier", "checksums", "binary_urls"} {
+		if _, ok := v010[key]; !ok {
+			t.Errorf("missing version key %q", key)
+		}
+	}
+
+	// Verify binary URL format
+	binaryURLs := v010["binary_urls"].(map[string]interface{})
+	expectedURL := "https://github.com/wondertwin-ai/registry/releases/download/twin-stripe-v0.1.0/twin-stripe-darwin-arm64"
+	if binaryURLs["darwin-arm64"] != expectedURL {
+		t.Errorf("binary_url = %q, want %q", binaryURLs["darwin-arm64"], expectedURL)
+	}
+
+	// Verify checksum format starts with sha256:
+	checksums := v010["checksums"].(map[string]interface{})
+	for platform, cs := range checksums {
+		s := cs.(string)
+		if len(s) < 8 || s[:7] != "sha256:" {
+			t.Errorf("checksum for %s doesn't start with sha256: got %q", platform, s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/gen-registry/main.go` — a Go CLI that updates `registry.json` with a single twin release entry
- Reads `twin-manifest.json` for metadata, parses GoReleaser checksums, and upserts version entries matching the existing `Registry`/`TwinEntry`/`Version` structs in `internal/registry/`
- Includes 5 tests covering: empty registry, second version, second twin, checksum parsing, and schema validation

## Coordination

This is **Workstream A** of the twin release pipeline (Phase 1). Workstream B (`feat/twin-release-pipeline`) adds the GoReleaser config and GitHub Actions workflow that calls this tool. Zero file overlap between the two — they can merge in any order.

## Test plan

- [x] `go build ./cmd/gen-registry/` compiles cleanly
- [x] `go vet ./cmd/gen-registry/` passes
- [x] `go test ./cmd/gen-registry/ -v` — all 5 tests pass
- [x] Manual verification: output JSON matches `internal/registry` structs and `installer.go` checksum format (`sha256:<hex>`)
- [ ] After both PRs merge: dispatch `release-twin.yml` for a twin and verify `wt install` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)