### PR TITLE
feat: add twin-loyaltylion for LoyaltyLion API v2

### DIFF
--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	.
 	./twin-clerk
 	./twin-logodev
+	./twin-loyaltylion
 	./twin-posthog
 	./twin-resend
 	./twin-smile

--- a/twin-loyaltylion/Dockerfile
+++ b/twin-loyaltylion/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /build
+COPY ../twinkit/ ./twinkit/
+COPY twin-loyaltylion/ ./twin-loyaltylion/
+WORKDIR /build/twin-loyaltylion
+RUN go build -o /twin-loyaltylion ./cmd/twin-loyaltylion/
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /twin-loyaltylion /usr/local/bin/twin-loyaltylion
+EXPOSE 8090
+ENTRYPOINT ["twin-loyaltylion"]

--- a/twin-loyaltylion/cmd/twin-loyaltylion/main.go
+++ b/twin-loyaltylion/cmd/twin-loyaltylion/main.go
@@ -1,0 +1,56 @@
+// twin-loyaltylion is a WonderTwin twin that simulates the LoyaltyLion REST API v2.
+// It implements customer management, points operations, reward redemption, and activity recording.
+//
+// SDK compatibility target: LoyaltyLion REST API v2
+// Integration method: override base URL in HTTP client, Basic auth (token:secret)
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+func main() {
+	cfg := twincore.ParseFlags("twin-loyaltylion")
+	if cfg.Port == 0 {
+		cfg.Port = 8090
+	}
+
+	twin := twincore.New(cfg)
+	memStore := store.New()
+	memStore.SeedDefaults()
+
+	// API handlers
+	apiHandler := api.NewHandler(memStore, twin.Middleware())
+	apiHandler.Routes(twin.Router)
+
+	// Admin control plane
+	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.SetConfigProvider(twin)
+	adminHandler.Routes(twin.Router)
+
+	// Load seed data if provided (overrides defaults)
+	if cfg.SeedFile != "" {
+		data, err := os.ReadFile(cfg.SeedFile)
+		if err != nil {
+			log.Fatalf("failed to read seed file: %v", err)
+		}
+		if err := memStore.LoadState(data); err != nil {
+			log.Fatalf("failed to load seed data: %v", err)
+		}
+		twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
+	}
+
+	twin.Logger.Info("twin-loyaltylion ready",
+		"port", cfg.Port,
+	)
+
+	if err := twin.Serve(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/twin-loyaltylion/go.mod
+++ b/twin-loyaltylion/go.mod
@@ -1,0 +1,10 @@
+module github.com/wondertwin-ai/wondertwin/twin-loyaltylion
+
+go 1.25.7
+
+replace github.com/wondertwin-ai/wondertwin/twinkit => ../twinkit
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/wondertwin-ai/wondertwin/twinkit v0.0.0-00010101000000-000000000000
+)

--- a/twin-loyaltylion/go.sum
+++ b/twin-loyaltylion/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/twin-loyaltylion/internal/api/handlers_activities.go
+++ b/twin-loyaltylion/internal/api/handlers_activities.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+// RecordActivity handles POST /v2/activities.
+func (h *Handler) RecordActivity(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+
+	var req struct {
+		Name       string            `json:"name"`
+		MerchantID string            `json:"merchant_id"`
+		Properties map[string]string `json:"properties,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Name == "" {
+		twincore.Error(w, http.StatusUnprocessableEntity, "name is required")
+		return
+	}
+	if req.MerchantID == "" {
+		twincore.Error(w, http.StatusUnprocessableEntity, "merchant_id is required")
+		return
+	}
+
+	now := h.store.Clock.Now().Format(time.RFC3339)
+	id := h.store.NextActivityID()
+	activity := store.Activity{
+		ID:         id,
+		Name:       req.Name,
+		MerchantID: req.MerchantID,
+		Properties: req.Properties,
+		Timestamp:  now,
+		APIKey:     apiKey,
+	}
+
+	h.store.Activities.Set(fmt.Sprintf("%d", id), activity)
+	twincore.JSON(w, http.StatusCreated, activity)
+}

--- a/twin-loyaltylion/internal/api/handlers_customers.go
+++ b/twin-loyaltylion/internal/api/handlers_customers.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+// ListCustomers handles GET /v2/customers with optional ?email= filter.
+func (h *Handler) ListCustomers(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	email := r.URL.Query().Get("email")
+
+	// Process any expired points before returning data
+	h.store.ProcessExpiredPoints(h.store.Clock.Now())
+
+	var customers []store.Customer
+	if email != "" {
+		c := h.store.GetCustomerByEmail(apiKey, email)
+		if c != nil {
+			customers = []store.Customer{*c}
+		} else {
+			customers = []store.Customer{}
+		}
+	} else {
+		customers = h.store.GetCustomersByMerchant(apiKey)
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"customers": customers,
+	})
+}
+
+// GetCustomer handles GET /v2/customers/{id}.
+func (h *Handler) GetCustomer(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid customer ID")
+		return
+	}
+
+	h.store.ProcessExpiredPoints(h.store.Clock.Now())
+
+	c, ok := h.store.Customers.Get(store.CustomerKey(id))
+	if !ok || c.APIKey != apiKey {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, c)
+}
+
+// CreateCustomer handles POST /v2/customers.
+func (h *Handler) CreateCustomer(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+
+	var req struct {
+		MerchantID string            `json:"merchant_id"`
+		Email      string            `json:"email"`
+		Properties map[string]string `json:"properties,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.MerchantID == "" {
+		twincore.Error(w, http.StatusUnprocessableEntity, "merchant_id is required")
+		return
+	}
+	if req.Email == "" {
+		twincore.Error(w, http.StatusUnprocessableEntity, "email is required")
+		return
+	}
+
+	now := h.store.Clock.Now().Format(time.RFC3339)
+	id := h.store.NextCustomerID()
+	c := store.Customer{
+		ID:             id,
+		MerchantID:     req.MerchantID,
+		Email:          req.Email,
+		PointsApproved: 0,
+		PointsPending:  0,
+		PointsSpent:    0,
+		PointsExpired:  0,
+		Properties:     req.Properties,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		APIKey:         apiKey,
+	}
+
+	h.store.Customers.Set(store.CustomerKey(id), c)
+	twincore.JSON(w, http.StatusCreated, c)
+}

--- a/twin-loyaltylion/internal/api/handlers_points.go
+++ b/twin-loyaltylion/internal/api/handlers_points.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+// GetPoints handles GET /v2/customers/{merchant_id}/points.
+func (h *Handler) GetPoints(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+
+	h.store.ProcessExpiredPoints(h.store.Clock.Now())
+
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	twincore.JSON(w, http.StatusOK, map[string]int{
+		"points_approved": c.PointsApproved,
+		"points_pending":  c.PointsPending,
+		"points_spent":    c.PointsSpent,
+		"points_expired":  c.PointsExpired,
+	})
+}
+
+// AddPoints handles POST /v2/customers/{merchant_id}/points.
+func (h *Handler) AddPoints(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+
+	var req struct {
+		Points int    `json:"points"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Points <= 0 {
+		twincore.Error(w, http.StatusUnprocessableEntity, "points must be positive")
+		return
+	}
+
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	now := h.store.Clock.Now()
+	c.PointsApproved += req.Points
+	c.UpdatedAt = now.Format(time.RFC3339)
+	h.store.Customers.Set(store.CustomerKey(c.ID), *c)
+
+	// Record transaction
+	txnID := h.store.NextTransactionID()
+	h.store.Transactions.Set(fmt.Sprintf("%d", txnID), store.PointsTransaction{
+		ID:         txnID,
+		CustomerID: c.ID,
+		Type:       "earn",
+		Amount:     req.Points,
+		Reason:     req.Reason,
+		Timestamp:  now.Format(time.RFC3339),
+		APIKey:     apiKey,
+	})
+
+	twincore.JSON(w, http.StatusOK, map[string]int{
+		"points_approved": c.PointsApproved,
+		"points_pending":  c.PointsPending,
+		"points_spent":    c.PointsSpent,
+		"points_expired":  c.PointsExpired,
+	})
+}
+
+// RemovePoints handles POST /v2/customers/{merchant_id}/points/remove.
+func (h *Handler) RemovePoints(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+
+	var req struct {
+		Points int    `json:"points"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Points <= 0 {
+		twincore.Error(w, http.StatusUnprocessableEntity, "points must be positive")
+		return
+	}
+
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	if c.PointsApproved < req.Points {
+		twincore.Error(w, http.StatusUnprocessableEntity, "insufficient_points")
+		return
+	}
+
+	now := h.store.Clock.Now()
+	c.PointsApproved -= req.Points
+	c.PointsSpent += req.Points
+	c.UpdatedAt = now.Format(time.RFC3339)
+	h.store.Customers.Set(store.CustomerKey(c.ID), *c)
+
+	// Record transaction
+	txnID := h.store.NextTransactionID()
+	h.store.Transactions.Set(fmt.Sprintf("%d", txnID), store.PointsTransaction{
+		ID:         txnID,
+		CustomerID: c.ID,
+		Type:       "spend",
+		Amount:     req.Points,
+		Reason:     req.Reason,
+		Timestamp:  now.Format(time.RFC3339),
+		APIKey:     apiKey,
+	})
+
+	twincore.JSON(w, http.StatusOK, map[string]int{
+		"points_approved": c.PointsApproved,
+		"points_pending":  c.PointsPending,
+		"points_spent":    c.PointsSpent,
+		"points_expired":  c.PointsExpired,
+	})
+}

--- a/twin-loyaltylion/internal/api/handlers_rewards.go
+++ b/twin-loyaltylion/internal/api/handlers_rewards.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+// ListAvailableRewards handles GET /v2/customers/{merchant_id}/available_rewards.
+func (h *Handler) ListAvailableRewards(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+
+	// Verify customer exists
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	rewards := h.store.GetRewardsByMerchant(apiKey)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"rewards": rewards,
+	})
+}
+
+// ClaimReward handles POST /v2/customers/{merchant_id}/claimed_rewards.
+func (h *Handler) ClaimReward(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+
+	var req struct {
+		RewardID   int `json:"reward_id"`
+		Multiplier int `json:"multiplier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Multiplier <= 0 {
+		req.Multiplier = 1
+	}
+
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	reward, ok := h.store.Rewards.Get(store.RewardKey(req.RewardID))
+	if !ok || reward.APIKey != apiKey {
+		twincore.Error(w, http.StatusNotFound, "reward not found")
+		return
+	}
+
+	totalCost := reward.PointCost * req.Multiplier
+	now := h.store.Clock.Now()
+
+	// Idempotency check
+	if existing := h.store.FindIdempotentClaim(c.ID, req.RewardID, req.Multiplier, apiKey, now); existing != nil {
+		twincore.JSON(w, http.StatusOK, map[string]any{
+			"claimed_reward": existing,
+		})
+		return
+	}
+
+	// Check balance
+	if c.PointsApproved < totalCost {
+		twincore.JSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error": "insufficient_points",
+		})
+		return
+	}
+
+	// Debit points
+	c.PointsApproved -= totalCost
+	c.PointsSpent += totalCost
+	c.UpdatedAt = now.Format(time.RFC3339)
+	h.store.Customers.Set(store.CustomerKey(c.ID), *c)
+
+	// Record transaction
+	txnID := h.store.NextTransactionID()
+	h.store.Transactions.Set(fmt.Sprintf("%d", txnID), store.PointsTransaction{
+		ID:         txnID,
+		CustomerID: c.ID,
+		Type:       "spend",
+		Amount:     totalCost,
+		Reason:     fmt.Sprintf("Redeemed: %s", reward.Title),
+		Timestamp:  now.Format(time.RFC3339),
+		APIKey:     apiKey,
+	})
+
+	// Create claimed reward
+	claimID := h.store.NextClaimedRewardID()
+	claimed := store.ClaimedReward{
+		ID:         claimID,
+		RewardID:   req.RewardID,
+		PointCost:  totalCost,
+		Redeemable: store.Redeemable{Code: generateDiscountCode(), Fulfilled: false},
+		Refunded:   false,
+		CreatedAt:  now.Format(time.RFC3339),
+		CustomerID: c.ID,
+		APIKey:     apiKey,
+		Multiplier: req.Multiplier,
+	}
+	h.store.ClaimedRewards.Set(store.ClaimedRewardKey(claimID), claimed)
+
+	twincore.JSON(w, http.StatusCreated, map[string]any{
+		"claimed_reward": claimed,
+	})
+}
+
+// RefundClaimedReward handles POST /v2/customers/{merchant_id}/claimed_rewards/{id}/refund.
+func (h *Handler) RefundClaimedReward(w http.ResponseWriter, r *http.Request) {
+	apiKey := getAPIKey(r)
+	merchantID := chi.URLParam(r, "merchant_id")
+	idStr := chi.URLParam(r, "id")
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		twincore.Error(w, http.StatusBadRequest, "invalid claimed reward ID")
+		return
+	}
+
+	c := h.store.GetCustomerByMerchantID(apiKey, merchantID)
+	if c == nil {
+		twincore.Error(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	claimed, ok := h.store.ClaimedRewards.Get(store.ClaimedRewardKey(id))
+	if !ok || claimed.APIKey != apiKey || claimed.CustomerID != c.ID {
+		twincore.Error(w, http.StatusNotFound, "claimed reward not found")
+		return
+	}
+
+	if claimed.Refunded {
+		twincore.Error(w, http.StatusUnprocessableEntity, "already refunded")
+		return
+	}
+
+	now := h.store.Clock.Now()
+
+	// Restore points
+	c.PointsApproved += claimed.PointCost
+	c.PointsSpent -= claimed.PointCost
+	if c.PointsSpent < 0 {
+		c.PointsSpent = 0
+	}
+	c.UpdatedAt = now.Format(time.RFC3339)
+	h.store.Customers.Set(store.CustomerKey(c.ID), *c)
+
+	// Record transaction
+	txnID := h.store.NextTransactionID()
+	h.store.Transactions.Set(fmt.Sprintf("%d", txnID), store.PointsTransaction{
+		ID:         txnID,
+		CustomerID: c.ID,
+		Type:       "adjust",
+		Amount:     claimed.PointCost,
+		Reason:     "Redemption refund",
+		Timestamp:  now.Format(time.RFC3339),
+		APIKey:     apiKey,
+	})
+
+	// Mark as refunded
+	claimed.Refunded = true
+	h.store.ClaimedRewards.Set(store.ClaimedRewardKey(id), claimed)
+
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"claimed_reward": claimed,
+	})
+}
+
+// generateDiscountCode creates a unique code in the format LOYAL-XXXX-XXXX.
+func generateDiscountCode() string {
+	b := make([]byte, 4)
+	rand.Read(b)
+	hex := strings.ToUpper(hex.EncodeToString(b))
+	return fmt.Sprintf("LOYAL-%s-%s", hex[:4], hex[4:])
+}

--- a/twin-loyaltylion/internal/api/handlers_test.go
+++ b/twin-loyaltylion/internal/api/handlers_test.go
@@ -1,0 +1,615 @@
+package api_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+func setupLoyaltyLion(t *testing.T) (*testutil.TwinClient, *testutil.AdminClient, *twincore.Middleware) {
+	t.Helper()
+	memStore := store.New()
+	memStore.SeedDefaults()
+	cfg := &twincore.Config{Name: "twin-loyaltylion-test"}
+	twin := twincore.New(cfg)
+	mw := twin.Middleware()
+	handler := api.NewHandler(memStore, mw)
+	handler.Routes(twin.Router)
+	adminHandler := admin.NewHandler(memStore, mw, memStore.Clock)
+	adminHandler.Routes(twin.Router)
+	srv := httptest.NewServer(twin.Router)
+	t.Cleanup(srv.Close)
+	tc := testutil.NewTwinClient(t, srv)
+	ac := testutil.NewAdminClient(tc)
+	return tc, ac, mw
+}
+
+func basicAuth(user, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+var authAlpha = map[string]string{
+	"Authorization": basicAuth("ll_test_key_alpha", "ll_test_secret_alpha"),
+}
+
+var authBeta = map[string]string{
+	"Authorization": basicAuth("ll_test_key_beta", "ll_test_secret_beta"),
+}
+
+func llGet(tc *testutil.TwinClient, path string, headers map[string]string) *testutil.Response {
+	return tc.DoWithHeaders("GET", path, nil, headers)
+}
+
+func llPost(tc *testutil.TwinClient, path string, body any, headers map[string]string) *testutil.Response {
+	return tc.DoWithHeaders("POST", path, body, headers)
+}
+
+// --- Auth Tests ---
+
+func TestAuthRequired(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := tc.Get("/v2/customers")
+	resp.AssertStatus(401)
+}
+
+func TestAuthInvalidKey(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	headers := map[string]string{
+		"Authorization": basicAuth("bad_key", "bad_secret"),
+	}
+	resp := llGet(tc, "/v2/customers", headers)
+	resp.AssertStatus(401)
+}
+
+func TestAuthInvalidSecret(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	headers := map[string]string{
+		"Authorization": basicAuth("ll_test_key_alpha", "wrong_secret"),
+	}
+	resp := llGet(tc, "/v2/customers", headers)
+	resp.AssertStatus(401)
+}
+
+func TestAuthMalformed(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	headers := map[string]string{
+		"Authorization": "Bearer some_token",
+	}
+	resp := llGet(tc, "/v2/customers", headers)
+	resp.AssertStatus(401)
+}
+
+// --- Customer CRUD Tests ---
+
+func TestListCustomers(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llGet(tc, "/v2/customers", authAlpha)
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	customers, ok := m["customers"].([]any)
+	if !ok {
+		t.Fatal("expected customers array")
+	}
+	if len(customers) != 3 {
+		t.Errorf("expected 3 customers for merchant alpha, got %d", len(customers))
+	}
+}
+
+func TestSearchCustomerByEmail(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Found
+	resp := llGet(tc, "/v2/customers?email=sarah@example.com", authAlpha)
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	customers := m["customers"].([]any)
+	if len(customers) != 1 {
+		t.Fatalf("expected 1 customer, got %d", len(customers))
+	}
+	c := customers[0].(map[string]any)
+	if c["email"] != "sarah@example.com" {
+		t.Errorf("expected sarah@example.com, got %v", c["email"])
+	}
+
+	// Not found
+	resp = llGet(tc, "/v2/customers?email=nobody@example.com", authAlpha)
+	resp.AssertStatus(200)
+	m = resp.JSONMap()
+	customers = m["customers"].([]any)
+	if len(customers) != 0 {
+		t.Errorf("expected 0 customers, got %d", len(customers))
+	}
+}
+
+func TestCreateCustomer(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llPost(tc, "/v2/customers", map[string]any{
+		"merchant_id": "new-cust-001",
+		"email":       "new@example.com",
+	}, authAlpha)
+	resp.AssertStatus(201)
+
+	m := resp.JSONMap()
+	if m["email"] != "new@example.com" {
+		t.Errorf("expected new@example.com, got %v", m["email"])
+	}
+	if m["merchant_id"] != "new-cust-001" {
+		t.Errorf("expected new-cust-001, got %v", m["merchant_id"])
+	}
+	if m["points_approved"] != float64(0) {
+		t.Errorf("expected 0 points_approved, got %v", m["points_approved"])
+	}
+}
+
+func TestGetCustomerByID(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Get customer 1 (Sarah)
+	resp := llGet(tc, "/v2/customers/1", authAlpha)
+	resp.AssertStatus(200)
+	m := resp.JSONMap()
+	if m["email"] != "sarah@example.com" {
+		t.Errorf("expected sarah@example.com, got %v", m["email"])
+	}
+}
+
+func TestGetCustomerNotFound(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llGet(tc, "/v2/customers/999", authAlpha)
+	resp.AssertStatus(404)
+}
+
+// --- Points Tests ---
+
+func TestGetPointsBalance(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llGet(tc, "/v2/customers/cust-001/points", authAlpha)
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["points_approved"] != float64(4200) {
+		t.Errorf("expected 4200 approved, got %v", m["points_approved"])
+	}
+	if m["points_pending"] != float64(100) {
+		t.Errorf("expected 100 pending, got %v", m["points_pending"])
+	}
+}
+
+func TestAddPoints(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llPost(tc, "/v2/customers/cust-001/points", map[string]any{
+		"points": 500,
+		"reason": "Manual bonus",
+	}, authAlpha)
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["points_approved"] != float64(4700) {
+		t.Errorf("expected 4700 approved after adding 500, got %v", m["points_approved"])
+	}
+}
+
+func TestRemovePoints(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llPost(tc, "/v2/customers/cust-001/points/remove", map[string]any{
+		"points": 200,
+		"reason": "Manual debit",
+	}, authAlpha)
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["points_approved"] != float64(4000) {
+		t.Errorf("expected 4000 approved after removing 200, got %v", m["points_approved"])
+	}
+	if m["points_spent"] != float64(3700) {
+		t.Errorf("expected 3700 spent, got %v", m["points_spent"])
+	}
+}
+
+func TestRemovePointsInsufficientBalance(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	// Alex has 0 approved points
+	resp := llPost(tc, "/v2/customers/cust-002/points/remove", map[string]any{
+		"points": 100,
+		"reason": "Too much",
+	}, authAlpha)
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("insufficient_points")
+}
+
+// --- Rewards & Redemption Tests ---
+
+func TestListAvailableRewards(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llGet(tc, "/v2/customers/cust-001/available_rewards", authAlpha)
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	rewards, ok := m["rewards"].([]any)
+	if !ok {
+		t.Fatal("expected rewards array")
+	}
+	if len(rewards) != 4 {
+		t.Errorf("expected 4 rewards for merchant alpha, got %d", len(rewards))
+	}
+}
+
+func TestClaimRewardHappyPath(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Jamie has 15000 points, claim $5 Off (500 pts, reward id 1)
+	resp := llPost(tc, "/v2/customers/cust-003/claimed_rewards", map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}, authAlpha)
+	resp.AssertStatus(201)
+
+	m := resp.JSONMap()
+	claimed := m["claimed_reward"].(map[string]any)
+	if claimed["point_cost"] != float64(500) {
+		t.Errorf("expected 500 point_cost, got %v", claimed["point_cost"])
+	}
+	redeemable := claimed["redeemable"].(map[string]any)
+	code := redeemable["code"].(string)
+	if len(code) == 0 {
+		t.Error("expected non-empty discount code")
+	}
+	if redeemable["fulfilled"] != false {
+		t.Error("expected fulfilled=false")
+	}
+
+	// Verify points were debited
+	resp = llGet(tc, "/v2/customers/cust-003/points", authAlpha)
+	resp.AssertStatus(200)
+	points := resp.JSONMap()
+	if points["points_approved"] != float64(14500) {
+		t.Errorf("expected 14500 approved after claiming 500, got %v", points["points_approved"])
+	}
+}
+
+func TestClaimRewardInsufficientPoints(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Alex has 0 points, try to claim $5 Off (500 pts)
+	resp := llPost(tc, "/v2/customers/cust-002/claimed_rewards", map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}, authAlpha)
+	resp.AssertStatus(422)
+	resp.AssertBodyContains("insufficient_points")
+}
+
+func TestRedemptionReversal(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Jamie claims $5 Off
+	resp := llPost(tc, "/v2/customers/cust-003/claimed_rewards", map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}, authAlpha)
+	resp.AssertStatus(201)
+	claimed := resp.JSONMap()["claimed_reward"].(map[string]any)
+	claimID := claimed["id"].(float64)
+
+	// Check points after claim
+	resp = llGet(tc, "/v2/customers/cust-003/points", authAlpha)
+	afterClaim := resp.JSONMap()
+	approvedAfterClaim := afterClaim["points_approved"].(float64)
+
+	// Refund
+	resp = llPost(tc, fmt.Sprintf("/v2/customers/cust-003/claimed_rewards/%d/refund", int(claimID)), nil, authAlpha)
+	resp.AssertStatus(200)
+	refunded := resp.JSONMap()["claimed_reward"].(map[string]any)
+	if refunded["refunded"] != true {
+		t.Error("expected refunded=true")
+	}
+
+	// Verify points restored
+	resp = llGet(tc, "/v2/customers/cust-003/points", authAlpha)
+	afterRefund := resp.JSONMap()
+	if afterRefund["points_approved"].(float64) != approvedAfterClaim+500 {
+		t.Errorf("expected points restored after refund, got %v", afterRefund["points_approved"])
+	}
+}
+
+func TestClaimRewardIdempotency(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	body := map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}
+
+	// First claim
+	resp1 := llPost(tc, "/v2/customers/cust-003/claimed_rewards", body, authAlpha)
+	resp1.AssertStatus(201)
+	claimed1 := resp1.JSONMap()["claimed_reward"].(map[string]any)
+
+	// Second identical claim within 60s window — should return same result
+	resp2 := llPost(tc, "/v2/customers/cust-003/claimed_rewards", body, authAlpha)
+	resp2.AssertStatus(200)
+	claimed2 := resp2.JSONMap()["claimed_reward"].(map[string]any)
+
+	if claimed1["id"] != claimed2["id"] {
+		t.Errorf("expected idempotent response with same ID, got %v and %v", claimed1["id"], claimed2["id"])
+	}
+
+	// Verify points were only debited once
+	resp := llGet(tc, "/v2/customers/cust-003/points", authAlpha)
+	points := resp.JSONMap()
+	// Jamie started with 15000, claimed 500 once
+	if points["points_approved"] != float64(14500) {
+		t.Errorf("expected 14500 (single debit), got %v", points["points_approved"])
+	}
+}
+
+func TestDiscountCodeUniqueness(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	codes := make(map[string]bool)
+	for i := 0; i < 5; i++ {
+		// Claim different rewards to avoid idempotency
+		rewardID := (i % 4) + 1
+		resp := llPost(tc, "/v2/customers/cust-003/claimed_rewards", map[string]any{
+			"reward_id":  rewardID,
+			"multiplier": i + 1, // Different multiplier to avoid idempotency
+		}, authAlpha)
+		if resp.StatusCode == 201 {
+			claimed := resp.JSONMap()["claimed_reward"].(map[string]any)
+			code := claimed["redeemable"].(map[string]any)["code"].(string)
+			if codes[code] {
+				t.Errorf("duplicate discount code: %s", code)
+			}
+			codes[code] = true
+		}
+	}
+}
+
+// --- Multi-Merchant Isolation Tests ---
+
+func TestMultiMerchantIsolation(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Same email, different merchants
+	respA := llGet(tc, "/v2/customers?email=sarah@example.com", authAlpha)
+	respA.AssertStatus(200)
+	customersA := respA.JSONMap()["customers"].([]any)
+
+	respB := llGet(tc, "/v2/customers?email=sarah@example.com", authBeta)
+	respB.AssertStatus(200)
+	customersB := respB.JSONMap()["customers"].([]any)
+
+	if len(customersA) != 1 || len(customersB) != 1 {
+		t.Fatalf("expected 1 customer each, got A=%d B=%d", len(customersA), len(customersB))
+	}
+
+	sarahA := customersA[0].(map[string]any)
+	sarahB := customersB[0].(map[string]any)
+
+	// Different IDs
+	if sarahA["id"] == sarahB["id"] {
+		t.Error("expected different customer IDs across merchants")
+	}
+
+	// Different points
+	if sarahA["points_approved"] == sarahB["points_approved"] {
+		t.Error("expected different points across merchants")
+	}
+
+	// Different merchant_ids
+	if sarahA["merchant_id"] == sarahB["merchant_id"] {
+		t.Error("expected different merchant_ids")
+	}
+}
+
+func TestMerchantCantSeeOtherMerchantCustomers(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+
+	// Morgan only exists in merchant B
+	resp := llGet(tc, "/v2/customers?email=morgan@example.com", authAlpha)
+	resp.AssertStatus(200)
+	customers := resp.JSONMap()["customers"].([]any)
+	if len(customers) != 0 {
+		t.Errorf("expected 0 customers for morgan in merchant A, got %d", len(customers))
+	}
+
+	// But visible in merchant B
+	resp = llGet(tc, "/v2/customers?email=morgan@example.com", authBeta)
+	resp.AssertStatus(200)
+	customers = resp.JSONMap()["customers"].([]any)
+	if len(customers) != 1 {
+		t.Errorf("expected 1 customer for morgan in merchant B, got %d", len(customers))
+	}
+}
+
+// --- Points Expiration Test ---
+
+func TestPointsExpiration(t *testing.T) {
+	tc, ac, _ := setupLoyaltyLion(t)
+
+	// Sarah has 4200 approved with 500 expiring in 30 days
+	resp := llGet(tc, "/v2/customers/cust-001/points", authAlpha)
+	resp.AssertStatus(200)
+	before := resp.JSONMap()
+	if before["points_approved"] != float64(4200) {
+		t.Fatalf("expected 4200 before expiration, got %v", before["points_approved"])
+	}
+
+	// Advance clock past 30 days
+	ac.AdvanceTime("744h").AssertStatus(200) // 31 days
+
+	// Check balance again — expired points should be moved
+	resp = llGet(tc, "/v2/customers/cust-001/points", authAlpha)
+	resp.AssertStatus(200)
+	after := resp.JSONMap()
+	if after["points_approved"] != float64(3700) {
+		t.Errorf("expected 3700 approved after expiration of 500, got %v", after["points_approved"])
+	}
+	if after["points_expired"] != float64(500) {
+		t.Errorf("expected 500 expired, got %v", after["points_expired"])
+	}
+}
+
+// --- Fault Injection Tests ---
+
+func TestFaultInjectionRedemptionUnavailable(t *testing.T) {
+	tc, _, mw := setupLoyaltyLion(t)
+
+	// Inject fault on the exact claimed_rewards path via middleware directly
+	claimPath := "/v2/customers/cust-003/claimed_rewards"
+	mw.Faults.Set(claimPath, twincore.FaultConfig{
+		StatusCode: 503,
+		Body:       `{"error": "service_unavailable"}`,
+		Rate:       1.0,
+	})
+
+	// Balance check should still work (different path)
+	resp := llGet(tc, "/v2/customers/cust-003/points", authAlpha)
+	resp.AssertStatus(200)
+
+	// But claiming should fail
+	resp = llPost(tc, claimPath, map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}, authAlpha)
+	resp.AssertStatus(503)
+
+	// Remove fault
+	mw.Faults.Remove(claimPath)
+
+	// Now claim should work
+	resp = llPost(tc, claimPath, map[string]any{
+		"reward_id":  1,
+		"multiplier": 1,
+	}, authAlpha)
+	resp.AssertStatus(201)
+}
+
+// --- Rate Limit Headers Test ---
+
+func TestRateLimitHeaders(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llGet(tc, "/v2/customers", authAlpha)
+	resp.AssertStatus(200)
+
+	limit := resp.Headers.Get("X-RateLimit-Limit")
+	remaining := resp.Headers.Get("X-RateLimit-Remaining")
+
+	if limit != "20" {
+		t.Errorf("expected X-RateLimit-Limit=20, got %s", limit)
+	}
+	if remaining == "" {
+		t.Error("expected X-RateLimit-Remaining header")
+	}
+}
+
+// --- Activities Test ---
+
+func TestRecordActivity(t *testing.T) {
+	tc, _, _ := setupLoyaltyLion(t)
+	resp := llPost(tc, "/v2/activities", map[string]any{
+		"name":        "purchase",
+		"merchant_id": "cust-001",
+		"properties": map[string]string{
+			"order_id": "ORD-123",
+			"total":    "110.57",
+			"currency": "USD",
+		},
+	}, authAlpha)
+	resp.AssertStatus(201)
+
+	m := resp.JSONMap()
+	if m["name"] != "purchase" {
+		t.Errorf("expected name=purchase, got %v", m["name"])
+	}
+}
+
+// --- Admin Tests ---
+
+func TestAdminHealth(t *testing.T) {
+	_, ac, _ := setupLoyaltyLion(t)
+	ac.Health().AssertStatus(200)
+}
+
+func TestAdminReset(t *testing.T) {
+	tc, ac, _ := setupLoyaltyLion(t)
+
+	// Create a new customer
+	llPost(tc, "/v2/customers", map[string]any{
+		"merchant_id": "temp-001",
+		"email":       "temp@example.com",
+	}, authAlpha)
+
+	// Reset
+	ac.Reset().AssertStatus(200)
+
+	// Should be back to fixtures (3 customers for alpha)
+	resp := llGet(tc, "/v2/customers", authAlpha)
+	resp.AssertStatus(200)
+	customers := resp.JSONMap()["customers"].([]any)
+	if len(customers) != 3 {
+		t.Errorf("expected 3 customers after reset, got %d", len(customers))
+	}
+}
+
+func TestAdminGetState(t *testing.T) {
+	_, ac, _ := setupLoyaltyLion(t)
+	resp := ac.GetState()
+	resp.AssertStatus(200)
+
+	m := resp.JSONMap()
+	if m["merchants"] == nil {
+		t.Error("expected merchants in state")
+	}
+	if m["customers"] == nil {
+		t.Error("expected customers in state")
+	}
+}
+
+func TestAdminLoadState(t *testing.T) {
+	tc, ac, _ := setupLoyaltyLion(t)
+
+	// Load custom state with only one merchant/customer
+	state := map[string]any{
+		"merchants": map[string]any{
+			"custom_key": map[string]any{
+				"api_key":    "custom_key",
+				"api_secret": "custom_secret",
+				"name":       "Custom Store",
+			},
+		},
+		"customers": map[string]any{
+			"100": map[string]any{
+				"id":              100,
+				"merchant_id":     "c-100",
+				"email":           "custom@example.com",
+				"points_approved": 9999,
+				"points_pending":  0,
+				"points_spent":    0,
+				"points_expired":  0,
+				"created_at":      "2026-01-01T00:00:00Z",
+				"updated_at":      "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+	ac.LoadState(state).AssertStatus(200)
+
+	// Original auth should fail
+	resp := llGet(tc, "/v2/customers", authAlpha)
+	resp.AssertStatus(401)
+
+	// Custom auth should work
+	customAuth := map[string]string{
+		"Authorization": basicAuth("custom_key", "custom_secret"),
+	}
+	resp = llGet(tc, "/v2/customers?email=custom@example.com", customAuth)
+	resp.AssertStatus(200)
+}

--- a/twin-loyaltylion/internal/api/router.go
+++ b/twin-loyaltylion/internal/api/router.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-loyaltylion/internal/store"
+)
+
+type contextKey string
+
+const merchantAPIKeyCtxKey contextKey = "merchant_api_key"
+
+// Handler holds all API handler state.
+type Handler struct {
+	store *store.MemoryStore
+	mw    *twincore.Middleware
+
+	// Rate limit tracking per API key
+	rateMu       sync.Mutex
+	rateCounters map[string]*rateCounter
+}
+
+type rateCounter struct {
+	count     int
+	windowEnd time.Time
+}
+
+// NewHandler creates a new API handler.
+func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
+	return &Handler{
+		store:        s,
+		mw:           mw,
+		rateCounters: make(map[string]*rateCounter),
+	}
+}
+
+// Routes mounts the API endpoints.
+func (h *Handler) Routes(r chi.Router) {
+	r.Route("/v2", func(r chi.Router) {
+		r.Use(h.authMiddleware)
+		r.Use(h.rateLimitHeaders)
+		r.Use(h.mw.FaultInjection)
+
+		// Customers
+		r.Get("/customers", h.ListCustomers)
+		r.Post("/customers", h.CreateCustomer)
+		r.Get("/customers/{id}", h.GetCustomer)
+
+		// Points (by merchant_id)
+		r.Get("/customers/{merchant_id}/points", h.GetPoints)
+		r.Post("/customers/{merchant_id}/points", h.AddPoints)
+		r.Post("/customers/{merchant_id}/points/remove", h.RemovePoints)
+
+		// Rewards & Redemptions (by merchant_id)
+		r.Get("/customers/{merchant_id}/available_rewards", h.ListAvailableRewards)
+		r.Post("/customers/{merchant_id}/claimed_rewards", h.ClaimReward)
+		r.Post("/customers/{merchant_id}/claimed_rewards/{id}/refund", h.RefundClaimedReward)
+
+		// Activities
+		r.Post("/activities", h.RecordActivity)
+	})
+}
+
+// authMiddleware validates Basic auth and maps API key to merchant.
+func (h *Handler) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			twincore.Error(w, http.StatusUnauthorized, "missing authorization header")
+			return
+		}
+
+		if !strings.HasPrefix(auth, "Basic ") {
+			twincore.Error(w, http.StatusUnauthorized, "invalid authorization format")
+			return
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+		if err != nil {
+			twincore.Error(w, http.StatusUnauthorized, "invalid base64 encoding")
+			return
+		}
+
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			twincore.Error(w, http.StatusUnauthorized, "invalid credentials format")
+			return
+		}
+
+		apiKey := parts[0]
+		apiSecret := parts[1]
+
+		merchant, ok := h.store.GetMerchantByAPIKey(apiKey)
+		if !ok {
+			twincore.Error(w, http.StatusUnauthorized, "invalid API key")
+			return
+		}
+
+		if merchant.APISecret != apiSecret {
+			twincore.Error(w, http.StatusUnauthorized, "invalid API secret")
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), merchantAPIKeyCtxKey, apiKey)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// getAPIKey extracts the authenticated merchant's API key from context.
+func getAPIKey(r *http.Request) string {
+	return r.Context().Value(merchantAPIKeyCtxKey).(string)
+}
+
+// rateLimitHeaders adds X-RateLimit-* headers to responses.
+func (h *Handler) rateLimitHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := getAPIKey(r)
+		now := time.Now()
+
+		h.rateMu.Lock()
+		rc, ok := h.rateCounters[apiKey]
+		if !ok || now.After(rc.windowEnd) {
+			rc = &rateCounter{count: 0, windowEnd: now.Add(time.Second)}
+			h.rateCounters[apiKey] = rc
+		}
+		rc.count++
+		remaining := 20 - rc.count
+		if remaining < 0 {
+			remaining = 0
+		}
+		h.rateMu.Unlock()
+
+		w.Header().Set("X-RateLimit-Limit", "20")
+		w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", remaining))
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/twin-loyaltylion/internal/store/memory.go
+++ b/twin-loyaltylion/internal/store/memory.go
@@ -1,0 +1,375 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	pkgstore "github.com/wondertwin-ai/wondertwin/twinkit/store"
+)
+
+// MemoryStore holds all twin state in memory.
+type MemoryStore struct {
+	Merchants      *pkgstore.Store[Merchant]
+	Customers      *pkgstore.Store[Customer]
+	Transactions   *pkgstore.Store[PointsTransaction]
+	Rewards        *pkgstore.Store[Reward]
+	ClaimedRewards *pkgstore.Store[ClaimedReward]
+	Activities     *pkgstore.Store[Activity]
+	ExpiringPoints *pkgstore.Store[ExpiringPoints]
+	Clock          *pkgstore.Clock
+
+	customerCounter      atomic.Int64
+	transactionCounter   atomic.Int64
+	rewardCounter        atomic.Int64
+	claimedRewardCounter atomic.Int64
+	activityCounter      atomic.Int64
+	expiringCounter      atomic.Int64
+}
+
+// New creates a new MemoryStore.
+func New() *MemoryStore {
+	return &MemoryStore{
+		Merchants:      pkgstore.New[Merchant]("merchant"),
+		Customers:      pkgstore.New[Customer]("cust"),
+		Transactions:   pkgstore.New[PointsTransaction]("txn"),
+		Rewards:        pkgstore.New[Reward]("reward"),
+		ClaimedRewards: pkgstore.New[ClaimedReward]("claim"),
+		Activities:     pkgstore.New[Activity]("act"),
+		ExpiringPoints: pkgstore.New[ExpiringPoints]("exp"),
+		Clock:          pkgstore.NewClock(),
+	}
+}
+
+// NextCustomerID returns the next auto-increment customer ID.
+func (s *MemoryStore) NextCustomerID() int {
+	return int(s.customerCounter.Add(1))
+}
+
+// NextTransactionID returns the next auto-increment transaction ID.
+func (s *MemoryStore) NextTransactionID() int {
+	return int(s.transactionCounter.Add(1))
+}
+
+// NextRewardID returns the next auto-increment reward ID.
+func (s *MemoryStore) NextRewardID() int {
+	return int(s.rewardCounter.Add(1))
+}
+
+// NextClaimedRewardID returns the next auto-increment claimed reward ID.
+func (s *MemoryStore) NextClaimedRewardID() int {
+	return int(s.claimedRewardCounter.Add(1))
+}
+
+// NextActivityID returns the next auto-increment activity ID.
+func (s *MemoryStore) NextActivityID() int {
+	return int(s.activityCounter.Add(1))
+}
+
+// NextExpiringID returns the next auto-increment expiring points ID.
+func (s *MemoryStore) NextExpiringID() int {
+	return int(s.expiringCounter.Add(1))
+}
+
+// CustomerKey returns the store key for a customer ID.
+func CustomerKey(id int) string {
+	return fmt.Sprintf("%d", id)
+}
+
+// RewardKey returns the store key for a reward ID.
+func RewardKey(id int) string {
+	return fmt.Sprintf("%d", id)
+}
+
+// ClaimedRewardKey returns the store key for a claimed reward ID.
+func ClaimedRewardKey(id int) string {
+	return fmt.Sprintf("%d", id)
+}
+
+// GetMerchantByAPIKey returns the merchant for a given API key.
+func (s *MemoryStore) GetMerchantByAPIKey(apiKey string) (Merchant, bool) {
+	return s.Merchants.Get(apiKey)
+}
+
+// GetCustomersByMerchant returns all customers for a given merchant API key.
+func (s *MemoryStore) GetCustomersByMerchant(apiKey string) []Customer {
+	return s.Customers.Filter(func(_ string, c Customer) bool {
+		return c.APIKey == apiKey
+	})
+}
+
+// GetCustomerByEmail returns a customer by email scoped to a merchant.
+func (s *MemoryStore) GetCustomerByEmail(apiKey, email string) *Customer {
+	items := s.Customers.Filter(func(_ string, c Customer) bool {
+		return c.APIKey == apiKey && c.Email == email
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return &items[0]
+}
+
+// GetCustomerByMerchantID returns a customer by their merchant_id scoped to a merchant.
+func (s *MemoryStore) GetCustomerByMerchantID(apiKey, merchantID string) *Customer {
+	items := s.Customers.Filter(func(_ string, c Customer) bool {
+		return c.APIKey == apiKey && c.MerchantID == merchantID
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return &items[0]
+}
+
+// GetRewardsByMerchant returns all rewards for a merchant.
+func (s *MemoryStore) GetRewardsByMerchant(apiKey string) []Reward {
+	return s.Rewards.Filter(func(_ string, r Reward) bool {
+		return r.APIKey == apiKey
+	})
+}
+
+// GetClaimedRewardsByCustomer returns all claimed rewards for a customer.
+func (s *MemoryStore) GetClaimedRewardsByCustomer(customerID int, apiKey string) []ClaimedReward {
+	return s.ClaimedRewards.Filter(func(_ string, cr ClaimedReward) bool {
+		return cr.CustomerID == customerID && cr.APIKey == apiKey
+	})
+}
+
+// FindIdempotentClaim checks for a recent identical claim (same customer, reward_id, multiplier within 60s).
+func (s *MemoryStore) FindIdempotentClaim(customerID, rewardID, multiplier int, apiKey string, now time.Time) *ClaimedReward {
+	items := s.ClaimedRewards.Filter(func(_ string, cr ClaimedReward) bool {
+		if cr.CustomerID != customerID || cr.RewardID != rewardID || cr.Multiplier != multiplier || cr.APIKey != apiKey || cr.Refunded {
+			return false
+		}
+		t, err := time.Parse(time.RFC3339, cr.CreatedAt)
+		if err != nil {
+			return false
+		}
+		return now.Sub(t) < 60*time.Second
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return &items[0]
+}
+
+// ProcessExpiredPoints checks all expiring points and transitions expired ones.
+func (s *MemoryStore) ProcessExpiredPoints(now time.Time) {
+	ids, items := s.ExpiringPoints.FilterWithIDs(func(_ string, ep ExpiringPoints) bool {
+		if ep.Expired || ep.Amount <= 0 {
+			return false
+		}
+		t, err := time.Parse(time.RFC3339, ep.ExpiresAt)
+		if err != nil {
+			return false
+		}
+		return now.After(t)
+	})
+
+	for i, ep := range items {
+		// Mark as expired
+		ep.Expired = true
+		s.ExpiringPoints.Set(ids[i], ep)
+
+		// Update customer balance
+		c, ok := s.Customers.Get(CustomerKey(ep.CustomerID))
+		if !ok {
+			continue
+		}
+		expired := ep.Amount
+		if expired > c.PointsApproved {
+			expired = c.PointsApproved
+		}
+		c.PointsApproved -= expired
+		c.PointsExpired += expired
+		c.UpdatedAt = now.Format(time.RFC3339)
+		s.Customers.Set(CustomerKey(c.ID), c)
+
+		// Record transaction
+		txnID := s.NextTransactionID()
+		s.Transactions.Set(fmt.Sprintf("%d", txnID), PointsTransaction{
+			ID:         txnID,
+			CustomerID: ep.CustomerID,
+			Type:       "expire",
+			Amount:     expired,
+			Reason:     "Points expired",
+			Timestamp:  now.Format(time.RFC3339),
+			APIKey:     ep.APIKey,
+		})
+	}
+}
+
+type stateSnapshot struct {
+	Merchants      map[string]Merchant         `json:"merchants"`
+	Customers      map[string]Customer         `json:"customers"`
+	Transactions   map[string]PointsTransaction `json:"transactions"`
+	Rewards        map[string]Reward           `json:"rewards"`
+	ClaimedRewards map[string]ClaimedReward    `json:"claimed_rewards"`
+	Activities     map[string]Activity         `json:"activities"`
+	ExpiringPoints map[string]ExpiringPoints   `json:"expiring_points"`
+}
+
+// Snapshot returns full state as JSON-serializable value.
+func (s *MemoryStore) Snapshot() any {
+	return stateSnapshot{
+		Merchants:      s.Merchants.Snapshot(),
+		Customers:      s.Customers.Snapshot(),
+		Transactions:   s.Transactions.Snapshot(),
+		Rewards:        s.Rewards.Snapshot(),
+		ClaimedRewards: s.ClaimedRewards.Snapshot(),
+		Activities:     s.Activities.Snapshot(),
+		ExpiringPoints: s.ExpiringPoints.Snapshot(),
+	}
+}
+
+// LoadState loads state from JSON.
+func (s *MemoryStore) LoadState(data []byte) error {
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	if snap.Merchants != nil {
+		s.Merchants.LoadSnapshot(snap.Merchants)
+	}
+	if snap.Customers != nil {
+		s.Customers.LoadSnapshot(snap.Customers)
+	}
+	if snap.Transactions != nil {
+		s.Transactions.LoadSnapshot(snap.Transactions)
+	}
+	if snap.Rewards != nil {
+		s.Rewards.LoadSnapshot(snap.Rewards)
+	}
+	if snap.ClaimedRewards != nil {
+		s.ClaimedRewards.LoadSnapshot(snap.ClaimedRewards)
+	}
+	if snap.Activities != nil {
+		s.Activities.LoadSnapshot(snap.Activities)
+	}
+	if snap.ExpiringPoints != nil {
+		s.ExpiringPoints.LoadSnapshot(snap.ExpiringPoints)
+	}
+	return nil
+}
+
+// Reset clears all state and reloads seed fixtures.
+func (s *MemoryStore) Reset() {
+	s.Merchants.Reset()
+	s.Customers.Reset()
+	s.Transactions.Reset()
+	s.Rewards.Reset()
+	s.ClaimedRewards.Reset()
+	s.Activities.Reset()
+	s.ExpiringPoints.Reset()
+	s.Clock.Reset()
+	s.customerCounter.Store(0)
+	s.transactionCounter.Store(0)
+	s.rewardCounter.Store(0)
+	s.claimedRewardCounter.Store(0)
+	s.activityCounter.Store(0)
+	s.expiringCounter.Store(0)
+	s.SeedDefaults()
+}
+
+// SeedDefaults populates the store with default fixture data.
+func (s *MemoryStore) SeedDefaults() {
+	now := s.Clock.Now()
+	thirtyDaysLater := now.Add(30 * 24 * time.Hour).Format(time.RFC3339)
+	ts := now.Format(time.RFC3339)
+
+	// Merchant A
+	s.Merchants.Set("ll_test_key_alpha", Merchant{
+		APIKey:    "ll_test_key_alpha",
+		APISecret: "ll_test_secret_alpha",
+		Name:      "Alpha Store",
+	})
+
+	// Merchant B
+	s.Merchants.Set("ll_test_key_beta", Merchant{
+		APIKey:    "ll_test_key_beta",
+		APISecret: "ll_test_secret_beta",
+		Name:      "Beta Store",
+	})
+
+	// --- Merchant A Customers ---
+	sarahID := s.NextCustomerID()
+	s.Customers.Set(CustomerKey(sarahID), Customer{
+		ID: sarahID, MerchantID: "cust-001", Email: "sarah@example.com",
+		PointsApproved: 4200, PointsPending: 100, PointsSpent: 3500, PointsExpired: 0,
+		CreatedAt: ts, UpdatedAt: ts, APIKey: "ll_test_key_alpha",
+	})
+
+	// Sarah has 500 points expiring in 30 days
+	expID := s.NextExpiringID()
+	s.ExpiringPoints.Set(fmt.Sprintf("%d", expID), ExpiringPoints{
+		ID: expID, CustomerID: sarahID, Amount: 500,
+		ExpiresAt: thirtyDaysLater, Expired: false, APIKey: "ll_test_key_alpha",
+	})
+
+	alexID := s.NextCustomerID()
+	s.Customers.Set(CustomerKey(alexID), Customer{
+		ID: alexID, MerchantID: "cust-002", Email: "alex@example.com",
+		PointsApproved: 0, PointsPending: 0, PointsSpent: 1000, PointsExpired: 0,
+		CreatedAt: ts, UpdatedAt: ts, APIKey: "ll_test_key_alpha",
+	})
+
+	jamieID := s.NextCustomerID()
+	s.Customers.Set(CustomerKey(jamieID), Customer{
+		ID: jamieID, MerchantID: "cust-003", Email: "jamie@example.com",
+		PointsApproved: 15000, PointsPending: 500, PointsSpent: 2000, PointsExpired: 0,
+		CreatedAt: ts, UpdatedAt: ts, APIKey: "ll_test_key_alpha",
+	})
+
+	// --- Merchant A Rewards ---
+	for _, r := range []struct {
+		title          string
+		cost           int
+		discountType   string
+		discountAmount int
+	}{
+		{"$5 Off", 500, "flat", 5},
+		{"$10 Off", 1000, "flat", 10},
+		{"$25 Off", 2500, "flat", 25},
+		{"Free Shipping", 750, "flat", 0},
+	} {
+		id := s.NextRewardID()
+		s.Rewards.Set(RewardKey(id), Reward{
+			ID: id, Title: r.title, PointCost: r.cost,
+			DiscountType: r.discountType, DiscountAmount: r.discountAmount,
+			APIKey: "ll_test_key_alpha",
+		})
+	}
+
+	// --- Merchant B Customers ---
+	sarahBID := s.NextCustomerID()
+	s.Customers.Set(CustomerKey(sarahBID), Customer{
+		ID: sarahBID, MerchantID: "sw-sarah-001", Email: "sarah@example.com",
+		PointsApproved: 1000, PointsPending: 0, PointsSpent: 0, PointsExpired: 0,
+		CreatedAt: ts, UpdatedAt: ts, APIKey: "ll_test_key_beta",
+	})
+
+	morganID := s.NextCustomerID()
+	s.Customers.Set(CustomerKey(morganID), Customer{
+		ID: morganID, MerchantID: "sw-morgan-001", Email: "morgan@example.com",
+		PointsApproved: 8000, PointsPending: 200, PointsSpent: 0, PointsExpired: 0,
+		CreatedAt: ts, UpdatedAt: ts, APIKey: "ll_test_key_beta",
+	})
+
+	// --- Merchant B Rewards ---
+	for _, r := range []struct {
+		title          string
+		cost           int
+		discountType   string
+		discountAmount int
+	}{
+		{"$10 Off", 1000, "flat", 10},
+		{"$50 Off", 5000, "flat", 50},
+	} {
+		id := s.NextRewardID()
+		s.Rewards.Set(RewardKey(id), Reward{
+			ID: id, Title: r.title, PointCost: r.cost,
+			DiscountType: r.discountType, DiscountAmount: r.discountAmount,
+			APIKey: "ll_test_key_beta",
+		})
+	}
+}

--- a/twin-loyaltylion/internal/store/types.go
+++ b/twin-loyaltylion/internal/store/types.go
@@ -1,0 +1,86 @@
+package store
+
+// Merchant represents a LoyaltyLion merchant identified by API credentials.
+type Merchant struct {
+	APIKey    string            `json:"api_key"`
+	APISecret string            `json:"api_secret"`
+	Name      string            `json:"name"`
+	Settings  map[string]string `json:"settings,omitempty"`
+}
+
+// Customer represents a loyalty program customer scoped to a merchant.
+type Customer struct {
+	ID             int               `json:"id"`
+	MerchantID     string            `json:"merchant_id"`
+	Email          string            `json:"email"`
+	PointsApproved int               `json:"points_approved"`
+	PointsPending  int               `json:"points_pending"`
+	PointsSpent    int               `json:"points_spent"`
+	PointsExpired  int               `json:"points_expired"`
+	Properties     map[string]string `json:"properties,omitempty"`
+	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at"`
+	// APIKey is the owning merchant's API key (used for scoping, not serialized to API responses).
+	APIKey string `json:"-"`
+}
+
+// PointsTransaction records a single points state change.
+type PointsTransaction struct {
+	ID         int    `json:"id"`
+	CustomerID int    `json:"customer_id"`
+	Type       string `json:"type"` // earn, spend, adjust, expire
+	Amount     int    `json:"amount"`
+	Reason     string `json:"reason"`
+	Timestamp  string `json:"timestamp"`
+	APIKey     string `json:"-"`
+}
+
+// Reward represents a redeemable reward in a merchant's catalog.
+type Reward struct {
+	ID             int    `json:"id"`
+	Title          string `json:"title"`
+	PointCost      int    `json:"point_cost"`
+	DiscountType   string `json:"discount_type"`   // flat, percentage
+	DiscountAmount int    `json:"discount_amount"`
+	APIKey         string `json:"-"`
+}
+
+// ClaimedReward represents a customer's reward redemption.
+type ClaimedReward struct {
+	ID        int        `json:"id"`
+	RewardID  int        `json:"reward_id"`
+	PointCost int        `json:"point_cost"`
+	Redeemable Redeemable `json:"redeemable"`
+	Refunded  bool       `json:"refunded"`
+	CreatedAt string     `json:"created_at"`
+	// Internal fields
+	CustomerID int    `json:"-"`
+	APIKey     string `json:"-"`
+	Multiplier int    `json:"-"`
+}
+
+// Redeemable holds the generated discount code for a claimed reward.
+type Redeemable struct {
+	Code      string `json:"code"`
+	Fulfilled bool   `json:"fulfilled"`
+}
+
+// Activity represents a recorded customer activity.
+type Activity struct {
+	ID         int               `json:"id"`
+	Name       string            `json:"name"`
+	MerchantID string            `json:"merchant_id"` // customer's merchant_id
+	Properties map[string]string `json:"properties,omitempty"`
+	Timestamp  string            `json:"timestamp"`
+	APIKey     string            `json:"-"`
+}
+
+// ExpiringPoints tracks points with an expiration date for a customer.
+type ExpiringPoints struct {
+	ID         int    `json:"id"`
+	CustomerID int    `json:"customer_id"`
+	Amount     int    `json:"amount"`
+	ExpiresAt  string `json:"expires_at"`
+	Expired    bool   `json:"expired"`
+	APIKey     string `json:"-"`
+}

--- a/twin-loyaltylion/provenance.json
+++ b/twin-loyaltylion/provenance.json
@@ -1,0 +1,20 @@
+{
+  "twin": "loyaltylion",
+  "sdk_target": {
+    "package": "loyaltylion",
+    "language": "rest",
+    "version": "v2"
+  },
+  "build": 1,
+  "generated_at": "2026-02-19T00:00:00-08:00",
+  "sources": {
+    "openapi": {
+      "origin": "none",
+      "url": ""
+    },
+    "sdk_analysis": {
+      "method": "manual",
+      "repo": "https://developers.loyaltylion.com"
+    }
+  }
+}

--- a/twin-loyaltylion/twin-manifest.json
+++ b/twin-loyaltylion/twin-manifest.json
@@ -1,0 +1,52 @@
+{
+  "twin": "loyaltylion",
+  "display_name": "LoyaltyLion",
+  "category": "loyalty",
+  "description": "Simulates the LoyaltyLion REST API v2 for customer management, points operations, reward redemption, and activity recording with multi-merchant isolation.",
+  "sdk_target": {
+    "primary": {
+      "package": "loyaltylion",
+      "language": "rest",
+      "version": "v2",
+      "api_version": "v2",
+      "repo_url": "https://developers.loyaltylion.com",
+      "docs_url": "https://developers.loyaltylion.com/api"
+    },
+    "additional": []
+  },
+  "service_surface": {
+    "openapi_spec": {
+      "available": false,
+      "origin": "none",
+      "url": ""
+    },
+    "auth_pattern": "basic_auth",
+    "has_webhooks": false,
+    "resource_count": 6
+  },
+  "coverage": {
+    "resources_implemented": [
+      "customers",
+      "points",
+      "rewards",
+      "claimed_rewards",
+      "activities",
+      "merchants"
+    ],
+    "resources_not_implemented": [
+      "tiers",
+      "rules",
+      "webhooks",
+      "segments"
+    ],
+    "estimated_coverage_pct": 40
+  },
+  "generation": {
+    "method": "manual",
+    "sources_used": {
+      "deepwiki": false,
+      "openapi": false,
+      "manual_docs": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `twin-loyaltylion`, a behavioral simulation of the LoyaltyLion REST API v2 for loyalty program testing
- Implements customer management, points operations (add/remove/expiration), reward redemption with idempotency and discount code generation, activity recording, and multi-merchant isolation via Basic auth
- Includes 29 tests covering auth, CRUD, points lifecycle, redemption reversal, idempotency, multi-merchant isolation, clock-driven expiration, fault injection, rate limit headers, and admin control plane

## API Surface
| Resource | Endpoints |
|----------|-----------|
| Customers | `GET/POST /v2/customers`, `GET /v2/customers/{id}` |
| Points | `GET/POST /v2/customers/{merchant_id}/points`, `POST .../points/remove` |
| Rewards | `GET /v2/customers/{merchant_id}/available_rewards` |
| Redemptions | `POST /v2/customers/{merchant_id}/claimed_rewards`, `POST .../claimed_rewards/{id}/refund` |
| Activities | `POST /v2/activities` |
| Admin | Full `/admin/*` control plane via twinkit |

## Seed Fixtures
- **Merchant Alpha** (`ll_test_key_alpha`): 3 customers (Sarah 4200pts w/ 500 expiring, Alex 0pts, Jamie 15000pts), 4 rewards
- **Merchant Beta** (`ll_test_key_beta`): 2 customers (Sarah 1000pts, Morgan 8000pts), 2 rewards

## Test plan
- [x] `go build ./...` passes across full workspace
- [x] `go test ./...` passes (29/29 tests)
- [ ] Verify admin conformance with `wt conformance` (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)