### PR TITLE
feat: add twin.json schema and CI schema validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - run: go vet ./...
       - run: go test ./... -count=1 -timeout 120s
 
+      - name: Validate twin schemas
+        run: go run ./cmd/validate-schemas/
+
       - name: Build wt CLI
         run: go build ./cmd/wt/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-twins build-all clean test vet goreleaser-check release-local verify-registry
+.PHONY: build build-twins build-all clean test vet goreleaser-check release-local verify-registry validate-schemas
 
 VERSION ?= dev
 GORELEASER ?= goreleaser
@@ -31,6 +31,9 @@ goreleaser-check: ## Validate Goreleaser config
 
 release-local: ## Build cross-platform release artifacts into dist/ using Goreleaser
 	$(GORELEASER) release --snapshot --clean
+
+validate-schemas: ## Validate all twin JSON files against their schemas
+	go run ./cmd/validate-schemas/
 
 verify-registry: ## Validate the live twin registry
 	go run ./cmd/verify-registry

--- a/cmd/validate-schemas/main.go
+++ b/cmd/validate-schemas/main.go
@@ -1,0 +1,120 @@
+// Command validate-schemas validates twin JSON files against their schemas.
+//
+// It discovers all twin-* directories and checks that twin.json,
+// twin-manifest.json, and provenance.json conform to the schemas
+// in the schemas/ directory.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+type schemaCheck struct {
+	file   string // filename to look for in each twin dir
+	schema string // schema filename in schemas/
+}
+
+var checks = []schemaCheck{
+	{"twin.json", "twin.schema.json"},
+	{"twin-manifest.json", "twin-manifest.schema.json"},
+	{"provenance.json", "provenance.schema.json"},
+}
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	schemasDir := filepath.Join(root, "schemas")
+
+	// Pre-compile all schemas.
+	compiled := make(map[string]*jsonschema.Schema, len(checks))
+	for _, c := range checks {
+		schemaPath := filepath.Join(schemasDir, c.schema)
+		sch, err := compileSchema(schemaPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: cannot compile schema %s: %v\n", c.schema, err)
+			os.Exit(1)
+		}
+		compiled[c.schema] = sch
+	}
+
+	// Discover twin directories.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: cannot read directory %s: %v\n", root, err)
+		os.Exit(1)
+	}
+
+	var twinDirs []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "twin-") {
+			twinDirs = append(twinDirs, e.Name())
+		}
+	}
+
+	if len(twinDirs) == 0 {
+		fmt.Fprintf(os.Stderr, "FAIL: no twin-* directories found in %s\n", root)
+		os.Exit(1)
+	}
+
+	var failures []string
+	validated := 0
+
+	for _, dir := range twinDirs {
+		for _, c := range checks {
+			filePath := filepath.Join(root, dir, c.file)
+
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					failures = append(failures, fmt.Sprintf("%s/%s: missing", dir, c.file))
+					continue
+				}
+				failures = append(failures, fmt.Sprintf("%s/%s: read error: %v", dir, c.file, err))
+				continue
+			}
+
+			var v any
+			if err := json.Unmarshal(data, &v); err != nil {
+				failures = append(failures, fmt.Sprintf("%s/%s: invalid JSON: %v", dir, c.file, err))
+				continue
+			}
+
+			if err := compiled[c.schema].Validate(v); err != nil {
+				failures = append(failures, fmt.Sprintf("%s/%s: %v", dir, c.file, err))
+				continue
+			}
+
+			validated++
+			fmt.Printf("  ok  %s/%s\n", dir, c.file)
+		}
+	}
+
+	fmt.Printf("\n%d files validated across %d twins\n", validated, len(twinDirs))
+
+	if len(failures) > 0 {
+		fmt.Printf("%d failures:\n", len(failures))
+		for _, f := range failures {
+			fmt.Printf("  FAIL  %s\n", f)
+		}
+		os.Exit(1)
+	}
+}
+
+func compileSchema(path string) (*jsonschema.Schema, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	c := jsonschema.NewCompiler()
+	return c.Compile("file://" + absPath)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/wondertwin-ai/wondertwin
 go 1.25.7
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/schemas/provenance.schema.json
+++ b/schemas/provenance.schema.json
@@ -53,7 +53,7 @@
           "properties": {
             "origin": {
               "type": "string",
-              "enum": ["vendor_published", "community_maintained", "derived", "manual", "unknown"],
+              "enum": ["vendor_published", "community_maintained", "derived", "manual", "none", "unknown"],
               "description": "Origin of the OpenAPI spec."
             },
             "url": {

--- a/schemas/twin-manifest.schema.json
+++ b/schemas/twin-manifest.schema.json
@@ -6,6 +6,12 @@
   "type": "object",
   "required": ["twin", "display_name", "category", "sdk_target", "service_surface", "coverage", "generation"],
   "properties": {
+    "tier": {
+      "type": "string",
+      "description": "Distribution tier for the twin.",
+      "enum": ["free", "paid"],
+      "default": "free"
+    },
     "twin": {
       "type": "string",
       "description": "Machine-readable twin identifier.",
@@ -52,6 +58,10 @@
             "docs_url": {
               "type": "string",
               "description": "Documentation URL for the SDK."
+            },
+            "api_version": {
+              "type": "string",
+              "description": "Version of the upstream API targeted."
             }
           },
           "additionalProperties": false

--- a/schemas/twin.schema.json
+++ b/schemas/twin.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wondertwin.dev/schemas/twin.schema.json",
+  "title": "Twin Configuration",
+  "description": "Schema for twin.json files that define a twin's identity, SDK target, and default port.",
+  "type": "object",
+  "required": ["name", "description", "category", "sdk", "default_port"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Machine-readable twin name, matching the directory suffix (twin-{name}).",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief description of what the twin simulates."
+    },
+    "category": {
+      "type": "string",
+      "description": "Service category (e.g., payments, email, analytics, loyalty, auth)."
+    },
+    "sdk": {
+      "type": "object",
+      "description": "Primary SDK or API this twin targets.",
+      "required": ["package", "version"],
+      "properties": {
+        "package": {
+          "type": "string",
+          "description": "SDK package name or API identifier."
+        },
+        "version": {
+          "type": "string",
+          "description": "SDK or API version targeted."
+        }
+      },
+      "additionalProperties": false
+    },
+    "default_port": {
+      "type": "integer",
+      "description": "Default port the twin listens on.",
+      "minimum": 1024,
+      "maximum": 65535
+    }
+  },
+  "additionalProperties": false
+}

--- a/twin-loyaltylion/twin-manifest.json
+++ b/twin-loyaltylion/twin-manifest.json
@@ -21,7 +21,7 @@
       "origin": "none",
       "url": ""
     },
-    "auth_pattern": "basic_auth",
+    "auth_pattern": "basic",
     "has_webhooks": false,
     "resource_count": 6
   },


### PR DESCRIPTION
## Summary

- Adds `schemas/twin.schema.json` — formal JSON Schema for the `twin.json` config files introduced in #71
- Adds `cmd/validate-schemas/` — Go tool that discovers all `twin-*` directories and validates `twin.json`, `twin-manifest.json`, and `provenance.json` against their schemas
- Adds schema validation step to CI pipeline (runs before build)
- Fixes schema gaps caught by the validator:
  - `twin-manifest.schema.json`: added `tier` field and `api_version` in `sdk_target.primary`
  - `provenance.schema.json`: added `"none"` to openapi origin enum
  - `twin-loyaltylion/twin-manifest.json`: fixed `basic_auth` → `basic`

21 files across 7 twins now validate cleanly.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make validate-schemas` validates all 21 files
- [x] CI runs validation before build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)