### PR TITLE
fix(twin-qbo): wire journal entries into transaction handlers (GAP-001)

### DIFF
--- a/twin-qbo/internal/api/handlers_bills.go
+++ b/twin-qbo/internal/api/handlers_bills.go
@@ -55,6 +55,7 @@ func (h *Handler) CreateOrUpdateBill(w http.ResponseWriter, r *http.Request) {
 		computeBillTotals(&bill)
 		bill.Balance = bill.TotalAmt
 		h.store.Bills.Set(bill.Id, bill)
+		h.journalBillCreated(&bill)
 		h.fireEvent("Bill", bill.Id, "Create")
 	}
 

--- a/twin-qbo/internal/api/handlers_invoices.go
+++ b/twin-qbo/internal/api/handlers_invoices.go
@@ -78,6 +78,7 @@ func (h *Handler) CreateOrUpdateInvoice(w http.ResponseWriter, r *http.Request) 
 		computeInvoiceTotals(&inv)
 		inv.Balance = inv.TotalAmt
 		h.store.Invoices.Set(inv.Id, inv)
+		h.journalInvoiceCreated(&inv)
 		h.fireEvent("Invoice", inv.Id, "Create")
 	}
 

--- a/twin-qbo/internal/api/handlers_payments.go
+++ b/twin-qbo/internal/api/handlers_payments.go
@@ -92,6 +92,7 @@ func (h *Handler) CreateOrUpdatePayment(w http.ResponseWriter, r *http.Request) 
 		pmt.UnappliedAmt = pmt.TotalAmt - applied
 
 		h.store.Payments.Set(pmt.Id, pmt)
+		h.journalPaymentCreated(&pmt)
 		h.fireEvent("Payment", pmt.Id, "Create")
 	}
 
@@ -153,6 +154,7 @@ func (h *Handler) CreateOrUpdateBillPayment(w http.ResponseWriter, r *http.Reque
 		}
 
 		h.store.BillPayments.Set(bp.Id, bp)
+		h.journalBillPaymentCreated(&bp)
 		h.fireEvent("BillPayment", bp.Id, "Create")
 	}
 

--- a/twin-qbo/internal/api/handlers_test.go
+++ b/twin-qbo/internal/api/handlers_test.go
@@ -395,3 +395,148 @@ func TestReports_TrialBalance(t *testing.T) {
 		t.Error("expected Header in report response")
 	}
 }
