### PR TITLE
feat: wondertwin-lock.json and wt ci for reproducible installs

### DIFF
--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,0 +1,61 @@
+// Package lockfile reads and writes wondertwin-lock.json for reproducible twin installs.
+package lockfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const Filename = "wondertwin-lock.json"
+
+// LockFile represents the contents of wondertwin-lock.json.
+type LockFile struct {
+	GeneratedAt       time.Time             `json:"generated_at"`
+	RegistryFetchedAt time.Time             `json:"registry_fetched_at"`
+	Twins             map[string]LockedTwin `json:"twins"`
+}
+
+// LockedTwin captures the resolved state of a single twin.
+type LockedTwin struct {
+	Version      string `json:"version"`
+	ResolvedFrom string `json:"resolved_from"`
+	SDKPackage   string `json:"sdk_package,omitempty"`
+	SDKVersion   string `json:"sdk_version,omitempty"`
+	Checksum     string `json:"checksum,omitempty"`
+	BinaryURL    string `json:"binary_url,omitempty"`
+}
+
+// Load reads and parses a lock file from the given directory.
+func Load(dir string) (*LockFile, error) {
+	path := filepath.Join(dir, Filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lf LockFile
+	if err := json.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", Filename, err)
+	}
+	return &lf, nil
+}
+
+// Save writes the lock file to the given directory with indented JSON.
+func Save(dir string, lf *LockFile) error {
+	data, err := json.MarshalIndent(lf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", Filename, err)
+	}
+	data = append(data, '\n')
+	path := filepath.Join(dir, Filename)
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Exists returns true if a lock file exists in the given directory.
+func Exists(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, Filename))
+	return err == nil
+}

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,0 +1,168 @@
+package lockfile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	lf := &LockFile{
+		GeneratedAt:       now,
+		RegistryFetchedAt: now,
+		Twins: map[string]LockedTwin{
+			"stripe": {
+				Version:      "0.1.0",
+				ResolvedFrom: "latest",
+				SDKPackage:   "github.com/stripe/stripe-go",
+				SDKVersion:   "81.0.0",
+				Checksum:     "sha256:abc123",
+				BinaryURL:    "https://example.com/twin-stripe-darwin-arm64",
+			},
+		},
+	}
+
+	if err := Save(dir, lf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify file exists
+	path := filepath.Join(dir, Filename)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file not created: %v", err)
+	}
+
+	// Verify it's valid JSON
+	data, _ := os.ReadFile(path)
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Load it back
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.Twins) != 1 {
+		t.Fatalf("expected 1 twin, got %d", len(loaded.Twins))
+	}
+
+	stripe := loaded.Twins["stripe"]
+	if stripe.Version != "0.1.0" {
+		t.Errorf("version = %q, want %q", stripe.Version, "0.1.0")
+	}
+	if stripe.ResolvedFrom != "latest" {
+		t.Errorf("resolved_from = %q, want %q", stripe.ResolvedFrom, "latest")
+	}
+	if stripe.SDKPackage != "github.com/stripe/stripe-go" {
+		t.Errorf("sdk_package = %q, want %q", stripe.SDKPackage, "github.com/stripe/stripe-go")
+	}
+	if stripe.Checksum != "sha256:abc123" {
+		t.Errorf("checksum = %q, want %q", stripe.Checksum, "sha256:abc123")
+	}
+	if stripe.BinaryURL != "https://example.com/twin-stripe-darwin-arm64" {
+		t.Errorf("binary_url = %q, want %q", stripe.BinaryURL, "https://example.com/twin-stripe-darwin-arm64")
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error loading missing lock file")
+	}
+}
+
+func TestExists(t *testing.T) {
+	dir := t.TempDir()
+
+	if Exists(dir) {
+		t.Fatal("Exists should return false for empty dir")
+	}
+
+	lf := &LockFile{
+		GeneratedAt: time.Now().UTC(),
+		Twins:       map[string]LockedTwin{},
+	}
+	if err := Save(dir, lf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if !Exists(dir) {
+		t.Fatal("Exists should return true after Save")
+	}
+}
+
+func TestSaveOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	lf1 := &LockFile{
+		GeneratedAt: now,
+		Twins: map[string]LockedTwin{
+			"stripe": {Version: "0.1.0", ResolvedFrom: "latest"},
+		},
+	}
+	if err := Save(dir, lf1); err != nil {
+		t.Fatalf("Save lf1: %v", err)
+	}
+
+	lf2 := &LockFile{
+		GeneratedAt: now,
+		Twins: map[string]LockedTwin{
+			"stripe": {Version: "0.2.0", ResolvedFrom: "latest"},
+			"twilio": {Version: "0.1.0", ResolvedFrom: "latest"},
+		},
+	}
+	if err := Save(dir, lf2); err != nil {
+		t.Fatalf("Save lf2: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.Twins) != 2 {
+		t.Fatalf("expected 2 twins, got %d", len(loaded.Twins))
+	}
+	if loaded.Twins["stripe"].Version != "0.2.0" {
+		t.Errorf("stripe version = %q, want %q", loaded.Twins["stripe"].Version, "0.2.0")
+	}
+}
+
+func TestOmitEmptyFields(t *testing.T) {
+	dir := t.TempDir()
+
+	lf := &LockFile{
+		GeneratedAt: time.Now().UTC(),
+		Twins: map[string]LockedTwin{
+			"stripe": {Version: "0.1.0", ResolvedFrom: "latest"},
+		},
+	}
+	if err := Save(dir, lf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, Filename))
+	var raw map[string]interface{}
+	json.Unmarshal(data, &raw)
+
+	twins := raw["twins"].(map[string]interface{})
+	stripe := twins["stripe"].(map[string]interface{})
+
+	// sdk_package, sdk_version, checksum, binary_url should be omitted when empty
+	if _, ok := stripe["sdk_package"]; ok {
+		t.Error("expected sdk_package to be omitted when empty")
+	}
+	if _, ok := stripe["checksum"]; ok {
+		t.Error("expected checksum to be omitted when empty")
+	}
+}

