### PR TITLE
feat: post-release validation and registry verification tool

### DIFF
--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -97,3 +97,19 @@ jobs:
             git commit -m "Update registry: twin-${{ inputs.twin }} v${{ inputs.version }}"
             git push
           fi
+
+      # ── Post-release validation ──────────────────────────────────
+      - name: Build wt CLI from source
+        working-directory: wondertwin
+        run: go build -o ./wt-test ./cmd/wt/
+
+      - name: Clear local twin cache
+        run: rm -rf ~/.wondertwin/bin/
+
+      - name: Install the just-released twin
+        working-directory: wondertwin
+        run: ./wt-test install ${{ inputs.twin }}@${{ inputs.version }}
+
+      - name: Run conformance on installed twin
+        working-directory: wondertwin
+        run: ./wt-test conformance ~/.wondertwin/bin/twin-${{ inputs.twin }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-twins build-all clean test vet goreleaser-check release-local
+.PHONY: build build-twins build-all clean test vet goreleaser-check release-local verify-registry
 
 VERSION ?= dev
 GORELEASER ?= goreleaser
@@ -31,3 +31,6 @@ goreleaser-check: ## Validate Goreleaser config
 
 release-local: ## Build cross-platform release artifacts into dist/ using Goreleaser
 	$(GORELEASER) release --snapshot --clean
+
+verify-registry: ## Validate the live twin registry
+	go run ./cmd/verify-registry

--- a/cmd/verify-registry/main.go
+++ b/cmd/verify-registry/main.go
@@ -1,0 +1,241 @@
+// Command verify-registry validates the live WonderTwin twin registry.
+//
+// It fetches registry.json, parses it, and runs a series of checks to
+// ensure all entries are well-formed and all binary downloads are reachable.
+//
+// Usage:
+//
+//	go run ./cmd/verify-registry
+//	go run ./cmd/verify-registry --registry-url https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.json
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const defaultRegistryURL = "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.json"
+
+var requiredPlatforms = []string{
+	"darwin-amd64",
+	"darwin-arm64",
+	"linux-amd64",
+	"linux-arm64",
+}
+
+// checksumRe matches the expected format: sha256:<64 hex chars>
+var checksumRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// registrySchema mirrors internal/registry types for standalone parsing.
+type registrySchema struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Twins         map[string]twinEntry `json:"twins"`
+}
+
+type twinEntry struct {
+	Description string                `json:"description"`
+	Repo        string                `json:"repo"`
+	Category    string                `json:"category"`
+	Author      string                `json:"author"`
+	Latest      string                `json:"latest"`
+	Versions    map[string]versionDef `json:"versions"`
+}
+
+type versionDef struct {
+	Released   string            `json:"released"`
+	SDKPackage string            `json:"sdk_package"`
+	SDKVersion string            `json:"sdk_version"`
+	Tier       string            `json:"tier"`
+	Checksums  map[string]string `json:"checksums"`
+	BinaryURLs map[string]string `json:"binary_urls"`
+}
+
+// checkResult stores the outcome of a single check.
+type checkResult struct {
+	Name   string
+	Passed bool
+	Detail string
+}
+
+func main() {
+	registryURL := flag.String("registry-url", defaultRegistryURL, "URL of the registry.json to validate")
+	flag.Parse()
+
+	results := run(*registryURL)
+	printResults(results)
+
+	for _, r := range results {
+		if !r.Passed {
+			os.Exit(1)
+		}
+	}
+}
+
+// run performs all validation checks and returns the results.
+func run(registryURL string) []checkResult {
+	var results []checkResult
+
+	// 1. Fetch registry
+	body, err := fetchRegistry(registryURL)
+	if err != nil {
+		return append(results, checkResult{"Fetch registry", false, err.Error()})
+	}
+	results = append(results, checkResult{"Fetch registry", true, registryURL})
+
+	// 2. Parse JSON
+	var reg registrySchema
+	if err := json.Unmarshal(body, &reg); err != nil {
+		return append(results, checkResult{"Parse JSON", false, err.Error()})
+	}
+	results = append(results, checkResult{"Parse JSON", true, ""})
+
+	// 3. Schema version
+	if reg.SchemaVersion < 1 {
+		results = append(results, checkResult{"Schema version", false, fmt.Sprintf("got %d, expected >= 1", reg.SchemaVersion)})
+	} else {
+		results = append(results, checkResult{"Schema version", true, fmt.Sprintf("%d", reg.SchemaVersion)})
+	}
+
+	if len(reg.Twins) == 0 {
+		return append(results, checkResult{"Twins present", false, "registry has no twins"})
+	}
+	results = append(results, checkResult{"Twins present", true, fmt.Sprintf("%d twin(s)", len(reg.Twins))})
+
+	// 4. Per-twin checks
+	for name, entry := range reg.Twins {
+		results = append(results, validateTwin(name, entry)...)
+	}
+
+	return results
+}
+
+func validateTwin(name string, entry twinEntry) []checkResult {
+	var results []checkResult
+
+	// latest points to existing version
+	if entry.Latest == "" {
+		results = append(results, checkResult{fmt.Sprintf("[%s] latest defined", name), false, "latest is empty"})
+	} else if _, ok := entry.Versions[entry.Latest]; !ok {
+		results = append(results, checkResult{fmt.Sprintf("[%s] latest exists in versions", name), false, fmt.Sprintf("latest=%q not found in versions", entry.Latest)})
+	} else {
+		results = append(results, checkResult{fmt.Sprintf("[%s] latest exists in versions", name), true, entry.Latest})
+	}
+
+	for ver, vd := range entry.Versions {
+		results = append(results, validateVersion(name, ver, vd)...)
+	}
+
+	return results
+}
+
+func validateVersion(name, ver string, vd versionDef) []checkResult {
+	var results []checkResult
+	prefix := fmt.Sprintf("[%s@%s]", name, ver)
+
+	// Platform entries in binary_urls
+	results = append(results, checkPlatforms(prefix+" binary_urls", vd.BinaryURLs)...)
+
+	// Platform entries in checksums
+	results = append(results, checkPlatforms(prefix+" checksums", vd.Checksums)...)
+
+	// Checksum format
+	for platform, cs := range vd.Checksums {
+		if !ValidChecksum(cs) {
+			results = append(results, checkResult{fmt.Sprintf("%s checksum format %s", prefix, platform), false, cs})
+		}
+	}
+
+	// Binary URL reachability (HEAD requests)
+	for platform, url := range vd.BinaryURLs {
+		ok, detail := headCheck(url)
+		results = append(results, checkResult{fmt.Sprintf("%s reachable %s", prefix, platform), ok, detail})
+	}
+
+	return results
+}
+
+func checkPlatforms(label string, m map[string]string) []checkResult {
+	var missing []string
+	for _, p := range requiredPlatforms {
+		if _, ok := m[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		return []checkResult{{label + " platforms", false, "missing: " + strings.Join(missing, ", ")}}
+	}
+	return []checkResult{{label + " platforms", true, fmt.Sprintf("%d platforms", len(m))}}
+}
+
+// ValidChecksum checks whether a checksum string matches sha256:<hex64>.
+func ValidChecksum(cs string) bool {
+	return checksumRe.MatchString(cs)
+}
+
+func headCheck(url string) (bool, string) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Head(url)
+	if err != nil {
+		return false, err.Error()
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return true, "200 OK"
+	}
+	// GitHub releases sometimes redirect HEAD; try GET with range header
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed {
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Range", "bytes=0-0")
+		resp2, err := client.Do(req)
+		if err != nil {
+			return false, err.Error()
+		}
+		resp2.Body.Close()
+		if resp2.StatusCode == http.StatusOK || resp2.StatusCode == http.StatusPartialContent {
+			return true, fmt.Sprintf("%d (GET range fallback)", resp2.StatusCode)
+		}
+		return false, fmt.Sprintf("HTTP %d", resp2.StatusCode)
+	}
+	return false, fmt.Sprintf("HTTP %d", resp.StatusCode)
+}
+
+func fetchRegistry(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func printResults(results []checkResult) {
+	passed, failed := 0, 0
+	for _, r := range results {
+		status := "PASS"
+		if !r.Passed {
+			status = "FAIL"
+			failed++
+		} else {
+			passed++
+		}
+		if r.Detail != "" {
+			fmt.Printf("  %s  %s — %s\n", status, r.Name, r.Detail)
+		} else {
+			fmt.Printf("  %s  %s\n", status, r.Name)
+		}
+	}
+	fmt.Printf("\n%d passed, %d failed\n", passed, failed)
+}

--- a/cmd/verify-registry/main_test.go
+++ b/cmd/verify-registry/main_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func validRegistry() registrySchema {
+	return registrySchema{
+		SchemaVersion: 1,
+		Twins: map[string]twinEntry{
+			"stripe": {
+				Description: "Stripe twin",
+				Latest:      "0.1.0",
+				Versions: map[string]versionDef{
+					"0.1.0": {
+						Released:   "2026-02-01",
+						SDKPackage: "github.com/stripe/stripe-go",
+						SDKVersion: "81.0.0",
+						Checksums: map[string]string{
+							"darwin-amd64": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+							"darwin-arm64": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+							"linux-amd64":  "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+							"linux-arm64":  "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+						},
+						BinaryURLs: map[string]string{
+							"darwin-amd64": "", // replaced per test
+							"darwin-arm64": "",
+							"linux-amd64":  "",
+							"linux-arm64":  "",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestValidChecksum(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", true},
+		{"sha256:0000000000000000000000000000000000000000000000000000000000000000", true},
+		{"sha256:short", false},
+		{"md5:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		{"sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789", false}, // uppercase
+		{"", false},
+		{"sha256:", false},
+	}
+	for _, tc := range tests {
+		if got := ValidChecksum(tc.input); got != tc.want {
+			t.Errorf("ValidChecksum(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestRunFullValidRegistry(t *testing.T) {
+	binaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer binaryServer.Close()
+
+	reg := validRegistry()
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	for _, p := range requiredPlatforms {
+		v.BinaryURLs[p] = binaryServer.URL + "/twin-stripe-" + p
+	}
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	}))
+	defer regServer.Close()
+
+	results := run(regServer.URL)
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("check %q failed: %s", r.Name, r.Detail)
+		}
+	}
+}
+
+func TestRunLatestMissing(t *testing.T) {
+	reg := validRegistry()
+	entry := reg.Twins["stripe"]
+	entry.Latest = "9.9.9"
+	reg.Twins["stripe"] = entry
+
+	binaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer binaryServer.Close()
+
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	for _, p := range requiredPlatforms {
+		v.BinaryURLs[p] = binaryServer.URL + "/" + p
+	}
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer regServer.Close()
+
+	results := run(regServer.URL)
+	foundFail := false
+	for _, r := range results {
+		if r.Name == "[stripe] latest exists in versions" && !r.Passed {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Error("expected latest-exists-in-versions check to fail")
+	}
+}
+
+func TestRunMissingPlatform(t *testing.T) {
+	reg := validRegistry()
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	delete(v.BinaryURLs, "linux-arm64")
+	delete(v.Checksums, "linux-arm64")
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	binaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer binaryServer.Close()
+
+	for _, p := range []string{"darwin-amd64", "darwin-arm64", "linux-amd64"} {
+		v.BinaryURLs[p] = binaryServer.URL + "/" + p
+	}
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer regServer.Close()
+
+	results := run(regServer.URL)
+	foundFail := false
+	for _, r := range results {
+		if !r.Passed && r.Detail == "missing: linux-arm64" {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Error("expected platform check to fail for missing linux-arm64")
+	}
+}
+
+func TestRunBinaryUnreachable(t *testing.T) {
+	reg := validRegistry()
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer goodServer.Close()
+
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer badServer.Close()
+
+	v.BinaryURLs["darwin-amd64"] = goodServer.URL + "/ok"
+	v.BinaryURLs["darwin-arm64"] = goodServer.URL + "/ok"
+	v.BinaryURLs["linux-amd64"] = goodServer.URL + "/ok"
+	v.BinaryURLs["linux-arm64"] = badServer.URL + "/missing"
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer regServer.Close()
+
+	results := run(regServer.URL)
+	foundFail := false
+	for _, r := range results {
+		if r.Name == "[stripe@0.1.0] reachable linux-arm64" && !r.Passed {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Error("expected reachability check to fail for linux-arm64")
+	}
+}
+
+func TestRunBadChecksum(t *testing.T) {
+	reg := validRegistry()
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	v.Checksums["darwin-amd64"] = "md5:badformat"
+
+	binaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer binaryServer.Close()
+
+	for _, p := range requiredPlatforms {
+		v.BinaryURLs[p] = binaryServer.URL + "/" + p
+	}
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer regServer.Close()
+
+	results := run(regServer.URL)
+	foundFail := false
+	for _, r := range results {
+		if !r.Passed && r.Name == "[stripe@0.1.0] checksum format darwin-amd64" {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Error("expected checksum format check to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Add post-release validation steps to `release-twin.yml` that build the `wt` CLI from source, install the just-released twin, and run conformance — testing the full loop (registry fetch → version resolution → binary download → checksum verification → conformance)
- Add `cmd/verify-registry` tool that validates the live registry on demand: fetches `registry.json`, checks schema version, validates `latest` pointers, platform coverage (4 platforms), checksum formats (`sha256:<hex64>`), and binary URL reachability via HEAD requests
- Add `make verify-registry` Makefile target

## Test plan
- [x] 6 unit tests passing for verify-registry (valid registry, missing latest, missing platform, unreachable binary, bad checksum format, checksum validation edge cases)
- [ ] Dispatch a twin release and verify the new CI validation steps pass in the Actions UI
- [ ] Run `make verify-registry` against the live registry