### PR TITLE
feat: multi-format logo support and twin sidecar skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ Two additional skills support the twin lifecycle after initial creation:
 
 - **[`skills/twin-extender.md`](skills/twin-extender.md)** — Guides expanding an existing twin's SDK coverage: gap analysis, adding new store types, handlers, admin endpoints, and tests.
 - **[`skills/twin-maintainer.md`](skills/twin-maintainer.md)** — Covers ongoing maintenance tasks: CI twin list updates, dependency upgrades, SDK drift detection, conformance updates, coverage audits, and twin addition/removal.
+- **[`skills/twin-sidecar.md`](skills/twin-sidecar.md)** — Guides building optional companion processes that fetch real data from upstream APIs to enrich a twin's seed data.
 
 ### The Manifest and Provenance Files
 

--- a/skills/twin-sidecar.md
+++ b/skills/twin-sidecar.md
@@ -1,0 +1,183 @@
+# SKILL: WonderTwin Twin Sidecar
+
+## Purpose
+
+Build optional companion processes (sidecars) that enrich a twin with real-world data from the upstream service's API. Sidecars bridge the gap between fully deterministic twin behavior and production-realistic test data, while keeping the twin itself offline and stateless.
+
+A sidecar fetches data from the real API, transforms it into a seed file or pushes it via the admin API, and the twin serves it. The twin never calls the real service — the sidecar does.
+
+## When to Use
+
+- A twin needs realistic data that cannot be generated deterministically (e.g., real logos, product catalogs, email templates, feature flag configs)
+- Users want their test environment to mirror production state without manual seed file creation
+- The twin already supports `LoadState` / `--seed` but has no tooling to populate the seed
+
+## When NOT to Use
+
+- The twin's deterministic data is sufficient for testing (most twins don't need sidecars)
+- The real API requires paid access that users may not have
+- The data is static and can ship as a checked-in seed file
+
+## Design Principles
+
+1. **Sidecars are always optional.** The twin must work without the sidecar. Sidecars add realism, not functionality.
+2. **The twin stays offline.** Only the sidecar contacts the real API. The twin never makes outbound requests.
+3. **Users provide their own credentials.** The sidecar uses the user's API key for the real service. This avoids licensing issues with redistributing fetched data.
+4. **Output is a seed file.** The sidecar produces a JSON file compatible with the twin's `LoadState` format. Users can inspect, edit, and version-control the output.
+5. **Idempotent and cacheable.** Running the sidecar twice with the same input produces the same seed file. Include timestamps and checksums for cache invalidation.
+
+## Directory Structure
+
+Sidecars live in the twin's directory under `sidecar/`:
+
+```
+twin-{name}/
+├── cmd/twin-{name}/main.go
+├── internal/...
+├── sidecar/
+│   └── {function}/
+│       ├── main.go           # Entry point
+│       └── README.md         # Usage, required env vars, output format
+├── twin-manifest.json
+└── twin.json
+```
+
+Example for logodev:
+```
+twin-logodev/
+├── sidecar/
+│   └── fetch-logos/
+│       ├── main.go
+│       └── README.md
+```
+
+## Naming Convention
+
+- Directory: `sidecar/{function}/` (e.g., `fetch-logos`, `sync-flags`, `mirror-catalog`)
+- Binary: `sidecar-{twin}-{function}` (e.g., `sidecar-logodev-fetch-logos`)
+- The function name should describe what data the sidecar fetches, not what it does with it
+
+## Implementation Steps
+
+### 1. Define the Seed Format
+
+The sidecar's output must match the twin's `LoadState` snapshot format. Check the twin's `stateSnapshot` struct in `internal/store/memory.go` to understand what fields are expected.
+
+```go
+// Example: logodev seed format
+{
+  "custom_logos": {
+    "stripe.com": {
+      "content_type": "image/svg+xml",
+      "data": "<base64-encoded content>"
+    }
+  }
+}
+```
+
+### 2. Build the Fetcher
+
+The sidecar is a standalone Go binary that:
+- Reads configuration from environment variables (API keys, domain lists, etc.)
+- Calls the real service API
+- Transforms responses into the twin's seed format
+- Writes the seed file to stdout or a specified path
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+)
+
+func main() {
+    apiKey := os.Getenv("SERVICE_API_KEY")
+    if apiKey == "" {
+        fmt.Fprintf(os.Stderr, "SERVICE_API_KEY required\n")
+        os.Exit(1)
+    }
+
+    // Fetch from real API...
+    // Transform to seed format...
+    // Write to stdout for piping into twin
+    json.NewEncoder(os.Stdout).Encode(seed)
+}
+```
+
+### 3. Document Usage
+
+Every sidecar must have a `README.md` that covers:
+- What data it fetches
+- Required environment variables
+- Example usage
+- Output format description
+- Rate limiting / API quota considerations
+- Licensing notes (can the fetched data be redistributed?)
+
+### 4. Wire to the Twin
+
+Users can use the sidecar output in two ways:
+
+**Via seed file (startup):**
+```bash
+# Fetch and save
+sidecar-logodev-fetch-logos > logos-seed.json
+
+# Start twin with seed
+twin-logodev --seed logos-seed.json
+```
+
+**Via admin API (runtime):**
+```bash
+# Twin is already running
+sidecar-logodev-fetch-logos | curl -X POST http://localhost:4116/admin/state -d @-
+```
+
+### 5. Add to wondertwin.json (Optional)
+
+If the user wants the sidecar to run alongside the twin:
+```json
+{
+  "twins": {
+    "logodev": {
+      "binary": "./bin/twin-logodev",
+      "port": 4116,
+      "seed": "./seeds/logos.json"
+    }
+  }
+}
+```
+
+The sidecar runs separately to refresh the seed file. It is not managed by `wt up`.
+
+## Quality Checklist
+
+- [ ] **Sidecar is optional.** Twin works without it.
+- [ ] **No credentials in code.** API keys come from environment variables.
+- [ ] **Output matches LoadState format.** The seed file loads without errors.
+- [ ] **README documents everything.** Env vars, usage, output format, licensing.
+- [ ] **Idempotent.** Same input produces same output.
+- [ ] **Error handling.** Clear messages for missing credentials, rate limits, API errors.
+- [ ] **No fetched data is committed.** Seed files generated by sidecars are in `.gitignore` or documented as user-generated.
+
+## Common Sidecar Patterns
+
+| Pattern | Example | Description |
+|---------|---------|-------------|
+| **Asset fetcher** | Logo images, templates | Downloads binary or text assets and encodes them for the seed file |
+| **Config mirror** | Feature flags, settings | Fetches configuration state to replicate production behavior |
+| **Catalog sync** | Products, prices, plans | Mirrors a subset of a service's data catalog |
+| **Schema fetcher** | Webhook schemas, event types | Downloads schema definitions the twin needs to validate against |
+
+## Licensing Considerations
+
+Sidecars fetch data from real APIs. The fetched data may be subject to the service's terms of use. Key points to document in each sidecar's README:
+
+- Whether the service allows caching/storing API responses
+- Whether fetched data can be redistributed (usually no — users fetch their own)
+- Rate limits and API quota impact
+- Whether the sidecar requires a paid API tier
+
+The default assumption: **users fetch their own data with their own credentials.** Sidecars are tools, not data distributors.

--- a/twin-logodev/internal/api/handlers_test.go
+++ b/twin-logodev/internal/api/handlers_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -102,6 +103,75 @@ func TestGetLogoDifferentDomains(t *testing.T) {
 	// Different domains should produce different SVGs (different colors/initials)
 	if string(resp1.Body) == string(resp2.Body) {
 		t.Error("expected different SVGs for different domains")
+	}
+}
+
+// --- Custom Logo Tests ---
+
+func TestGetCustomLogoSVG(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	// Load a custom SVG logo via seed data
+	seed := json.RawMessage(`{"custom_logos":{"acme.com":{"content_type":"image/svg+xml","data":"PHN2Zz5hY21lPC9zdmc+"}}}`)
+	tc.Post("/admin/state", seed).AssertStatus(200)
+
+	resp := tc.Get("/acme.com?token=test")
+	resp.AssertStatus(200)
+
+	ct := resp.Headers.Get("Content-Type")
+	if ct != "image/svg+xml" {
+		t.Errorf("expected Content-Type=image/svg+xml, got %s", ct)
+	}
+	if string(resp.Body) != "<svg>acme</svg>" {
+		t.Errorf("expected custom SVG, got %s", string(resp.Body))
+	}
+}
+
+func TestGetCustomLogoPNG(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	// Load a custom PNG logo (fake PNG data for test)
+	seed := json.RawMessage(`{"custom_logos":{"img.com":{"content_type":"image/png","data":"iVBORw0KGgo="}}}`)
+	tc.Post("/admin/state", seed).AssertStatus(200)
+
+	resp := tc.Get("/img.com?token=test")
+	resp.AssertStatus(200)
+
+	ct := resp.Headers.Get("Content-Type")
+	if ct != "image/png" {
+		t.Errorf("expected Content-Type=image/png, got %s", ct)
+	}
+}
+
+func TestCustomLogoFallbackToPlaceholder(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	// Load custom logo for one domain
+	seed := json.RawMessage(`{"custom_logos":{"known.com":{"content_type":"image/svg+xml","data":"PHN2Zz48L3N2Zz4="}}}`)
+	tc.Post("/admin/state", seed).AssertStatus(200)
+
+	// Unknown domain should still get a placeholder
+	resp := tc.Get("/unknown.com?token=test")
+	resp.AssertStatus(200)
+	if !strings.Contains(string(resp.Body), "<svg") {
+		t.Error("expected placeholder SVG for unknown domain")
+	}
+}
+
+func TestCustomLogosResetOnReset(t *testing.T) {
+	_, tc := setupLogodev(t)
+
+	seed := json.RawMessage(`{"custom_logos":{"reset-test.com":{"content_type":"image/svg+xml","data":"PHN2Zz48L3N2Zz4="}}}`)
+	tc.Post("/admin/state", seed).AssertStatus(200)
+
+	tc.Post("/admin/reset", nil).AssertStatus(200)
+
+	// After reset, should get placeholder, not custom logo
+	resp := tc.Get("/reset-test.com?token=test")
+	resp.AssertStatus(200)
+	// Placeholder SVGs contain initials — custom one was just "<svg></svg>"
+	if !strings.Contains(string(resp.Body), "RE") {
+		t.Error("expected placeholder SVG with initials after reset")
 	}
 }
 

--- a/twin-logodev/internal/api/router.go
+++ b/twin-logodev/internal/api/router.go
@@ -57,9 +57,10 @@ func (h *Handler) GetLogo(w http.ResponseWriter, r *http.Request) {
 
 	// Check for custom logo
 	if custom, ok := h.store.CustomLogos[domain]; ok {
-		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Header().Set("Content-Type", custom.ContentType)
+		w.Header().Set("Cache-Control", "public, max-age=86400")
 		w.WriteHeader(http.StatusOK)
-		w.Write(custom)
+		w.Write(custom.Data)
 		return
 	}
 

--- a/twin-logodev/internal/store/memory.go
+++ b/twin-logodev/internal/store/memory.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"time"
 
@@ -9,9 +10,8 @@ import (
 
 // MemoryStore holds all logo twin state.
 type MemoryStore struct {
-	Requests *pkgstore.Store[LogoRequest]
-	// CustomLogos maps domain -> SVG content for specific test domains
-	CustomLogos map[string][]byte
+	Requests    *pkgstore.Store[LogoRequest]
+	CustomLogos map[string]CustomLogo
 	Clock       *pkgstore.Clock
 }
 
@@ -19,7 +19,7 @@ type MemoryStore struct {
 func New() *MemoryStore {
 	return &MemoryStore{
 		Requests:    pkgstore.New[LogoRequest]("logo"),
-		CustomLogos: make(map[string][]byte),
+		CustomLogos: make(map[string]CustomLogo),
 		Clock:       pkgstore.NewClock(),
 	}
 }
@@ -36,14 +36,27 @@ func (s *MemoryStore) RecordRequest(domain string, size int, format string, grey
 	})
 }
 
+type logoSnapshot struct {
+	ContentType string `json:"content_type"`
+	Data        string `json:"data"` // base64-encoded
+}
+
 type stateSnapshot struct {
-	Requests    map[string]LogoRequest `json:"requests"`
-	CustomLogos map[string]string      `json:"custom_logos,omitempty"` // domain -> base64 SVG
+	Requests    map[string]LogoRequest    `json:"requests"`
+	CustomLogos map[string]logoSnapshot   `json:"custom_logos,omitempty"`
 }
 
 func (s *MemoryStore) Snapshot() any {
+	logos := make(map[string]logoSnapshot, len(s.CustomLogos))
+	for domain, logo := range s.CustomLogos {
+		logos[domain] = logoSnapshot{
+			ContentType: logo.ContentType,
+			Data:        base64.StdEncoding.EncodeToString(logo.Data),
+		}
+	}
 	return stateSnapshot{
-		Requests: s.Requests.Snapshot(),
+		Requests:    s.Requests.Snapshot(),
+		CustomLogos: logos,
 	}
 }
 
@@ -53,11 +66,22 @@ func (s *MemoryStore) LoadState(data []byte) error {
 		return err
 	}
 	s.Requests.LoadSnapshot(snap.Requests)
+	for domain, logo := range snap.CustomLogos {
+		decoded, err := base64.StdEncoding.DecodeString(logo.Data)
+		if err != nil {
+			return err
+		}
+		ct := logo.ContentType
+		if ct == "" {
+			ct = "image/svg+xml"
+		}
+		s.CustomLogos[domain] = CustomLogo{ContentType: ct, Data: decoded}
+	}
 	return nil
 }
 
 func (s *MemoryStore) Reset() {
 	s.Requests.Reset()
-	s.CustomLogos = make(map[string][]byte)
+	s.CustomLogos = make(map[string]CustomLogo)
 	s.Clock.Reset()
 }

--- a/twin-logodev/internal/store/types.go
+++ b/twin-logodev/internal/store/types.go
@@ -10,3 +10,9 @@ type LogoRequest struct {
 	Greyscale bool      `json:"greyscale,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 }
