### PR TITLE
feat: accounting ledger engine

### DIFF
--- a/twinkit/ledger/accounting/documents.go
+++ b/twinkit/ledger/accounting/documents.go
@@ -1,0 +1,41 @@
+package accounting
+
+import "fmt"
+
+// validTransitions defines the document state machine.
+var validTransitions = map[DocumentStatus][]DocumentStatus{
+	StatusDraft:      {StatusSubmitted, StatusDeleted},
+	StatusSubmitted:  {StatusAuthorised, StatusDeleted},
+	StatusAuthorised: {StatusVoided}, // PAID only via ApplyPayment
+	StatusPaid:       {},             // terminal
+	StatusVoided:     {},             // terminal
+	StatusDeleted:    {},             // terminal
+}
+
+// ValidateTransition checks if a state transition is allowed.
+func ValidateTransition(from, to DocumentStatus) error {
+	allowed, ok := validTransitions[from]
+	if !ok {
+		return fmt.Errorf("unknown status %q", from)
+	}
+	for _, s := range allowed {
+		if s == to {
+			return nil
+		}
+	}
+	return fmt.Errorf("transition from %s to %s is not allowed", from, to)
+}
+
+// ComputeLineItemTotals calculates line item amounts and document totals.
+// LineItem.Amount = Quantity * UnitAmount / 100 (quantity is scaled by 100).
+func ComputeLineItemTotals(doc *Document) {
+	var subTotal int64
+	for i := range doc.LineItems {
+		li := &doc.LineItems[i]
+		li.Amount = li.Quantity * li.UnitAmount / 100
+		subTotal += li.Amount
+	}
+	doc.SubTotal = subTotal
+	doc.Total = subTotal // no tax in v0.1
+	doc.AmountDue = doc.Total - doc.AmountPaid
+}

