### PR TITLE
chore: gitignore and CONTRIBUTING cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 .wt/
 dist/
+wondertwin.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,13 @@ The fastest way to build a twin is with the twin generator skill and an AI codin
 
 The skill is designed to produce twins that conform to the standard structure and quality bar from the start.
 
+### Using the Twin Extender and Maintainer Skills
+
+Two additional skills support the twin lifecycle after initial creation:
+
+- **[`skills/twin-extender.md`](skills/twin-extender.md)** — Guides expanding an existing twin's SDK coverage: gap analysis, adding new store types, handlers, admin endpoints, and tests.
+- **[`skills/twin-maintainer.md`](skills/twin-maintainer.md)** — Covers ongoing maintenance tasks: CI twin list updates, dependency upgrades, SDK drift detection, conformance updates, coverage audits, and twin addition/removal.
+
 ### The Manifest and Provenance Files
 
 #### `twin-manifest.json`


### PR DESCRIPTION
## Summary

- Add `wondertwin.json` to `.gitignore` — it's the local workspace config file, shouldn't be tracked
- Link twin-extender and twin-maintainer skills from CONTRIBUTING.md so contributors can discover them
- Removed stale `bin/twin-clerk` binary locally (was never tracked, `bin/` is gitignored)

## Test plan
- [x] `wondertwin.json` no longer shows as untracked
- [x] Skill links resolve correctly in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)