+
+// CustomLogo holds logo content with its media type.
+type CustomLogo struct {
+	ContentType string `json:"content_type"`
+	Data        []byte `json:"data"`
+}


### PR DESCRIPTION
## Summary

- **Logodev multi-format support**: The twin can now serve SVG, PNG, JPEG, or any image format via custom logos loaded through seed data. Previously hardcoded to `image/svg+xml`.
- **Twin sidecar skill**: New `skills/twin-sidecar.md` documents the pattern for building optional companion processes that fetch real data from upstream APIs to enrich twin seed data.

## Details

### Logodev changes
- New `CustomLogo` type with `ContentType` + `Data` fields (replaces raw `[]byte`)
- `LoadState` hydrates custom logos from base64-encoded seed data with per-logo content types
- `Snapshot` round-trips custom logos correctly
- Handler serves the correct `Content-Type` header per logo
- 4 new tests: custom SVG, custom PNG, placeholder fallback, reset clears custom logos

### Sidecar skill
Documents the architecture for optional data-fetching sidecars:
- Sidecars are always optional — twins work without them
- Users provide their own API credentials
- Output is a JSON seed file compatible with `LoadState`
- Covers naming conventions, directory structure, implementation steps, and licensing considerations

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (13 logodev tests, all green)
- [x] Custom logos load via `/admin/state` with correct content types
- [x] Placeholder fallback works for domains without custom logos
- [x] Reset clears custom logos

🤖 Generated with [Claude Code](https://claude.com/claude-code)