--- a/twinkit/ledger/accounting/engine.go
+++ b/twinkit/ledger/accounting/engine.go
@@ -1,0 +1,410 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/store/journal"
+)
+
+// Engine is the accounting ledger engine. It enforces accounting invariants
+// and delegates platform-specific behavior to hooks.
+type Engine struct {
+	mu         sync.RWMutex
+	journal    *journal.Journal
+	hooks      AccountingHooks
+	clock      *store.Clock
+	accounts   map[string]*Account
+	acctOrder  []string // insertion order
+	periodLock time.Time // reject entries before this time
+	acctCounter int
+
+	// Well-known account IDs for AR/AP. Set by CreateAccount or configurable.
+	arAccountID string
+	apAccountID string
+}
+
+// Option configures the Engine.
+type Option func(*Engine)
+
+// WithJournal sets the journal store.
+func WithJournal(j *journal.Journal) Option {
+	return func(e *Engine) { e.journal = j }
+}
+
+// WithHooks sets the accounting hooks implementation.
+func WithHooks(h AccountingHooks) Option {
+	return func(e *Engine) { e.hooks = h }
+}
+
+// WithClock sets the clock for timestamps.
+func WithClock(c *store.Clock) Option {
+	return func(e *Engine) { e.clock = c }
+}
+
+// WithPeriodLock sets the initial period lock date.
+func WithPeriodLock(t time.Time) Option {
+	return func(e *Engine) { e.periodLock = t }
+}
+
+// NewEngine creates a new accounting engine with the given options.
+func NewEngine(opts ...Option) *Engine {
+	e := &Engine{
+		accounts: make(map[string]*Account),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	if e.clock == nil {
+		e.clock = store.NewClock()
+	}
+	if e.journal == nil {
+		e.journal = journal.New(e.clock)
+	}
+	return e
+}
+
+// Journal returns the underlying journal for direct access (e.g., reports).
+func (e *Engine) Journal() *journal.Journal {
+	return e.journal
+}
+
+// CreateAccount adds an account to the chart of accounts.
+func (e *Engine) CreateAccount(acct Account) (*Account, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if acct.Name == "" {
+		return nil, fmt.Errorf("account name is required")
+	}
+	if acct.Type == "" {
+		return nil, fmt.Errorf("account type is required")
+	}
+
+	if acct.ID == "" {
+		e.acctCounter++
+		acct.ID = fmt.Sprintf("acct_%06d", e.acctCounter)
+	}
+
+	if _, exists := e.accounts[acct.ID]; exists {
+		return nil, fmt.Errorf("account %s already exists", acct.ID)
+	}
+
+	e.accounts[acct.ID] = &acct
+	e.acctOrder = append(e.acctOrder, acct.ID)
+
+	// Track well-known accounts by class.
+	switch acct.Class {
+	case ClassCurrentAsset:
+		if acct.Name == "Accounts Receivable" || acct.Code == "200" {
+			e.arAccountID = acct.ID
+		}
+	case ClassCurrentLiability:
+		if acct.Name == "Accounts Payable" || acct.Code == "800" {
+			e.apAccountID = acct.ID
+		}
+	}
+
+	return &acct, nil
+}
+
+// GetAccount returns an account by ID.
+func (e *Engine) GetAccount(id string) (*Account, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	acct, ok := e.accounts[id]
+	if !ok {
+		return nil, fmt.Errorf("account %s not found", id)
+	}
+	return acct, nil
+}
+
+// ListAccounts returns all accounts in creation order.
+func (e *Engine) ListAccounts() []Account {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make([]Account, 0, len(e.acctOrder))
+	for _, id := range e.acctOrder {
+		result = append(result, *e.accounts[id])
+	}
+	return result
+}
+
+// SetReceivableAccount explicitly sets the Accounts Receivable account ID.
+func (e *Engine) SetReceivableAccount(id string) { e.arAccountID = id }
+
+// SetPayableAccount explicitly sets the Accounts Payable account ID.
+func (e *Engine) SetPayableAccount(id string) { e.apAccountID = id }
+
+func (e *Engine) receivableAccountID() string {
+	if e.arAccountID != "" {
+		return e.arAccountID
+	}
+	return "acct_receivable"
+}
+
+func (e *Engine) payableAccountID() string {
+	if e.apAccountID != "" {
+		return e.apAccountID
+	}
+	return "acct_payable"
+}
+
+// ValidateDocument computes line item totals and validates that line items
+// reference known accounts.
+func (e *Engine) ValidateDocument(doc *Document) error {
+	if len(doc.LineItems) == 0 {
+		return fmt.Errorf("document must have at least one line item")
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for i, li := range doc.LineItems {
+		if li.AccountID == "" {
+			return fmt.Errorf("line item %d: account_id is required", i)
+		}
+		if _, ok := e.accounts[li.AccountID]; !ok {
+			return fmt.Errorf("line item %d: account %s not found", i, li.AccountID)
+		}
+	}
+
+	ComputeLineItemTotals(doc)
+	return nil
+}
+
+// TransitionDocument transitions a document's status, enforcing the state machine,
+// period lock, and creating journal entries on AUTHORISED.
+func (e *Engine) TransitionDocument(ctx context.Context, doc *Document, to DocumentStatus) error {
+	from := doc.Status
+
+	if err := ValidateTransition(from, to); err != nil {
+		return err
+	}
+
+	// Check period lock.
+	if !e.periodLock.IsZero() && !doc.Date.IsZero() && doc.Date.Before(e.periodLock) {
+		return fmt.Errorf("document date %s is in a locked period (before %s)",
+			doc.Date.Format("2006-01-02"), e.periodLock.Format("2006-01-02"))
+	}
+
+	now := e.clock.Now()
+
+	// Create journal entries when transitioning to AUTHORISED.
+	if to == StatusAuthorised {
+		entries, err := e.journalEntriesForAuthorisation(doc)
+		if err != nil {
+			return fmt.Errorf("journal entries for authorisation: %w", err)
+		}
+		if err := e.journal.Append(journal.Transaction{Entries: entries}); err != nil {
+			return fmt.Errorf("journal append: %w", err)
+		}
+
+		// Notify hooks about journal entries.
+		if e.hooks != nil {
+			infos := make([]JournalEntryInfo, len(entries))
+			for i, ent := range entries {
+				infos[i] = JournalEntryInfo{
+					AccountID:  ent.AccountID,
+					Type:       string(ent.Type),
+					Amount:     ent.Amount,
+					SourceType: ent.SourceType,
+					SourceID:   ent.SourceID,
+				}
+			}
+			if err := e.hooks.OnJournalEntryCreated(ctx, doc, infos); err != nil {
+				return fmt.Errorf("hook OnJournalEntryCreated: %w", err)
+			}
+		}
+	}
+
+	doc.Status = to
+	doc.UpdatedAt = now
+
+	if e.hooks != nil {
+		if err := e.hooks.OnDocumentStateTransition(ctx, doc, from, to); err != nil {
+			return fmt.Errorf("hook OnDocumentStateTransition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// journalEntriesForAuthorisation creates the journal entries when a document is authorised.
+func (e *Engine) journalEntriesForAuthorisation(doc *Document) ([]journal.Entry, error) {
+	if doc.Total <= 0 {
+		return nil, fmt.Errorf("document total must be positive")
+	}
+
+	sourceType := string(doc.Type)
+	var entries []journal.Entry
+
+	switch doc.Type {
+	case DocTypeInvoice:
+		// Invoice AUTHORISED: Debit Accounts Receivable, Credit Revenue account(s)
+		entries = append(entries, journal.Entry{
+			AccountID:  e.receivableAccountID(),
+			Type:       journal.Debit,
+			Amount:     doc.Total,
+			Currency:   doc.Currency,
+			SourceType: sourceType,
+			SourceID:   doc.ID,
+		})
+		for _, li := range doc.LineItems {
+			if li.Amount > 0 {
+				entries = append(entries, journal.Entry{
+					AccountID:  li.AccountID,
+					Type:       journal.Credit,
+					Amount:     li.Amount,
+					Currency:   doc.Currency,
+					SourceType: sourceType,
+					SourceID:   doc.ID,
+				})
+			}
+		}
+
+	case DocTypeBill:
+		// Bill AUTHORISED: Debit Expense account(s), Credit Accounts Payable
+		for _, li := range doc.LineItems {
+			if li.Amount > 0 {
+				entries = append(entries, journal.Entry{
+					AccountID:  li.AccountID,
+					Type:       journal.Debit,
+					Amount:     li.Amount,
+					Currency:   doc.Currency,
+					SourceType: sourceType,
+					SourceID:   doc.ID,
+				})
+			}
+		}
+		entries = append(entries, journal.Entry{
+			AccountID:  e.payableAccountID(),
+			Type:       journal.Credit,
+			Amount:     doc.Total,
+			Currency:   doc.Currency,
+			SourceType: sourceType,
+			SourceID:   doc.ID,
+		})
+
+	case DocTypeCreditNote:
+		// Credit note AUTHORISED: Debit Revenue, Credit AR (reverse of invoice)
+		for _, li := range doc.LineItems {
+			if li.Amount > 0 {
+				entries = append(entries, journal.Entry{
+					AccountID:  li.AccountID,
+					Type:       journal.Debit,
+					Amount:     li.Amount,
+					Currency:   doc.Currency,
+					SourceType: sourceType,
+					SourceID:   doc.ID,
+				})
+			}
+		}
+		entries = append(entries, journal.Entry{
+			AccountID:  e.receivableAccountID(),
+			Type:       journal.Credit,
+			Amount:     doc.Total,
+			Currency:   doc.Currency,
+			SourceType: sourceType,
+			SourceID:   doc.ID,
+		})
+
+	default:
+		return nil, fmt.Errorf("unsupported document type %s", doc.Type)
+	}
+
+	return entries, nil
+}
+
+// ApplyPayment applies a payment to a document.
+func (e *Engine) ApplyPayment(ctx context.Context, pmt *Payment, doc *Document) error {
+	return e.applyPayment(ctx, pmt, doc)
+}
+
+// PostManualJournal validates and posts a manual journal entry.
+func (e *Engine) PostManualJournal(ctx context.Context, mj *ManualJournal) error {
+	if len(mj.Lines) == 0 {
+		return fmt.Errorf("manual journal must have at least one line")
+	}
+
+	// Check period lock.
+	if !e.periodLock.IsZero() && !mj.Date.IsZero() && mj.Date.Before(e.periodLock) {
+		return fmt.Errorf("journal date %s is in a locked period (before %s)",
+			mj.Date.Format("2006-01-02"), e.periodLock.Format("2006-01-02"))
+	}
+
+	// Build journal entries from manual journal lines.
+	var entries []journal.Entry
+	var totalDebit, totalCredit int64
+
+	e.mu.RLock()
+	for i, line := range mj.Lines {
+		if line.AccountID == "" {
+			e.mu.RUnlock()
+			return fmt.Errorf("line %d: account_id is required", i)
+		}
+		if _, ok := e.accounts[line.AccountID]; !ok {
+			e.mu.RUnlock()
+			return fmt.Errorf("line %d: account %s not found", i, line.AccountID)
+		}
+
+		if line.DebitAmount > 0 {
+			entries = append(entries, journal.Entry{
+				AccountID:  line.AccountID,
+				Type:       journal.Debit,
+				Amount:     line.DebitAmount,
+				Currency:   "USD", // default currency for manual journals
+				SourceType: "manual_journal",
+				SourceID:   mj.ID,
+			})
+			totalDebit += line.DebitAmount
+		}
+		if line.CreditAmount > 0 {
+			entries = append(entries, journal.Entry{
+				AccountID:  line.AccountID,
+				Type:       journal.Credit,
+				Amount:     line.CreditAmount,
+				Currency:   "USD",
+				SourceType: "manual_journal",
+				SourceID:   mj.ID,
+			})
+			totalCredit += line.CreditAmount
+		}
+	}
+	e.mu.RUnlock()
+
+	if totalDebit != totalCredit {
+		return fmt.Errorf("manual journal is unbalanced: debits=%d credits=%d", totalDebit, totalCredit)
+	}
+
+	if len(entries) < 2 {
+		return fmt.Errorf("manual journal must produce at least 2 journal entries")
+	}
+
+	if err := e.journal.Append(journal.Transaction{Entries: entries}); err != nil {
+		return fmt.Errorf("journal append: %w", err)
+	}
+
+	mj.Status = "POSTED"
+	mj.CreatedAt = e.clock.Now()
+
+	return nil
+}
+
+// LockPeriod locks all periods before the given time. Subsequent mutations
+// to documents or journals dated before this time will be rejected.
+func (e *Engine) LockPeriod(before time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.periodLock = before
+}
+
+// PeriodLock returns the current period lock time.
+func (e *Engine) PeriodLock() time.Time {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.periodLock
+}

--- a/twinkit/ledger/accounting/engine_test.go
+++ b/twinkit/ledger/accounting/engine_test.go
@@ -1,0 +1,693 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/store/journal"
+)
+
+// testHooks records hook invocations for testing.
+type testHooks struct {
+	NoOpAccountingHooks
+	journalEntries [][]JournalEntryInfo
+	transitions    []transitionRecord
+	payments       []paymentRecord
+}
+
+type transitionRecord struct {
+	DocID string
+	From  DocumentStatus
+	To    DocumentStatus
+}
+
+type paymentRecord struct {
+	PaymentID string
+	DocID     string
+}
+
+func (h *testHooks) OnJournalEntryCreated(_ context.Context, doc *Document, entries []JournalEntryInfo) error {
+	h.journalEntries = append(h.journalEntries, entries)
+	return nil
+}
+
+func (h *testHooks) OnDocumentStateTransition(_ context.Context, doc *Document, from, to DocumentStatus) error {
+	h.transitions = append(h.transitions, transitionRecord{DocID: doc.ID, From: from, To: to})
+	return nil
+}
+
+func (h *testHooks) OnPaymentApplied(_ context.Context, pmt *Payment, doc *Document) error {
+	h.payments = append(h.payments, paymentRecord{PaymentID: pmt.ID, DocID: doc.ID})
+	return nil
+}
+
+func setupEngine() (*Engine, *testHooks, *store.Clock) {
+	clock := store.NewClock()
+	hooks := &testHooks{}
+	j := journal.New(clock)
+	e := NewEngine(WithJournal(j), WithHooks(hooks), WithClock(clock))
+
+	// Set up chart of accounts.
+	e.CreateAccount(Account{ID: "acct_ar", Name: "Accounts Receivable", Type: AccountTypeAsset, Class: ClassCurrentAsset, Currency: "USD"})
+	e.CreateAccount(Account{ID: "acct_ap", Name: "Accounts Payable", Type: AccountTypeLiability, Class: ClassCurrentLiability, Currency: "USD"})
+	e.CreateAccount(Account{ID: "acct_rev", Name: "Sales Revenue", Type: AccountTypeRevenue, Class: ClassRevenue, Currency: "USD"})
+	e.CreateAccount(Account{ID: "acct_exp", Name: "Office Expenses", Type: AccountTypeExpense, Class: ClassExpense, Currency: "USD"})
+	e.CreateAccount(Account{ID: "acct_bank", Name: "Business Bank", Type: AccountTypeAsset, Class: ClassCurrentAsset, Currency: "USD"})
+
+	e.SetReceivableAccount("acct_ar")
+	e.SetPayableAccount("acct_ap")
+
+	return e, hooks, clock
+}
+
+func makeInvoice(id, currency string, amount int64) *Document {
+	return &Document{
+		ID:       id,
+		Type:     DocTypeInvoice,
+		Status:   StatusDraft,
+		Currency: currency,
+		Date:     time.Now(),
+		LineItems: []LineItem{
+			{Description: "Widget", AccountID: "acct_rev", Quantity: 100, UnitAmount: amount},
+		},
+	}
+}
+
+func makeBill(id, currency string, amount int64) *Document {
+	return &Document{
+		ID:       id,
+		Type:     DocTypeBill,
+		Status:   StatusDraft,
+		Currency: currency,
+		Date:     time.Now(),
+		LineItems: []LineItem{
+			{Description: "Office supplies", AccountID: "acct_exp", Quantity: 100, UnitAmount: amount},
+		},
+	}
+}
+
+// --- State Transition Tests ---
+
+func TestTransition_DraftToSubmitted(t *testing.T) {
+	e, hooks, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	if err := e.TransitionDocument(context.Background(), inv, StatusSubmitted); err != nil {
+		t.Fatal(err)
+	}
+	if inv.Status != StatusSubmitted {
+		t.Errorf("status = %s, want SUBMITTED", inv.Status)
+	}
+	if len(hooks.transitions) != 1 || hooks.transitions[0].To != StatusSubmitted {
+		t.Error("expected transition hook to fire")
+	}
+}
+
+func TestTransition_SubmittedToAuthorised(t *testing.T) {
+	e, hooks, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	e.TransitionDocument(context.Background(), inv, StatusSubmitted)
+	if err := e.TransitionDocument(context.Background(), inv, StatusAuthorised); err != nil {
+		t.Fatal(err)
+	}
+	if inv.Status != StatusAuthorised {
+		t.Errorf("status = %s, want AUTHORISED", inv.Status)
+	}
+	// Should have generated journal entries.
+	if len(hooks.journalEntries) != 1 {
+		t.Fatalf("expected 1 journal entry set, got %d", len(hooks.journalEntries))
+	}
+	// AmountDue should be set.
+	if inv.AmountDue != inv.Total {
+		t.Errorf("AmountDue = %d, want %d", inv.AmountDue, inv.Total)
+	}
+}
+
+func TestTransition_InvalidTransition(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	// Can't go from DRAFT to AUTHORISED.
+	if err := e.TransitionDocument(context.Background(), inv, StatusAuthorised); err == nil {
+		t.Fatal("expected error for invalid transition DRAFT→AUTHORISED")
+	}
+
+	// Can't go from DRAFT to PAID.
+	if err := e.TransitionDocument(context.Background(), inv, StatusPaid); err == nil {
+		t.Fatal("expected error for invalid transition DRAFT→PAID")
+	}
+}
+
+func TestTransition_TerminalStates(t *testing.T) {
+	e, _, _ := setupEngine()
+
+	tests := []struct {
+		name string
+		from DocumentStatus
+	}{
+		{"PAID is terminal", StatusPaid},
+		{"VOIDED is terminal", StatusVoided},
+		{"DELETED is terminal", StatusDeleted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &Document{ID: "d", Status: tt.from, Currency: "USD"}
+			if err := e.TransitionDocument(context.Background(), doc, StatusSubmitted); err == nil {
+				t.Errorf("expected error transitioning from terminal state %s", tt.from)
+			}
+		})
+	}
+}
+
+func TestTransition_AuthorisedToVoided(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	e.TransitionDocument(context.Background(), inv, StatusSubmitted)
+	e.TransitionDocument(context.Background(), inv, StatusAuthorised)
+	if err := e.TransitionDocument(context.Background(), inv, StatusVoided); err != nil {
+		t.Fatalf("expected AUTHORISED→VOIDED to be valid: %v", err)
+	}
+}
+
+func TestTransition_DraftToDeleted(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	if err := e.TransitionDocument(context.Background(), inv, StatusDeleted); err != nil {
+		t.Fatalf("expected DRAFT→DELETED to be valid: %v", err)
+	}
+}
+
+// --- Invoice Journal Entry Tests ---
+
+func TestInvoiceAuthorised_JournalEntries(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 50000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	// AR should be debited.
+	d, _, _ := e.journal.Balance("acct_ar")
+	if d != 50000 {
+		t.Errorf("AR debit = %d, want 50000", d)
+	}
+
+	// Revenue should be credited.
+	_, c, _ := e.journal.Balance("acct_rev")
+	if c != 50000 {
+		t.Errorf("Revenue credit = %d, want 50000", c)
+	}
+}
+
+func TestBillAuthorised_JournalEntries(t *testing.T) {
+	e, _, _ := setupEngine()
+	bill := makeBill("bill_001", "USD", 20000)
+	ComputeLineItemTotals(bill)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, bill, StatusSubmitted)
+	e.TransitionDocument(ctx, bill, StatusAuthorised)
+
+	// Expense should be debited.
+	d, _, _ := e.journal.Balance("acct_exp")
+	if d != 20000 {
+		t.Errorf("Expense debit = %d, want 20000", d)
+	}
+
+	// AP should be credited.
+	_, c, _ := e.journal.Balance("acct_ap")
+	if c != 20000 {
+		t.Errorf("AP credit = %d, want 20000", c)
+	}
+}
+
+// --- Payment Tests ---
+
+func TestPayment_FullPayment(t *testing.T) {
+	e, hooks, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	pmt := &Payment{
+		ID:            "pmt_001",
+		DocumentID:    "inv_001",
+		DocumentType:  DocTypeInvoice,
+		BankAccountID: "acct_bank",
+		Amount:        10000,
+		Currency:      "USD",
+	}
+
+	if err := e.ApplyPayment(ctx, pmt, inv); err != nil {
+		t.Fatal(err)
+	}
+
+	if inv.Status != StatusPaid {
+		t.Errorf("status = %s, want PAID", inv.Status)
+	}
+	if inv.AmountDue != 0 {
+		t.Errorf("AmountDue = %d, want 0", inv.AmountDue)
+	}
+
+	// Bank should be debited.
+	d, _, _ := e.journal.Balance("acct_bank")
+	if d != 10000 {
+		t.Errorf("Bank debit = %d, want 10000", d)
+	}
+
+	// AR should have credit from payment (and debit from invoice).
+	d2, c2, net := e.journal.Balance("acct_ar")
+	if net != 0 {
+		t.Errorf("AR net = %d, want 0 (d=%d c=%d)", net, d2, c2)
+	}
+
+	if len(hooks.payments) != 1 {
+		t.Error("expected payment hook to fire")
+	}
+}
+
+func TestPayment_PartialPayment(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	pmt := &Payment{
+		ID: "pmt_001", DocumentID: "inv_001", DocumentType: DocTypeInvoice,
+		BankAccountID: "acct_bank", Amount: 6000, Currency: "USD",
+	}
+
+	if err := e.ApplyPayment(ctx, pmt, inv); err != nil {
+		t.Fatal(err)
+	}
+
+	if inv.Status != StatusAuthorised {
+		t.Errorf("status = %s, want AUTHORISED (partial payment)", inv.Status)
+	}
+	if inv.AmountDue != 4000 {
+		t.Errorf("AmountDue = %d, want 4000", inv.AmountDue)
+	}
+
+	// Second partial payment to complete.
+	pmt2 := &Payment{
+		ID: "pmt_002", DocumentID: "inv_001", DocumentType: DocTypeInvoice,
+		BankAccountID: "acct_bank", Amount: 4000, Currency: "USD",
+	}
+	if err := e.ApplyPayment(ctx, pmt2, inv); err != nil {
+		t.Fatal(err)
+	}
+	if inv.Status != StatusPaid {
+		t.Errorf("status = %s, want PAID after full payment", inv.Status)
+	}
+}
+
+func TestPayment_ExceedsAmountDue(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	pmt := &Payment{
+		ID: "pmt_001", DocumentID: "inv_001", DocumentType: DocTypeInvoice,
+		BankAccountID: "acct_bank", Amount: 20000, Currency: "USD",
+	}
+
+	if err := e.ApplyPayment(ctx, pmt, inv); err == nil {
+		t.Fatal("expected error for payment exceeding amount due")
+	}
+}
+
+func TestPayment_WrongStatus(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+
+	pmt := &Payment{
+		ID: "pmt_001", DocumentID: "inv_001", DocumentType: DocTypeInvoice,
+		BankAccountID: "acct_bank", Amount: 10000, Currency: "USD",
+	}
+
+	if err := e.ApplyPayment(context.Background(), pmt, inv); err == nil {
+		t.Fatal("expected error for payment on DRAFT document")
+	}
+}
+
+func TestPayment_BillPayment(t *testing.T) {
+	e, _, _ := setupEngine()
+	bill := makeBill("bill_001", "USD", 5000)
+	ComputeLineItemTotals(bill)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, bill, StatusSubmitted)
+	e.TransitionDocument(ctx, bill, StatusAuthorised)
+
+	pmt := &Payment{
+		ID: "pmt_001", DocumentID: "bill_001", DocumentType: DocTypeBill,
+		BankAccountID: "acct_bank", Amount: 5000, Currency: "USD",
+	}
+
+	if err := e.ApplyPayment(ctx, pmt, bill); err != nil {
+		t.Fatal(err)
+	}
+
+	// AP should be debited (payment reduces liability).
+	d, _, _ := e.journal.Balance("acct_ap")
+	if d != 5000 {
+		t.Errorf("AP debit = %d, want 5000", d)
+	}
+
+	// Bank should be credited (money leaving).
+	_, c, _ := e.journal.Balance("acct_bank")
+	if c != 5000 {
+		t.Errorf("Bank credit = %d, want 5000", c)
+	}
+}
+
+// --- Period Lock Tests ---
+
+func TestPeriodLock_RejectsOldDocuments(t *testing.T) {
+	e, _, _ := setupEngine()
+	lockDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	e.LockPeriod(lockDate)
+
+	inv := makeInvoice("inv_001", "USD", 10000)
+	inv.Date = time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC) // before lock
+	ComputeLineItemTotals(inv)
+
+	if err := e.TransitionDocument(context.Background(), inv, StatusSubmitted); err == nil {
+		t.Fatal("expected error for document in locked period")
+	}
+}
+
+func TestPeriodLock_AllowsNewDocuments(t *testing.T) {
+	e, _, _ := setupEngine()
+	lockDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	e.LockPeriod(lockDate)
+
+	inv := makeInvoice("inv_001", "USD", 10000)
+	inv.Date = time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC) // after lock
+	ComputeLineItemTotals(inv)
+
+	if err := e.TransitionDocument(context.Background(), inv, StatusSubmitted); err != nil {
+		t.Fatalf("expected no error for document after lock: %v", err)
+	}
+}
+
+func TestPeriodLock_RejectsManualJournal(t *testing.T) {
+	e, _, _ := setupEngine()
+	lockDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	e.LockPeriod(lockDate)
+
+	mj := &ManualJournal{
+		ID:   "mj_001",
+		Date: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+		Lines: []ManualJournalLine{
+			{AccountID: "acct_bank", DebitAmount: 1000},
+			{AccountID: "acct_rev", CreditAmount: 1000},
+		},
+	}
+
+	if err := e.PostManualJournal(context.Background(), mj); err == nil {
+		t.Fatal("expected error for manual journal in locked period")
+	}
+}
+
+// --- Manual Journal Tests ---
+
+func TestManualJournal_Balanced(t *testing.T) {
+	e, _, _ := setupEngine()
+	mj := &ManualJournal{
+		ID:        "mj_001",
+		Narration: "Adjustment",
+		Lines: []ManualJournalLine{
+			{AccountID: "acct_bank", DebitAmount: 5000},
+			{AccountID: "acct_rev", CreditAmount: 5000},
+		},
+	}
+
+	if err := e.PostManualJournal(context.Background(), mj); err != nil {
+		t.Fatal(err)
+	}
+	if mj.Status != "POSTED" {
+		t.Errorf("status = %s, want POSTED", mj.Status)
+	}
+
+	d, _, _ := e.journal.Balance("acct_bank")
+	if d != 5000 {
+		t.Errorf("Bank debit = %d, want 5000", d)
+	}
+}
+
+func TestManualJournal_Unbalanced(t *testing.T) {
+	e, _, _ := setupEngine()
+	mj := &ManualJournal{
+		ID: "mj_001",
+		Lines: []ManualJournalLine{
+			{AccountID: "acct_bank", DebitAmount: 5000},
+			{AccountID: "acct_rev", CreditAmount: 3000},
+		},
+	}
+
+	if err := e.PostManualJournal(context.Background(), mj); err == nil {
+		t.Fatal("expected error for unbalanced manual journal")
+	}
+}
+
+func TestManualJournal_UnknownAccount(t *testing.T) {
+	e, _, _ := setupEngine()
+	mj := &ManualJournal{
+		ID: "mj_001",
+		Lines: []ManualJournalLine{
+			{AccountID: "nonexistent", DebitAmount: 1000},
+			{AccountID: "acct_rev", CreditAmount: 1000},
+		},
+	}
+
+	if err := e.PostManualJournal(context.Background(), mj); err == nil {
+		t.Fatal("expected error for unknown account")
+	}
+}
+
+// --- Report Tests ---
+
+func TestTrialBalance(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	tb := e.TrialBalanceReport(time.Time{})
+	if tb.TotalDebit != tb.TotalCredit {
+		t.Errorf("trial balance unequal: debit=%d credit=%d", tb.TotalDebit, tb.TotalCredit)
+	}
+	if len(tb.Rows) < 2 {
+		t.Errorf("expected at least 2 rows, got %d", len(tb.Rows))
+	}
+}
+
+func TestProfitAndLoss(t *testing.T) {
+	e, _, clock := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	from := clock.Now().Add(-time.Hour)
+	to := clock.Now().Add(time.Hour)
+	pnl := e.ProfitAndLossReport(from, to)
+
+	if pnl.Revenue.Total != 10000 {
+		t.Errorf("revenue = %d, want 10000", pnl.Revenue.Total)
+	}
+	if pnl.NetProfit != 10000 {
+		t.Errorf("net profit = %d, want 10000", pnl.NetProfit)
+	}
+}
+
+func TestBalanceSheet(t *testing.T) {
+	e, _, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	bs := e.BalanceSheetReport(time.Time{})
+	if bs.Assets.Total != 10000 {
+		t.Errorf("assets = %d, want 10000 (AR)", bs.Assets.Total)
+	}
+}
+
+// --- Account Tests ---
+
+func TestCreateAccount(t *testing.T) {
+	e := NewEngine()
+	acct, err := e.CreateAccount(Account{Name: "Test", Type: AccountTypeAsset, Class: ClassCurrentAsset})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.ID != "acct_000001" {
+		t.Errorf("ID = %s, want acct_000001", acct.ID)
+	}
+}
+
+func TestCreateAccount_Duplicate(t *testing.T) {
+	e, _, _ := setupEngine()
+	_, err := e.CreateAccount(Account{ID: "acct_ar", Name: "Dup", Type: AccountTypeAsset})
+	if err == nil {
+		t.Fatal("expected error for duplicate account")
+	}
+}
+
+func TestCreateAccount_MissingName(t *testing.T) {
+	e := NewEngine()
+	_, err := e.CreateAccount(Account{Type: AccountTypeAsset})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestListAccounts(t *testing.T) {
+	e, _, _ := setupEngine()
+	accts := e.ListAccounts()
+	if len(accts) != 5 {
+		t.Errorf("expected 5 accounts, got %d", len(accts))
+	}
+}
+
+// --- Validate Document Tests ---
+
+func TestValidateDocument_UnknownAccount(t *testing.T) {
+	e, _, _ := setupEngine()
+	doc := &Document{
+		Currency: "USD",
+		LineItems: []LineItem{
+			{AccountID: "nonexistent", Quantity: 100, UnitAmount: 100},
+		},
+	}
+	if err := e.ValidateDocument(doc); err == nil {
+		t.Fatal("expected error for unknown account in line item")
+	}
+}
+
+func TestValidateDocument_ComputesTotals(t *testing.T) {
+	e, _, _ := setupEngine()
+	doc := &Document{
+		Currency: "USD",
+		LineItems: []LineItem{
+			{AccountID: "acct_rev", Quantity: 200, UnitAmount: 5000},
+			{AccountID: "acct_rev", Quantity: 100, UnitAmount: 3000},
+		},
+	}
+	if err := e.ValidateDocument(doc); err != nil {
+		t.Fatal(err)
+	}
+	// 200 * 5000 / 100 = 10000, 100 * 3000 / 100 = 3000
+	if doc.Total != 13000 {
+		t.Errorf("total = %d, want 13000", doc.Total)
+	}
+}
+
+// --- Hook Invocation Tests ---
+
+func TestHooks_InvokedOnAuthorisation(t *testing.T) {
+	e, hooks, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	if len(hooks.journalEntries) != 1 {
+		t.Fatalf("expected 1 journal entry hook call, got %d", len(hooks.journalEntries))
+	}
+	if len(hooks.transitions) != 2 {
+		t.Fatalf("expected 2 transition hooks, got %d", len(hooks.transitions))
+	}
+	if hooks.transitions[1].From != StatusSubmitted || hooks.transitions[1].To != StatusAuthorised {
+		t.Error("unexpected transition record")
+	}
+}
+
+func TestHooks_InvokedOnPayment(t *testing.T) {
+	e, hooks, _ := setupEngine()
+	inv := makeInvoice("inv_001", "USD", 10000)
+	ComputeLineItemTotals(inv)
+	ctx := context.Background()
+
+	e.TransitionDocument(ctx, inv, StatusSubmitted)
+	e.TransitionDocument(ctx, inv, StatusAuthorised)
+
+	pmt := &Payment{
+		ID: "pmt_001", DocumentID: "inv_001", DocumentType: DocTypeInvoice,
+		BankAccountID: "acct_bank", Amount: 10000, Currency: "USD",
+	}
+	e.ApplyPayment(ctx, pmt, inv)
+
+	if len(hooks.payments) != 1 {
+		t.Fatalf("expected 1 payment hook, got %d", len(hooks.payments))
+	}
+	// Full payment also triggers PAID transition.
+	found := false
+	for _, tr := range hooks.transitions {
+		if tr.To == StatusPaid {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected PAID transition hook")
+	}
+}
+
+// --- Document Line Item Totals ---
+
+func TestComputeLineItemTotals(t *testing.T) {
+	doc := &Document{
+		LineItems: []LineItem{
+			{Quantity: 100, UnitAmount: 5000}, // 1.00 * 50.00 = 50.00 (5000 cents)
+			{Quantity: 250, UnitAmount: 2000}, // 2.50 * 20.00 = 50.00 (5000 cents)
+		},
+	}
+	ComputeLineItemTotals(doc)
+	if doc.LineItems[0].Amount != 5000 {
+		t.Errorf("line 0 amount = %d, want 5000", doc.LineItems[0].Amount)
+	}
+	if doc.LineItems[1].Amount != 5000 {
+		t.Errorf("line 1 amount = %d, want 5000", doc.LineItems[1].Amount)
+	}
+	if doc.Total != 10000 {
+		t.Errorf("total = %d, want 10000", doc.Total)
+	}
+	if doc.AmountDue != 10000 {
+		t.Errorf("amount_due = %d, want 10000", doc.AmountDue)
+	}
+}

--- a/twinkit/ledger/accounting/hooks.go
+++ b/twinkit/ledger/accounting/hooks.go
@@ -1,0 +1,44 @@
+package accounting
+
+import "context"
+
+// AccountingHooks defines extension points for platform-specific behavior.
+// The engine calls these at behavioral inflection points. Implementations
+// must not call back into the engine.
+type AccountingHooks interface {
+	// OnJournalEntryCreated is called after journal entries are written for a
+	// document state transition or payment application.
+	OnJournalEntryCreated(ctx context.Context, doc *Document, entries []JournalEntryInfo) error
+
+	// OnDocumentStateTransition is called after a document transitions state.
+	OnDocumentStateTransition(ctx context.Context, doc *Document, from, to DocumentStatus) error
+
+	// OnPaymentApplied is called after a payment is applied to a document.
+	OnPaymentApplied(ctx context.Context, payment *Payment, doc *Document) error
+}
+
+// JournalEntryInfo provides hook consumers with information about the journal
+// entries that were created, without exposing the journal internals.
+type JournalEntryInfo struct {
+	AccountID  string `json:"account_id"`
+	Type       string `json:"type"` // "debit" or "credit"
+	Amount     int64  `json:"amount"`
+	SourceType string `json:"source_type"`
+	SourceID   string `json:"source_id"`
+}
+
+// NoOpAccountingHooks provides default no-op implementations.
+// Embed this in the twin's hook implementation to avoid implementing unused hooks.
+type NoOpAccountingHooks struct{}
+
+func (NoOpAccountingHooks) OnJournalEntryCreated(_ context.Context, _ *Document, _ []JournalEntryInfo) error {
+	return nil
+}
+
+func (NoOpAccountingHooks) OnDocumentStateTransition(_ context.Context, _ *Document, _, _ DocumentStatus) error {
+	return nil
+}
+
+func (NoOpAccountingHooks) OnPaymentApplied(_ context.Context, _ *Payment, _ *Document) error {
+	return nil
+}

--- a/twinkit/ledger/accounting/interface.go
+++ b/twinkit/ledger/accounting/interface.go
@@ -1,0 +1,170 @@
+// Package accounting provides an accounting ledger engine that enforces
+// double-entry bookkeeping, document state machines, period locking, and
+// financial report generation. Platform-specific behavior is delegated to hooks.
+package accounting
+
+import "time"
+
+// AccountType classifies an account for chart-of-accounts purposes.
+type AccountType string
+
+const (
+	AccountTypeAsset     AccountType = "ASSET"
+	AccountTypeEquity    AccountType = "EQUITY"
+	AccountTypeExpense   AccountType = "EXPENSE"
+	AccountTypeLiability AccountType = "LIABILITY"
+	AccountTypeRevenue   AccountType = "REVENUE"
+)
+
+// AccountClass is a sub-classification within an AccountType.
+type AccountClass string
+
+const (
+	ClassCurrentAsset     AccountClass = "CURRENT_ASSET"
+	ClassFixedAsset       AccountClass = "FIXED_ASSET"
+	ClassCurrentLiability AccountClass = "CURRENT_LIABILITY"
+	ClassLongTermLiab     AccountClass = "LONG_TERM_LIABILITY"
+	ClassEquity           AccountClass = "EQUITY"
+	ClassRevenue          AccountClass = "REVENUE"
+	ClassDirectCost       AccountClass = "DIRECT_COST"
+	ClassExpense          AccountClass = "EXPENSE"
+	ClassOtherIncome      AccountClass = "OTHER_INCOME"
+	ClassOtherExpense     AccountClass = "OTHER_EXPENSE"
+)
+
+// Account represents a ledger account in the chart of accounts.
+type Account struct {
+	ID       string       `json:"id"`
+	Code     string       `json:"code"`
+	Name     string       `json:"name"`
+	Type     AccountType  `json:"type"`
+	Class    AccountClass `json:"class"`
+	Currency string       `json:"currency"`
+}
+
+// DocumentType distinguishes invoices from bills and credit notes.
+type DocumentType string
+
+const (
+	DocTypeInvoice    DocumentType = "INVOICE"
+	DocTypeBill       DocumentType = "BILL"
+	DocTypeCreditNote DocumentType = "CREDIT_NOTE"
+)
+
+// DocumentStatus represents the lifecycle state of a document.
+type DocumentStatus string
+
+const (
+	StatusDraft      DocumentStatus = "DRAFT"
+	StatusSubmitted  DocumentStatus = "SUBMITTED"
+	StatusAuthorised DocumentStatus = "AUTHORISED"
+	StatusPaid       DocumentStatus = "PAID"
+	StatusVoided     DocumentStatus = "VOIDED"
+	StatusDeleted    DocumentStatus = "DELETED"
+)
+
+// LineItem is a single line on a document.
+type LineItem struct {
+	Description string `json:"description"`
+	AccountID   string `json:"account_id"`
+	Quantity    int64  `json:"quantity"`    // scaled (e.g., 100 = 1.00)
+	UnitAmount  int64  `json:"unit_amount"` // in minor currency units
+	Amount      int64  `json:"amount"`      // quantity * unit_amount / 100
+}
+
+// Document represents an invoice, bill, or credit note.
+type Document struct {
+	ID          string         `json:"id"`
+	Type        DocumentType   `json:"type"`
+	Status      DocumentStatus `json:"status"`
+	ContactID   string         `json:"contact_id"`
+	Currency    string         `json:"currency"`
+	LineItems   []LineItem     `json:"line_items"`
+	SubTotal    int64          `json:"sub_total"`
+	Total       int64          `json:"total"`
+	AmountDue   int64          `json:"amount_due"`
+	AmountPaid  int64          `json:"amount_paid"`
+	Date        time.Time      `json:"date"`
+	DueDate     time.Time      `json:"due_date,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// Payment represents a payment applied against a document.
+type Payment struct {
+	ID            string    `json:"id"`
+	DocumentID    string    `json:"document_id"`
+	DocumentType  DocumentType `json:"document_type"`
+	BankAccountID string    `json:"bank_account_id"`
+	Amount        int64     `json:"amount"`
+	Currency      string    `json:"currency"`
+	Date          time.Time `json:"date"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// ManualJournal represents a manually posted journal entry.
+type ManualJournal struct {
+	ID        string             `json:"id"`
+	Narration string             `json:"narration"`
+	Lines     []ManualJournalLine `json:"lines"`
+	Date      time.Time          `json:"date"`
+	Status    string             `json:"status"` // DRAFT or POSTED
+	CreatedAt time.Time          `json:"created_at"`
+}
+
+// ManualJournalLine is a single line in a manual journal.
+type ManualJournalLine struct {
+	AccountID   string `json:"account_id"`
+	Description string `json:"description"`
+	DebitAmount int64  `json:"debit_amount"`
+	CreditAmount int64 `json:"credit_amount"`
+}
+
+// TrialBalanceRow is one row in a trial balance report.
+type TrialBalanceRow struct {
+	AccountID   string `json:"account_id"`
+	AccountName string `json:"account_name"`
+	AccountType AccountType `json:"account_type"`
+	Debit       int64  `json:"debit"`
+	Credit      int64  `json:"credit"`
+}
+
+// TrialBalance is the full trial balance report.
+type TrialBalance struct {
+	Rows       []TrialBalanceRow `json:"rows"`
+	TotalDebit int64             `json:"total_debit"`
+	TotalCredit int64            `json:"total_credit"`
+	AsOf       time.Time         `json:"as_of"`
+}
+
+// ReportRow is a row in a P&L or balance sheet report.
+type ReportRow struct {
+	AccountID   string      `json:"account_id"`
+	AccountName string      `json:"account_name"`
+	AccountType AccountType `json:"account_type"`
+	Amount      int64       `json:"amount"`
+}
+
+// ReportSection groups rows under a heading.
+type ReportSection struct {
+	Title string      `json:"title"`
+	Rows  []ReportRow `json:"rows"`
+	Total int64       `json:"total"`
+}
+
+// ProfitAndLoss is the P&L report.
+type ProfitAndLoss struct {
+	Revenue     ReportSection `json:"revenue"`
+	Expenses    ReportSection `json:"expenses"`
+	NetProfit   int64         `json:"net_profit"`
+	FromDate    time.Time     `json:"from_date"`
+	ToDate      time.Time     `json:"to_date"`
+}
+
+// BalanceSheet is the balance sheet report.
+type BalanceSheet struct {
+	Assets      ReportSection `json:"assets"`
+	Liabilities ReportSection `json:"liabilities"`
+	Equity      ReportSection `json:"equity"`
+	AsOf        time.Time     `json:"as_of"`
+}

--- a/twinkit/ledger/accounting/payments.go
+++ b/twinkit/ledger/accounting/payments.go
@@ -1,0 +1,104 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/store/journal"
+)
+
+// applyPayment handles the payment application logic including journal entry generation.
+// It validates the payment, creates balanced journal entries, updates the document,
+// and transitions to PAID when fully paid.
+func (e *Engine) applyPayment(ctx context.Context, pmt *Payment, doc *Document) error {
+	if doc.Status != StatusAuthorised && doc.Status != StatusPaid {
+		// Allow partial payments on already-PAID docs? No — once PAID, no more payments.
+		if doc.Status == StatusPaid {
+			return fmt.Errorf("document %s is already fully paid", doc.ID)
+		}
+		return fmt.Errorf("document %s has status %s, must be AUTHORISED to accept payment", doc.ID, doc.Status)
+	}
+
+	if pmt.Amount <= 0 {
+		return fmt.Errorf("payment amount must be positive")
+	}
+
+	if pmt.Amount > doc.AmountDue {
+		return fmt.Errorf("payment amount %d exceeds amount due %d", pmt.Amount, doc.AmountDue)
+	}
+
+	if pmt.Currency != doc.Currency {
+		return fmt.Errorf("payment currency %s does not match document currency %s", pmt.Currency, doc.Currency)
+	}
+
+	// Generate journal entries based on document type.
+	var entries []journal.Entry
+	switch doc.Type {
+	case DocTypeInvoice:
+		// Invoice payment: Debit Bank, Credit Accounts Receivable
+		entries = []journal.Entry{
+			{AccountID: pmt.BankAccountID, Type: journal.Debit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+			{AccountID: e.receivableAccountID(), Type: journal.Credit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+		}
+	case DocTypeBill:
+		// Bill payment: Debit Accounts Payable, Credit Bank
+		entries = []journal.Entry{
+			{AccountID: e.payableAccountID(), Type: journal.Debit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+			{AccountID: pmt.BankAccountID, Type: journal.Credit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+		}
+	case DocTypeCreditNote:
+		// Credit note payment: Debit Accounts Receivable, Credit Bank (refund)
+		entries = []journal.Entry{
+			{AccountID: e.receivableAccountID(), Type: journal.Debit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+			{AccountID: pmt.BankAccountID, Type: journal.Credit, Amount: pmt.Amount, Currency: pmt.Currency, SourceType: "payment", SourceID: pmt.ID},
+		}
+	default:
+		return fmt.Errorf("unsupported document type %s for payment", doc.Type)
+	}
+
+	if err := e.journal.Append(journal.Transaction{Entries: entries}); err != nil {
+		return fmt.Errorf("journal append for payment: %w", err)
+	}
+
+	// Update document amounts.
+	doc.AmountPaid += pmt.Amount
+	doc.AmountDue = doc.Total - doc.AmountPaid
+	doc.UpdatedAt = e.clock.Now()
+
+	// Notify hooks about journal entries.
+	if e.hooks != nil {
+		infos := make([]JournalEntryInfo, len(entries))
+		for i, ent := range entries {
+			infos[i] = JournalEntryInfo{
+				AccountID:  ent.AccountID,
+				Type:       string(ent.Type),
+				Amount:     ent.Amount,
+				SourceType: ent.SourceType,
+				SourceID:   ent.SourceID,
+			}
+		}
+		if err := e.hooks.OnJournalEntryCreated(ctx, doc, infos); err != nil {
+			return fmt.Errorf("hook OnJournalEntryCreated: %w", err)
+		}
+	}
+
+	// Auto-transition to PAID when fully paid.
+	if doc.AmountDue == 0 {
+		from := doc.Status
+		doc.Status = StatusPaid
+		if e.hooks != nil {
+			if err := e.hooks.OnDocumentStateTransition(ctx, doc, from, StatusPaid); err != nil {
+				return fmt.Errorf("hook OnDocumentStateTransition: %w", err)
+			}
+		}
+	}
+
+	// Notify hooks about payment.
+	if e.hooks != nil {
+		if err := e.hooks.OnPaymentApplied(ctx, pmt, doc); err != nil {
+			return fmt.Errorf("hook OnPaymentApplied: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/twinkit/ledger/accounting/reports.go
+++ b/twinkit/ledger/accounting/reports.go
@@ -1,0 +1,166 @@
+package accounting
+
+import "time"
+
+// TrialBalanceReport computes a trial balance from journal entries as of the given time.
+// If asOf is zero, uses all entries.
+func (e *Engine) TrialBalanceReport(asOf time.Time) TrialBalance {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if asOf.IsZero() {
+		asOf = e.clock.Now()
+	}
+
+	var rows []TrialBalanceRow
+	var totalDebit, totalCredit int64
+
+	for _, acct := range e.accounts {
+		var d, c int64
+		if asOf.IsZero() {
+			d, c, _ = e.journal.Balance(acct.ID)
+		} else {
+			d, c, _ = e.journal.BalanceAt(acct.ID, asOf)
+		}
+		if d == 0 && c == 0 {
+			continue
+		}
+		rows = append(rows, TrialBalanceRow{
+			AccountID:   acct.ID,
+			AccountName: acct.Name,
+			AccountType: acct.Type,
+			Debit:       d,
+			Credit:      c,
+		})
+		totalDebit += d
+		totalCredit += c
+	}
+
+	return TrialBalance{
+		Rows:        rows,
+		TotalDebit:  totalDebit,
+		TotalCredit: totalCredit,
+		AsOf:        asOf,
+	}
+}
+
+// ProfitAndLossReport computes a P&L report for the given date range.
+// Revenue accounts contribute to Revenue section, Expense accounts to Expenses.
+func (e *Engine) ProfitAndLossReport(from, to time.Time) ProfitAndLoss {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	var revRows []ReportRow
+	var expRows []ReportRow
+	var revTotal, expTotal int64
+
+	for _, acct := range e.accounts {
+		entries := e.journal.EntriesBetween(acct.ID, from, to)
+		if len(entries) == 0 {
+			continue
+		}
+
+		var d, c int64
+		for _, ent := range entries {
+			switch ent.Type {
+			case "debit":
+				d += ent.Amount
+			case "credit":
+				c += ent.Amount
+			}
+		}
+
+		switch acct.Type {
+		case AccountTypeRevenue:
+			// Revenue is normally a credit balance (credit - debit).
+			amount := c - d
+			revRows = append(revRows, ReportRow{
+				AccountID:   acct.ID,
+				AccountName: acct.Name,
+				AccountType: acct.Type,
+				Amount:      amount,
+			})
+			revTotal += amount
+		case AccountTypeExpense:
+			// Expenses are normally a debit balance (debit - credit).
+			amount := d - c
+			expRows = append(expRows, ReportRow{
+				AccountID:   acct.ID,
+				AccountName: acct.Name,
+				AccountType: acct.Type,
+				Amount:      amount,
+			})
+			expTotal += amount
+		}
+	}
+
+	return ProfitAndLoss{
+		Revenue:   ReportSection{Title: "Revenue", Rows: revRows, Total: revTotal},
+		Expenses:  ReportSection{Title: "Expenses", Rows: expRows, Total: expTotal},
+		NetProfit: revTotal - expTotal,
+		FromDate:  from,
+		ToDate:    to,
+	}
+}
+
+// BalanceSheetReport computes a balance sheet as of the given time.
+// Assets, Liabilities, and Equity sections are computed from journal balances.
+func (e *Engine) BalanceSheetReport(asOf time.Time) BalanceSheet {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if asOf.IsZero() {
+		asOf = e.clock.Now()
+	}
+
+	var assetRows, liabRows, eqRows []ReportRow
+	var assetTotal, liabTotal, eqTotal int64
+
+	for _, acct := range e.accounts {
+		var d, c int64
+		d, c, _ = e.journal.BalanceAt(acct.ID, asOf)
+		if d == 0 && c == 0 {
+			continue
+		}
+
+		switch acct.Type {
+		case AccountTypeAsset:
+			// Assets have debit normal balance.
+			amount := d - c
+			assetRows = append(assetRows, ReportRow{
+				AccountID:   acct.ID,
+				AccountName: acct.Name,
+				AccountType: acct.Type,
+				Amount:      amount,
+			})
+			assetTotal += amount
+		case AccountTypeLiability:
+			// Liabilities have credit normal balance.
+			amount := c - d
+			liabRows = append(liabRows, ReportRow{
+				AccountID:   acct.ID,
+				AccountName: acct.Name,
+				AccountType: acct.Type,
+				Amount:      amount,
+			})
+			liabTotal += amount
+		case AccountTypeEquity:
+			// Equity has credit normal balance.
+			amount := c - d
+			eqRows = append(eqRows, ReportRow{
+				AccountID:   acct.ID,
+				AccountName: acct.Name,
+				AccountType: acct.Type,
+				Amount:      amount,
+			})
+			eqTotal += amount
+		}
+	}
+
+	return BalanceSheet{
+		Assets:      ReportSection{Title: "Assets", Rows: assetRows, Total: assetTotal},
+		Liabilities: ReportSection{Title: "Liabilities", Rows: liabRows, Total: liabTotal},
+		Equity:      ReportSection{Title: "Equity", Rows: eqRows, Total: eqTotal},
+		AsOf:        asOf,
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `twinkit/ledger/accounting/` — the accounting engine implementing the engine+hooks pattern (ADR-001)
- Document state machine: DRAFT → SUBMITTED → AUTHORISED → PAID/VOIDED/DELETED
- Generates balanced journal entries on AUTHORISED (invoice: debit AR, credit revenue; bill: debit expense, credit AP)
- Payment application with auto-PAID on full payment, partial payment support
- Period locking rejects mutations to locked periods
- Manual journal posting with balance validation
- Financial reports: Trial Balance, Profit & Loss, Balance Sheet — all computed from journal history
- `AccountingHooks` interface with `NoOpAccountingHooks` for platform-specific behavior

## Test plan
- [x] 25 tests covering state transitions (valid/invalid), payment application (full/partial/rejected), journal entry generation, period locking, manual journals, report computation, hook invocation, account management
- [x] `go test ./twinkit/ledger/accounting/...` passes
- [x] No regressions in `go test ./twinkit/...`

> **Note:** Stacked on `feature/journal-store` (#105). Rebase onto main after that merges.