### PR TITLE
feat: twin release pipeline (GoReleaser + workflow)

### DIFF
--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -1,0 +1,76 @@
+name: Release Twin
+
+on:
+  workflow_dispatch:
+    inputs:
+      twin:
+        description: "Twin name (e.g., stripe)"
+        required: true
+        type: string
+      version:
+        description: "Version string without v prefix (e.g., 0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout wondertwin
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: wondertwin
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: wondertwin/go.mod
+
+      - name: Create and push twin tag
+        working-directory: wondertwin
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "twin-${{ inputs.twin }}-v${{ inputs.version }}"
+          git push origin "twin-${{ inputs.twin }}-v${{ inputs.version }}"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --config .goreleaser-twin.yml --clean
+          workdir: wondertwin
+        env:
+          GITHUB_TOKEN: ${{ secrets.REGISTRY_PUSH_TOKEN }}
+          TWIN: ${{ inputs.twin }}
+          VERSION: ${{ inputs.version }}
+
+      - name: Checkout registry
+        uses: actions/checkout@v4
+        with:
+          repository: wondertwin-ai/registry
+          token: ${{ secrets.REGISTRY_PUSH_TOKEN }}
+          path: registry
+
+      - name: Update registry.json
+        working-directory: wondertwin
+        run: |
+          go run ./cmd/gen-registry \
+            --twin "${{ inputs.twin }}" \
+            --version "${{ inputs.version }}" \
+            --checksums-file dist/checksums.txt \
+            --registry-file "${{ github.workspace }}/registry/registry.json"
+
+      - name: Push registry update
+        working-directory: registry
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add registry.json
+          git commit -m "Update registry: twin-${{ inputs.twin }} v${{ inputs.version }}"
+          git push

--- a/.goreleaser-twin.yml
+++ b/.goreleaser-twin.yml
@@ -1,0 +1,46 @@
+version: 2
+
+project_name: "twin-{{ .Env.TWIN }}"
+
+builds:
+  - id: twin
+    main: "./twin-{{ .Env.TWIN }}/cmd/twin-{{ .Env.TWIN }}/"
+    binary: "twin-{{ .Env.TWIN }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - id: binaries
+    ids:
+      - twin
+    formats:
+      - binary
+    name_template: "twin-{{ .Env.TWIN }}-{{ .Os }}-{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: wondertwin-ai
+    name: registry
+  name_template: "twin-{{ .Env.TWIN }}-v{{ .Env.VERSION }}"
+  draft: false
+  prerelease: auto
+
+snapshot:
+  version_template: "{{ .Env.VERSION }}-next"
+
+changelog:
+  disable: true
+
+gomod:
+  proxy: true


### PR DESCRIPTION
## Summary

- Adds `.goreleaser-twin.yml` — GoReleaser v2 config that cross-compiles a single twin (driven by `TWIN` env var) for darwin/linux amd64/arm64 as raw binaries, releasing to `wondertwin-ai/registry`
- Adds `.github/workflows/release-twin.yml` — `workflow_dispatch` workflow with `twin` and `version` inputs that tags, builds via GoReleaser, and updates `registry.json` via `gen-registry`

## Coordination with Workstream A

This PR has **zero file overlap** with #26 (`feat/gen-registry`). The workflow calls `go run ./cmd/gen-registry` which will resolve after both branches merge to `main`. Either merge order works — if this merges first, the workflow will simply fail until gen-registry is also on main.

## Verified

- GoReleaser snapshot build succeeds locally (`TWIN=stripe VERSION=0.1.0 goreleaser release --config .goreleaser-twin.yml --snapshot --clean`)
- Produces 4 binaries: `twin-stripe-{darwin,linux}-{amd64,arm64}`
- Checksums file matches the format gen-registry expects (`<sha256>  twin-stripe-<platform>`)

## Post-merge steps

After both PRs merge:
```bash
for twin in stripe twilio clerk resend posthog logodev; do
  gh workflow run release-twin.yml -f twin=$twin -f version=0.1.0
done
```

## Test plan

- [x] `goreleaser --snapshot` produces correct binary names and checksums
- [ ] Dispatch workflow after both PRs merge and verify end-to-end release
- [ ] `wt install stripe@latest` against populated registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)