+
+// --- Journal Entry Generation (GAP-001) ---
+
+func TestJournalEntries_InvoiceCreatesEntries(t *testing.T) {
+	h, r := setupTestHandler()
+
+	// Create AR account.
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Accounts Receivable", "AccountType": "Accounts Receivable",
+	})
+
+	// Create income account.
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Sales", "AccountType": "Income",
+	})
+
+	// Create invoice — should generate journal entries.
+	doReq(r, "POST", "/v3/company/123/invoice", map[string]any{
+		"CustomerRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{
+			"Amount": 1000.00, "DetailType": "SalesItemLineDetail",
+			"SalesItemLineDetail": map[string]any{"Qty": 1, "UnitPrice": 1000},
+		}},
+	})
+
+	// Journal should have entries.
+	txs := h.engine.Journal().Transactions()
+	if len(txs) == 0 {
+		t.Fatal("expected journal transactions after invoice create, got 0")
+	}
+
+	// Trial balance should now have data.
+	w := doReq(r, "GET", "/v3/company/123/reports/TrialBalance", nil)
+	resp := parseResp(t, w)
+	rows := resp["Rows"]
+	if rows == nil {
+		t.Fatal("expected Rows in trial balance")
+	}
+	rowList, ok := rows.([]any)
+	if !ok || len(rowList) == 0 {
+		t.Error("expected non-empty trial balance rows after invoice creation")
+	}
+}
+
+func TestJournalEntries_PaymentCreatesEntries(t *testing.T) {
+	h, r := setupTestHandler()
+
+	// Create accounts.
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Accounts Receivable", "AccountType": "Accounts Receivable",
+	})
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Bank", "AccountType": "Bank",
+	})
+
+	// Create invoice.
+	w := doReq(r, "POST", "/v3/company/123/invoice", map[string]any{
+		"CustomerRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{
+			"Amount": 500.00, "DetailType": "SalesItemLineDetail",
+			"SalesItemLineDetail": map[string]any{"Qty": 1, "UnitPrice": 500},
+		}},
+	})
+	invID := parseResp(t, w)["Invoice"].(map[string]any)["Id"].(string)
+
+	txsBefore := len(h.engine.Journal().Transactions())
+
+	// Create payment with bank deposit.
+	w = doReq(r, "POST", "/v3/company/123/payment", map[string]any{
+		"CustomerRef":         map[string]any{"value": "1"},
+		"TotalAmt":            500.00,
+		"DepositToAccountRef": map[string]any{"value": "2"},
+		"Line": []map[string]any{{
+			"Amount":    500.00,
+			"LinkedTxn": []map[string]any{{"TxnId": invID, "TxnType": "Invoice"}},
+		}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("payment create: %d %s", w.Code, w.Body.String())
+	}
+
+	txsAfter := len(h.engine.Journal().Transactions())
+	if txsAfter <= txsBefore {
+		t.Errorf("expected new journal transaction from payment, before=%d after=%d", txsBefore, txsAfter)
+	}
+}
+
+func TestJournalEntries_BillCreatesEntries(t *testing.T) {
+	h, r := setupTestHandler()
+
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Accounts Payable", "AccountType": "Accounts Payable",
+	})
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Office Supplies", "AccountType": "Expense",
+	})
+
+	txsBefore := len(h.engine.Journal().Transactions())
+
+	doReq(r, "POST", "/v3/company/123/bill", map[string]any{
+		"VendorRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{
+			"Amount": 200.00, "DetailType": "AccountBasedExpenseLineDetail",
+			"AccountBasedExpenseLineDetail": map[string]any{
+				"AccountRef": map[string]any{"value": "2"},
+			},
+		}},
+	})
+
+	txsAfter := len(h.engine.Journal().Transactions())
+	if txsAfter <= txsBefore {
+		t.Errorf("expected new journal transaction from bill, before=%d after=%d", txsBefore, txsAfter)
+	}
+}
+
+func TestJournalEntries_ManualJournalEntry(t *testing.T) {
+	h, r := setupTestHandler()
+
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Bank", "AccountType": "Bank",
+	})
+	doReq(r, "POST", "/v3/company/123/account", map[string]any{
+		"Name": "Revenue", "AccountType": "Income",
+	})
+
+	txsBefore := len(h.engine.Journal().Transactions())
+
+	doReq(r, "POST", "/v3/company/123/journalentry", map[string]any{
+		"Line": []map[string]any{
+			{"Amount": 500.00, "DetailType": "JournalEntryLineDetail",
+				"JournalEntryLineDetail": map[string]any{
+					"PostingType": "Debit", "AccountRef": map[string]any{"value": "1"},
+				}},
+			{"Amount": 500.00, "DetailType": "JournalEntryLineDetail",
+				"JournalEntryLineDetail": map[string]any{
+					"PostingType": "Credit", "AccountRef": map[string]any{"value": "2"},
+				}},
+		},
+	})
+
+	txsAfter := len(h.engine.Journal().Transactions())
+	if txsAfter <= txsBefore {
+		t.Errorf("expected new journal transaction from JE, before=%d after=%d", txsBefore, txsAfter)
+	}
+}

--- a/twin-qbo/internal/api/handlers_transactions.go
+++ b/twin-qbo/internal/api/handlers_transactions.go
@@ -118,6 +118,7 @@ func (h *Handler) CreateOrUpdateSalesReceipt(w http.ResponseWriter, r *http.Requ
 		for _, line := range sr.Line { total += line.Amount }
 		sr.TotalAmt = total
 		h.store.SalesReceipts.Set(sr.Id, sr)
+		h.journalSalesReceiptCreated(&sr)
 	}
 	qboJSON(w, http.StatusOK, entityResponse("SalesReceipt", sr))
 }
@@ -155,6 +156,7 @@ func (h *Handler) CreateOrUpdateDeposit(w http.ResponseWriter, r *http.Request) 
 		for _, line := range dep.Line { total += line.Amount }
 		dep.TotalAmt = total
 		h.store.Deposits.Set(dep.Id, dep)
+		h.journalDepositCreated(&dep)
 	}
 	qboJSON(w, http.StatusOK, entityResponse("Deposit", dep))
 }
@@ -189,6 +191,7 @@ func (h *Handler) CreateOrUpdateTransfer(w http.ResponseWriter, r *http.Request)
 		xfer.Domain = "QBO"
 		xfer.MetaData = h.store.NewMetaData()
 		h.store.Transfers.Set(xfer.Id, xfer)
+		h.journalTransferCreated(&xfer)
 	}
 	qboJSON(w, http.StatusOK, entityResponse("Transfer", xfer))
 }
@@ -230,6 +233,7 @@ func (h *Handler) CreateOrUpdateJournalEntry(w http.ResponseWriter, r *http.Requ
 		}
 		je.TotalAmt = total
 		h.store.JournalEntries.Set(je.Id, je)
