### PR TITLE
feat(twin-clerk): /v1/jwks alias + custom user IDs for demo auth

### DIFF
--- a/twin-clerk/internal/api/handlers_users.go
+++ b/twin-clerk/internal/api/handlers_users.go
@@ -13,6 +13,10 @@ import (
 
 // createUserRequest is the JSON body for POST /v1/users.
 type createUserRequest struct {
+	// ID allows callers to set a specific user ID (twin-only extension).
+	// Real Clerk auto-generates IDs; this field enables test systems to
+	// align Clerk user IDs with their own identifiers (e.g. merchant UUIDs).
+	ID              string         `json:"id,omitempty"`
 	ExternalID      string         `json:"external_id,omitempty"`
 	EmailAddress    []string       `json:"email_address,omitempty"`
 	PhoneNumber     []string       `json:"phone_number,omitempty"`
@@ -46,7 +50,10 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := h.store.Users.NextID()
+	id := req.ID
+	if id == "" {
+		id = h.store.Users.NextID()
+	}
 	now := store.Now()
 
 	// Build email addresses

--- a/twin-clerk/internal/api/router.go
+++ b/twin-clerk/internal/api/router.go
@@ -26,6 +26,9 @@ func NewHandler(s *store.MemoryStore, mw *twincore.Middleware, jwtMgr *JWTManage
 func (h *Handler) Routes(r chi.Router) {
 	// Public endpoints (no auth required)
 	r.Get("/.well-known/jwks.json", h.GetJWKS)
+	// Alias: Clerk SDKs fetch JWKS from {apiUrl}/v1/jwks (Go SDK, @clerk/backend).
+	// Must be outside the auth-protected /v1 route group.
+	r.Get("/v1/jwks", h.GetJWKS)
 
 	// Clerk Frontend API (FAPI) — used by clerk-js browser SDK.
 	// These endpoints use cookie-based auth, not Bearer tokens.


### PR DESCRIPTION
## Summary
- Add `/v1/jwks` route alias (outside auth middleware) so Clerk SDKs can fetch JWKS from `{apiUrl}/v1/jwks`
- Support optional `id` field in `POST /v1/users` to let callers set specific user IDs — essential for aligning Clerk user IDs with external identifiers (e.g., merchant UUIDs in demo mode)
- Add tests for both features (43 total tests pass)

## Context
Part of the Clerk twin demo auth wiring. The merchant dashboard's `getMerchantId()` returns `userId` from Clerk's `auth()`, which is used directly in API URL paths. When running against the twin, seeded user IDs must match the merchant UUIDs in the database.

## Test plan
- [x] `TestJWKSV1Alias` — verifies `/v1/jwks` returns valid JWKS without auth
- [x] `TestCreateUserWithCustomID` — verifies custom ID is used and retrievable
- [x] All 43 existing tests pass