### PR TITLE
feat: add --prerelease flag and api_version to gen-registry

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -38,6 +38,7 @@ type Version struct {
 	Released   string            `yaml:"released" json:"released"`
 	SDKPackage string            `yaml:"sdk_package" json:"sdk_package"`
 	SDKVersion string            `yaml:"sdk_version" json:"sdk_version"`
+	APIVersion string            `yaml:"api_version,omitempty" json:"api_version,omitempty"`
 	Tier       string            `yaml:"tier" json:"tier"`
 	Checksums  map[string]string `yaml:"checksums" json:"checksums"`
 	BinaryURLs map[string]string `yaml:"binary_urls" json:"binary_urls"`

--- a/twin-stripe/twin-manifest.json
+++ b/twin-stripe/twin-manifest.json
@@ -8,6 +8,7 @@
       "package": "github.com/stripe/stripe-go",
       "language": "go",
       "version": "v81",
+      "api_version": "2024-12-18",
       "repo_url": "https://github.com/stripe/stripe-go",
       "docs_url": "https://docs.stripe.com/api"
     },

--- a/twin-twilio/twin-manifest.json
+++ b/twin-twilio/twin-manifest.json
@@ -8,6 +8,7 @@
       "package": "github.com/twilio/twilio-go",
       "language": "go",
       "version": "v1",
+      "api_version": "2010-04-01",
       "repo_url": "https://github.com/twilio/twilio-go",
       "docs_url": "https://www.twilio.com/docs/libraries/reference/twilio-go"
     },


### PR DESCRIPTION
## Summary

- **--prerelease flag**: Adds a version to the registry without updating `latest`, allowing beta/RC publishes that don't affect `wt install stripe@latest`. First release on a new twin still sets latest even with --prerelease.
- **api_version field**: Flows from `twin-manifest.json` `sdk_target.primary.api_version` into registry version entries. Omitted from JSON when absent for backward compatibility.
- Adds `api_version` to stripe (`2024-12-18`) and twilio (`2010-04-01`) manifests.
- Adds `APIVersion` field to `internal/registry.Version` struct.

## Test plan

- [x] Prerelease: version added, latest stays at previous value
- [x] Without prerelease: latest updates normally (existing behavior preserved)
- [x] First release with prerelease on empty twin: latest still set
- [x] Manifest with api_version: registry entry includes it
- [x] Manifest without api_version: registry entry omits it
- [x] Backward compat: old registry.json without api_version parses correctly
- [x] All existing tests still pass
- [x] Full `go test ./...` passes