--- a/internal/registry/installer_test.go
+++ b/internal/registry/installer_test.go
@@ -1,0 +1,120 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallFromURL(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho hello\n")
+	checksum := fmt.Sprintf("sha256:%x", sha256.Sum256(binaryContent))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(binaryContent)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("stripe", "0.1.0", srv.URL+"/twin-stripe", checksum, dir)
+	if err != nil {
+		t.Fatalf("InstallFromURL: %v", err)
+	}
+
+	// Verify binary exists and is executable
+	binaryPath := filepath.Join(dir, "twin-stripe")
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		t.Fatalf("binary not found: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("binary is not executable")
+	}
+
+	// Verify version sidecar
+	versionData, err := os.ReadFile(binaryPath + ".version")
+	if err != nil {
+		t.Fatalf("version file not found: %v", err)
+	}
+	if string(versionData) != "0.1.0" {
+		t.Errorf("version = %q, want %q", string(versionData), "0.1.0")
+	}
+}
+
+func TestInstallFromURLChecksumMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("binary content"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("stripe", "0.1.0", srv.URL+"/twin-stripe", "sha256:0000000000000000000000000000000000000000000000000000000000000000", dir)
+	if err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+
+	// Binary should not exist after failed checksum
+	binaryPath := filepath.Join(dir, "twin-stripe")
+	if _, err := os.Stat(binaryPath); err == nil {
+		t.Error("binary should not exist after checksum mismatch")
+	}
+}
+
+func TestInstallFromURLNoChecksum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("binary content"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("stripe", "0.1.0", srv.URL+"/twin-stripe", "", dir)
+	if err != nil {
+		t.Fatalf("InstallFromURL without checksum: %v", err)
+	}
+
+	binaryPath := filepath.Join(dir, "twin-stripe")
+	if _, err := os.Stat(binaryPath); err != nil {
+		t.Fatalf("binary not found: %v", err)
+	}
+}
+
+func TestIsAlreadyInstalled(t *testing.T) {
+	dir := t.TempDir()
+	twinName := "stripe"
+
+	// Not installed yet
+	if IsAlreadyInstalled(twinName, "0.1.0", dir) {
+		t.Error("should not be installed in empty dir")
+	}
+
+	// Write binary and version sidecar
+	binaryPath := filepath.Join(dir, "twin-stripe")
+	os.WriteFile(binaryPath, []byte("binary"), 0o755)
+	os.WriteFile(binaryPath+".version", []byte("0.1.0"), 0o644)
+
+	if !IsAlreadyInstalled(twinName, "0.1.0", dir) {
+		t.Error("should be installed")
+	}
+
+	// Different version
+	if IsAlreadyInstalled(twinName, "0.2.0", dir) {
+		t.Error("should not match different version")
+	}
+}
+
+func TestInstallFromURLHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("stripe", "0.1.0", srv.URL+"/twin-stripe", "", dir)
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `wondertwin-lock.json` lock file for reproducible twin installations
- `wt install` (manifest mode) now writes a lock file after resolving versions, capturing resolved version, SDK info, platform-specific checksum, and binary URL
- `wt ci` reads the lock file and installs exact locked versions without fetching the registry — fails with a clear error if no lock file exists
- `wt up` checks for a lock file first: uses locked versions if present, otherwise falls back to full registry resolution via `wt install`
- Adds `registry.InstallFromURL` for downloading binaries by direct URL with checksum verification (used by lock file installs)

## Files changed

- `cmd/wt/main.go` — modified install, up commands; added ci command
- `internal/lockfile/` — new package (structs, Load/Save/Exists)
- `internal/registry/installer.go` — added InstallFromURL
- `internal/registry/installer_test.go` — tests for InstallFromURL
- `internal/lockfile/lockfile_test.go` — tests for lockfile package

Zero overlap with workstreams C (release validation) or D (gen-registry enhancements).

## Test plan

- [x] `go build ./cmd/wt/` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] Lockfile tests: save/load roundtrip, missing file error, exists check, overwrite, omitempty JSON fields
- [x] InstallFromURL tests: success, checksum mismatch, no checksum, HTTP error
- [ ] Manual: `wt install` with a manifest creates `wondertwin-lock.json`
- [ ] Manual: `wt ci` succeeds with valid lock file
- [ ] Manual: `wt ci` fails without lock file
- [ ] Manual: `wt up` uses locked versions when lock file present