+		h.journalJournalEntryCreated(&je)
 	}
 	qboJSON(w, http.StatusOK, entityResponse("JournalEntry", je))
 }
@@ -305,6 +309,7 @@ func (h *Handler) CreateOrUpdatePurchase(w http.ResponseWriter, r *http.Request)
 		for _, line := range pur.Line { total += line.Amount }
 		pur.TotalAmt = total
 		h.store.Purchases.Set(pur.Id, pur)
+		h.journalPurchaseCreated(&pur)
 	}
 	qboJSON(w, http.StatusOK, entityResponse("Purchase", pur))
 }

--- a/twin-qbo/internal/api/journal.go
+++ b/twin-qbo/internal/api/journal.go
@@ -1,0 +1,339 @@
+package api
+
+import (
+	"github.com/wondertwin-ai/wondertwin/twinkit/store/journal"
+	"github.com/wondertwin-ai/wondertwin/twin-qbo/internal/store"
+)
+
+// Well-known account IDs. These are set when accounts are created via the API.
+// If an account with the matching AccountType exists, its ID is used.
+// Otherwise these fallback IDs are used (the engine will accept them
+// even without a registered account — journal entries are ID-based).
+const (
+	fallbackAR          = "accounts_receivable"
+	fallbackAP          = "accounts_payable"
+	fallbackUndeposited = "undeposited_funds"
+)
+
+// resolveAR returns the Accounts Receivable account ID.
+func (h *Handler) resolveAR() string {
+	items := h.store.Accounts.Filter(func(_ string, a store.Account) bool {
+		return a.AccountType == "Accounts Receivable" && a.Active
+	})
+	if len(items) > 0 {
+		return items[0].Id
+	}
+	return fallbackAR
+}
+
+// resolveAP returns the Accounts Payable account ID.
+func (h *Handler) resolveAP() string {
+	items := h.store.Accounts.Filter(func(_ string, a store.Account) bool {
+		return a.AccountType == "Accounts Payable" && a.Active
+	})
+	if len(items) > 0 {
+		return items[0].Id
+	}
+	return fallbackAP
+}
+
+// resolveUndeposited returns the Undeposited Funds account ID.
+func (h *Handler) resolveUndeposited() string {
+	items := h.store.Accounts.Filter(func(_ string, a store.Account) bool {
+		return a.AccountType == "Other Current Asset" && a.Name == "Undeposited Funds"
+	})
+	if len(items) > 0 {
+		return items[0].Id
+	}
+	return fallbackUndeposited
+}
+
+// journalInvoiceCreated creates journal entries for a new invoice.
+// Debit: Accounts Receivable, Credit: Income account(s) from line items.
+func (h *Handler) journalInvoiceCreated(inv *store.Invoice) {
+	if inv.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(inv.TotalAmt * 100)
+	currency := "USD"
+	if inv.CurrencyRef != nil {
+		currency = inv.CurrencyRef.Value
+	}
+
+	var entries []journal.Entry
+	entries = append(entries, journal.Entry{
+		AccountID: h.resolveAR(), Type: journal.Debit, Amount: amount,
+		Currency: currency, SourceType: "invoice", SourceID: inv.Id,
+	})
+
+	// Credit income accounts from line items.
+	credited := h.creditLineItems(inv.Line, currency, "invoice", inv.Id)
+	if len(credited) > 0 {
+		entries = append(entries, credited...)
+	} else {
+		// No line-level accounts — credit a single income entry.
+		entries = append(entries, journal.Entry{
+			AccountID: "income", Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "invoice", SourceID: inv.Id,
+		})
+	}
+
+	h.engine.Journal().Append(journal.Transaction{Entries: entries})
+}
+
+// journalBillCreated creates journal entries for a new bill.
+// Debit: Expense account(s), Credit: Accounts Payable.
+func (h *Handler) journalBillCreated(bill *store.Bill) {
+	if bill.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(bill.TotalAmt * 100)
+	currency := "USD"
+
+	var entries []journal.Entry
+	// Debit expense accounts from line items.
+	debited := h.debitLineItems(bill.Line, currency, "bill", bill.Id)
+	if len(debited) > 0 {
+		entries = append(entries, debited...)
+	} else {
+		entries = append(entries, journal.Entry{
+			AccountID: "expense", Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "bill", SourceID: bill.Id,
+		})
+	}
+
+	entries = append(entries, journal.Entry{
+		AccountID: h.resolveAP(), Type: journal.Credit, Amount: amount,
+		Currency: currency, SourceType: "bill", SourceID: bill.Id,
+	})
+
+	h.engine.Journal().Append(journal.Transaction{Entries: entries})
+}
+
+// journalPaymentCreated creates journal entries for a customer payment.
+// Debit: Bank/Undeposited Funds, Credit: Accounts Receivable.
+func (h *Handler) journalPaymentCreated(pmt *store.Payment) {
+	if pmt.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(pmt.TotalAmt * 100)
+	currency := "USD"
+
+	depositTo := h.resolveUndeposited()
+	if pmt.DepositToAccountRef != nil {
+		depositTo = pmt.DepositToAccountRef.Value
+	}
+
+	h.engine.Journal().Append(journal.Transaction{Entries: []journal.Entry{
+		{AccountID: depositTo, Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "payment", SourceID: pmt.Id},
+		{AccountID: h.resolveAR(), Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "payment", SourceID: pmt.Id},
+	}})
+}
+
+// journalBillPaymentCreated creates journal entries for a vendor bill payment.
+// Debit: Accounts Payable, Credit: Bank account.
+func (h *Handler) journalBillPaymentCreated(bp *store.BillPayment) {
+	if bp.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(bp.TotalAmt * 100)
+	currency := "USD"
+
+	bankAcct := "bank"
+	if bp.CheckPayment != nil && bp.CheckPayment.BankAccountRef != nil {
+		bankAcct = bp.CheckPayment.BankAccountRef.Value
+	}
+
+	h.engine.Journal().Append(journal.Transaction{Entries: []journal.Entry{
+		{AccountID: h.resolveAP(), Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "billpayment", SourceID: bp.Id},
+		{AccountID: bankAcct, Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "billpayment", SourceID: bp.Id},
+	}})
+}
+
+// journalSalesReceiptCreated creates entries for an immediate-payment sale.
+// Debit: Undeposited Funds/Bank, Credit: Income.
+func (h *Handler) journalSalesReceiptCreated(sr *store.SalesReceipt) {
+	if sr.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(sr.TotalAmt * 100)
+	currency := "USD"
+	depositTo := h.resolveUndeposited()
+	if sr.DepositToAccountRef != nil {
+		depositTo = sr.DepositToAccountRef.Value
+	}
+
+	var entries []journal.Entry
+	entries = append(entries, journal.Entry{
+		AccountID: depositTo, Type: journal.Debit, Amount: amount,
+		Currency: currency, SourceType: "salesreceipt", SourceID: sr.Id,
+	})
+	credited := h.creditLineItems(sr.Line, currency, "salesreceipt", sr.Id)
+	if len(credited) > 0 {
+		entries = append(entries, credited...)
+	} else {
+		entries = append(entries, journal.Entry{
+			AccountID: "income", Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "salesreceipt", SourceID: sr.Id,
+		})
+	}
+	h.engine.Journal().Append(journal.Transaction{Entries: entries})
+}
+
+// journalDepositCreated creates entries for a bank deposit.
+// Debit: Bank, Credit: Undeposited Funds.
+func (h *Handler) journalDepositCreated(dep *store.Deposit) {
+	if dep.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(dep.TotalAmt * 100)
+	currency := "USD"
+	bankAcct := "bank"
+	if dep.DepositToAccountRef != nil {
+		bankAcct = dep.DepositToAccountRef.Value
+	}
+
+	h.engine.Journal().Append(journal.Transaction{Entries: []journal.Entry{
+		{AccountID: bankAcct, Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "deposit", SourceID: dep.Id},
+		{AccountID: h.resolveUndeposited(), Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "deposit", SourceID: dep.Id},
+	}})
+}
+
+// journalTransferCreated creates entries for an inter-account transfer.
+// Debit: ToAccount, Credit: FromAccount.
+func (h *Handler) journalTransferCreated(xfer *store.Transfer) {
+	if xfer.Amount <= 0 {
+		return
+	}
+	amount := int64(xfer.Amount * 100)
+	currency := "USD"
+
+	from := "bank_from"
+	to := "bank_to"
+	if xfer.FromAccountRef != nil {
+		from = xfer.FromAccountRef.Value
+	}
+	if xfer.ToAccountRef != nil {
+		to = xfer.ToAccountRef.Value
+	}
+
+	h.engine.Journal().Append(journal.Transaction{Entries: []journal.Entry{
+		{AccountID: to, Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "transfer", SourceID: xfer.Id},
+		{AccountID: from, Type: journal.Credit, Amount: amount,
+			Currency: currency, SourceType: "transfer", SourceID: xfer.Id},
+	}})
+}
+
+// journalJournalEntryCreated creates entries from a manual journal entry.
+func (h *Handler) journalJournalEntryCreated(je *store.JournalEntry) {
+	var entries []journal.Entry
+	currency := "USD"
+	for _, line := range je.Line {
+		if line.JournalEntryLineDetail == nil {
+			continue
+		}
+		acctID := "unknown"
+		if line.JournalEntryLineDetail.AccountRef != nil {
+			acctID = line.JournalEntryLineDetail.AccountRef.Value
+		}
+		amount := int64(line.Amount * 100)
+		if amount <= 0 {
+			continue
+		}
+		entryType := journal.Debit
+		if line.JournalEntryLineDetail.PostingType == "Credit" {
+			entryType = journal.Credit
+		}
+		entries = append(entries, journal.Entry{
+			AccountID: acctID, Type: entryType, Amount: amount,
+			Currency: currency, SourceType: "journalentry", SourceID: je.Id,
+		})
+	}
+	if len(entries) >= 2 {
+		h.engine.Journal().Append(journal.Transaction{Entries: entries})
+	}
+}
+
+// journalPurchaseCreated creates entries for an expense purchase.
+// Debit: Expense account(s), Credit: Payment account (bank/credit card).
+func (h *Handler) journalPurchaseCreated(pur *store.Purchase) {
+	if pur.TotalAmt <= 0 {
+		return
+	}
+	amount := int64(pur.TotalAmt * 100)
+	currency := "USD"
+	payAcct := "bank"
+	if pur.AccountRef != nil {
+		payAcct = pur.AccountRef.Value
+	}
+
+	var entries []journal.Entry
+	debited := h.debitLineItems(pur.Line, currency, "purchase", pur.Id)
+	if len(debited) > 0 {
+		entries = append(entries, debited...)
+	} else {
+		entries = append(entries, journal.Entry{
+			AccountID: "expense", Type: journal.Debit, Amount: amount,
+			Currency: currency, SourceType: "purchase", SourceID: pur.Id,
+		})
+	}
+	entries = append(entries, journal.Entry{
+		AccountID: payAcct, Type: journal.Credit, Amount: amount,
+		Currency: currency, SourceType: "purchase", SourceID: pur.Id,
+	})
+	h.engine.Journal().Append(journal.Transaction{Entries: entries})
+}
+
+// creditLineItems creates Credit entries from sales line items that have account references.
+func (h *Handler) creditLineItems(lines []store.Line, currency, sourceType, sourceID string) []journal.Entry {
+	var entries []journal.Entry
+	for _, line := range lines {
+		if line.Amount <= 0 {
+			continue
+		}
+		acctID := ""
+		if line.SalesItemLineDetail != nil && line.SalesItemLineDetail.ItemRef != nil {
+			// Resolve item's income account.
+			if item, ok := h.store.Items.Get(line.SalesItemLineDetail.ItemRef.Value); ok && item.IncomeAccountRef != nil {
+				acctID = item.IncomeAccountRef.Value
+			}
+		}
+		if acctID == "" {
+			continue
+		}
+		entries = append(entries, journal.Entry{
+			AccountID: acctID, Type: journal.Credit, Amount: int64(line.Amount * 100),
+			Currency: currency, SourceType: sourceType, SourceID: sourceID,
+		})
+	}
+	return entries
+}
+
+// debitLineItems creates Debit entries from expense line items.
+func (h *Handler) debitLineItems(lines []store.Line, currency, sourceType, sourceID string) []journal.Entry {
+	var entries []journal.Entry
+	for _, line := range lines {
+		if line.Amount <= 0 {
+			continue
+		}
+		acctID := ""
+		if line.AccountBasedExpenseLineDetail != nil && line.AccountBasedExpenseLineDetail.AccountRef != nil {
+			acctID = line.AccountBasedExpenseLineDetail.AccountRef.Value
+		}
+		if acctID == "" {
+			continue
+		}
+		entries = append(entries, journal.Entry{
+			AccountID: acctID, Type: journal.Debit, Amount: int64(line.Amount * 100),
+			Currency: currency, SourceType: sourceType, SourceID: sourceID,
+		})
+	}
+	return entries
+}


### PR DESCRIPTION
## Summary
All transaction handlers now generate balanced double-entry journal entries. Reports (Trial Balance, P&L, Balance Sheet) return real computed data instead of empty results.

Covers: Invoice, Bill, Payment, BillPayment, SalesReceipt, Deposit, Transfer, JournalEntry, Purchase.

## Test plan
- [x] 4 new tests: invoice creates entries, payment creates entries, bill creates entries, manual JE creates entries
- [x] Trial balance returns non-empty rows after invoice creation
- [x] All 18 tests pass