### PR TITLE
fix(twin-qbo): add void/delete to all transaction types (GAP-003)

### DIFF
--- a/twin-qbo/internal/api/handlers_bills.go
+++ b/twin-qbo/internal/api/handlers_bills.go
@@ -17,14 +17,33 @@ func (h *Handler) CreateOrUpdateBill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if op == "delete" {
-		if _, ok := h.store.Bills.Get(bill.Id); !ok {
+	if op == "delete" || op == "void" {
+		existing, ok := h.store.Bills.Get(bill.Id)
+		if !ok {
 			notFoundFault(w, "Bill", bill.Id)
 			return
 		}
-		h.store.Bills.Delete(bill.Id)
-		h.fireEvent("Bill", bill.Id, "Delete")
-		qboJSON(w, http.StatusOK, entityResponse("Bill", bill))
+		if err := ValidateSyncToken(existing.SyncToken, bill.SyncToken); err != nil {
+			staleSyncTokenFault(w)
+			return
+		}
+		if op == "void" {
+			existing.Balance = 0
+			existing.TotalAmt = 0
+			for i := range existing.Line {
+				existing.Line[i].Amount = 0
+			}
+		}
+		existing.SyncToken = IncrementSyncToken(existing.SyncToken)
+		existing.MetaData.LastUpdatedTime = h.store.Now()
+		if op == "delete" {
+			h.store.Bills.Delete(bill.Id)
+			h.fireEvent("Bill", bill.Id, "Delete")
+		} else {
+			h.store.Bills.Set(bill.Id, existing)
+			h.fireEvent("Bill", bill.Id, "Void")
+		}
+		qboJSON(w, http.StatusOK, entityResponse("Bill", existing))
 		return
 	}
 

--- a/twin-qbo/internal/api/handlers_payments.go
+++ b/twin-qbo/internal/api/handlers_payments.go
@@ -110,10 +110,35 @@ func (h *Handler) GetPayment(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) CreateOrUpdateBillPayment(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var bp store.BillPayment
 	if err := json.NewDecoder(r.Body).Decode(&bp); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+
+	if op == "void" {
+		existing, ok := h.store.BillPayments.Get(bp.Id)
+		if !ok { notFoundFault(w, "BillPayment", bp.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, bp.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		// Un-apply from linked bills.
+		for _, line := range existing.Line {
+			for _, link := range line.LinkedTxn {
+				if link.TxnType == "Bill" {
+					if bill, ok := h.store.Bills.Get(link.TxnId); ok {
+						bill.Balance += line.Amount; bill.MetaData.LastUpdatedTime = h.store.Now()
+						h.store.Bills.Set(bill.Id, bill)
+					}
+				}
+			}
+		}
+		existing.SyncToken = IncrementSyncToken(existing.SyncToken); existing.MetaData.LastUpdatedTime = h.store.Now()
+		h.store.BillPayments.Set(existing.Id, existing); h.fireEvent("BillPayment", existing.Id, "Void")
+		qboJSON(w, http.StatusOK, entityResponse("BillPayment", existing)); return
+	}
+	if op == "delete" {
+		h.store.BillPayments.Delete(bp.Id); h.fireEvent("BillPayment", bp.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("BillPayment", bp)); return
 	}
 
 	if bp.Id != "" {

--- a/twin-qbo/internal/api/handlers_test.go
+++ b/twin-qbo/internal/api/handlers_test.go
@@ -457,6 +457,79 @@ func TestReports_TrialBalance(t *testing.T) {
 	}
 }
 
+// --- Void/Delete Operations (GAP-003) ---
+
+func TestBill_Void(t *testing.T) {
+	_, r := setupTestHandler()
+	w := doReq(r, "POST", "/v3/company/123/bill", map[string]any{
+		"VendorRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{"Amount": 200.00, "DetailType": "AccountBasedExpenseLineDetail",
+			"AccountBasedExpenseLineDetail": map[string]any{"AccountRef": map[string]any{"value": "1"}}}},
+	})
+	resp := parseResp(t, w)
+	billID := resp["Bill"].(map[string]any)["Id"].(string)
+
+	w = doReq(r, "POST", "/v3/company/123/bill?operation=void", map[string]any{
+		"Id": billID, "SyncToken": "0",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("void bill: %d %s", w.Code, w.Body.String())
+	}
+	resp = parseResp(t, w)
+	bill := resp["Bill"].(map[string]any)
+	if bill["Balance"].(float64) != 0 {
+		t.Errorf("voided Balance = %v, want 0", bill["Balance"])
+	}
+	if bill["TotalAmt"].(float64) != 0 {
+		t.Errorf("voided TotalAmt = %v, want 0", bill["TotalAmt"])
+	}
+}
+
+func TestCreditMemo_Delete(t *testing.T) {
+	_, r := setupTestHandler()
+	w := doReq(r, "POST", "/v3/company/123/creditmemo", map[string]any{
+		"CustomerRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{"Amount": 50.00, "DetailType": "SalesItemLineDetail",
+			"SalesItemLineDetail": map[string]any{"Qty": 1, "UnitPrice": 50}}},
+	})
+	cmID := parseResp(t, w)["CreditMemo"].(map[string]any)["Id"].(string)
+
+	w = doReq(r, "POST", "/v3/company/123/creditmemo?operation=delete", map[string]any{
+		"Id": cmID, "SyncToken": "0",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete credit memo: %d %s", w.Code, w.Body.String())
+	}
+
+	// Should be gone.
+	w = doReq(r, "GET", "/v3/company/123/creditmemo/"+cmID, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 after delete, got %d", w.Code)
+	}
+}
+
+func TestSalesReceipt_Void(t *testing.T) {
+	_, r := setupTestHandler()
+	w := doReq(r, "POST", "/v3/company/123/salesreceipt", map[string]any{
+		"CustomerRef": map[string]any{"value": "1"},
+		"Line": []map[string]any{{"Amount": 75.00, "DetailType": "SalesItemLineDetail",
+			"SalesItemLineDetail": map[string]any{"Qty": 1, "UnitPrice": 75}}},
+	})
+	srID := parseResp(t, w)["SalesReceipt"].(map[string]any)["Id"].(string)
+
+	w = doReq(r, "POST", "/v3/company/123/salesreceipt?operation=void", map[string]any{
+		"Id": srID, "SyncToken": "0",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("void sales receipt: %d %s", w.Code, w.Body.String())
+	}
+	resp := parseResp(t, w)
+	sr := resp["SalesReceipt"].(map[string]any)
+	if sr["TotalAmt"].(float64) != 0 {
+		t.Errorf("voided TotalAmt = %v, want 0", sr["TotalAmt"])
+	}
+}
+
 // --- Journal Entry Generation (GAP-001) ---
 
 func TestJournalEntries_InvoiceCreatesEntries(t *testing.T) {

--- a/twin-qbo/internal/api/handlers_transactions.go
+++ b/twin-qbo/internal/api/handlers_transactions.go
@@ -11,10 +11,20 @@ import (
 // --- Credit Memo ---
 
 func (h *Handler) CreateOrUpdateCreditMemo(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var cm store.CreditMemo
 	if err := json.NewDecoder(r.Body).Decode(&cm); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" || op == "void" {
+		existing, ok := h.store.CreditMemos.Get(cm.Id)
+		if !ok { notFoundFault(w, "CreditMemo", cm.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, cm.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		if op == "void" { existing.TotalAmt = 0; existing.RemainingCredit = 0; for i := range existing.Line { existing.Line[i].Amount = 0 } }
+		existing.SyncToken = IncrementSyncToken(existing.SyncToken); existing.MetaData.LastUpdatedTime = h.store.Now()
+		if op == "delete" { h.store.CreditMemos.Delete(cm.Id); h.fireEvent("CreditMemo", cm.Id, "Delete") } else { h.store.CreditMemos.Set(cm.Id, existing); h.fireEvent("CreditMemo", cm.Id, "Void") }
+		qboJSON(w, http.StatusOK, entityResponse("CreditMemo", existing)); return
 	}
 	if cm.Id != "" {
 		existing, ok := h.store.CreditMemos.Get(cm.Id)
@@ -54,10 +64,16 @@ func computeCreditMemoTotals(cm *store.CreditMemo) {
 // --- Vendor Credit ---
 
 func (h *Handler) CreateOrUpdateVendorCredit(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var vc store.VendorCredit
 	if err := json.NewDecoder(r.Body).Decode(&vc); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.VendorCredits.Get(vc.Id); !ok { notFoundFault(w, "VendorCredit", vc.Id); return }
+		h.store.VendorCredits.Delete(vc.Id); h.fireEvent("VendorCredit", vc.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("VendorCredit", vc)); return
 	}
 	if vc.Id != "" {
 		existing, ok := h.store.VendorCredits.Get(vc.Id)
@@ -92,10 +108,20 @@ func (h *Handler) GetVendorCredit(w http.ResponseWriter, r *http.Request) {
 // --- Sales Receipt ---
 
 func (h *Handler) CreateOrUpdateSalesReceipt(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var sr store.SalesReceipt
 	if err := json.NewDecoder(r.Body).Decode(&sr); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" || op == "void" {
+		existing, ok := h.store.SalesReceipts.Get(sr.Id)
+		if !ok { notFoundFault(w, "SalesReceipt", sr.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, sr.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		if op == "void" { existing.TotalAmt = 0; for i := range existing.Line { existing.Line[i].Amount = 0 } }
+		existing.SyncToken = IncrementSyncToken(existing.SyncToken); existing.MetaData.LastUpdatedTime = h.store.Now()
+		if op == "delete" { h.store.SalesReceipts.Delete(sr.Id); h.fireEvent("SalesReceipt", sr.Id, "Delete") } else { h.store.SalesReceipts.Set(sr.Id, existing); h.fireEvent("SalesReceipt", sr.Id, "Void") }
+		qboJSON(w, http.StatusOK, entityResponse("SalesReceipt", existing)); return
 	}
 	if sr.Id != "" {
 		existing, ok := h.store.SalesReceipts.Get(sr.Id)
@@ -133,10 +159,16 @@ func (h *Handler) GetSalesReceipt(w http.ResponseWriter, r *http.Request) {
 // --- Deposit ---
 
 func (h *Handler) CreateOrUpdateDeposit(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var dep store.Deposit
 	if err := json.NewDecoder(r.Body).Decode(&dep); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.Deposits.Get(dep.Id); !ok { notFoundFault(w, "Deposit", dep.Id); return }
+		h.store.Deposits.Delete(dep.Id); h.fireEvent("Deposit", dep.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("Deposit", dep)); return
 	}
 	if dep.Id != "" {
 		existing, ok := h.store.Deposits.Get(dep.Id)
@@ -171,10 +203,16 @@ func (h *Handler) GetDeposit(w http.ResponseWriter, r *http.Request) {
 // --- Transfer ---
 
 func (h *Handler) CreateOrUpdateTransfer(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var xfer store.Transfer
 	if err := json.NewDecoder(r.Body).Decode(&xfer); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.Transfers.Get(xfer.Id); !ok { notFoundFault(w, "Transfer", xfer.Id); return }
+		h.store.Transfers.Delete(xfer.Id); h.fireEvent("Transfer", xfer.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("Transfer", xfer)); return
 	}
 	if xfer.Id != "" {
 		existing, ok := h.store.Transfers.Get(xfer.Id)
@@ -206,10 +244,16 @@ func (h *Handler) GetTransfer(w http.ResponseWriter, r *http.Request) {
 // --- Journal Entry ---
 
 func (h *Handler) CreateOrUpdateJournalEntry(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var je store.JournalEntry
 	if err := json.NewDecoder(r.Body).Decode(&je); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.JournalEntries.Get(je.Id); !ok { notFoundFault(w, "JournalEntry", je.Id); return }
+		h.store.JournalEntries.Delete(je.Id); h.fireEvent("JournalEntry", je.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("JournalEntry", je)); return
 	}
 	if je.Id != "" {
 		existing, ok := h.store.JournalEntries.Get(je.Id)
@@ -248,10 +292,16 @@ func (h *Handler) GetJournalEntry(w http.ResponseWriter, r *http.Request) {
 // --- Estimate ---
 
 func (h *Handler) CreateOrUpdateEstimate(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var est store.Estimate
 	if err := json.NewDecoder(r.Body).Decode(&est); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.Estimates.Get(est.Id); !ok { notFoundFault(w, "Estimate", est.Id); return }
+		h.store.Estimates.Delete(est.Id); h.fireEvent("Estimate", est.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("Estimate", est)); return
 	}
 	if est.Id != "" {
 		existing, ok := h.store.Estimates.Get(est.Id)
@@ -286,10 +336,16 @@ func (h *Handler) GetEstimate(w http.ResponseWriter, r *http.Request) {
 // --- Purchase ---
 
 func (h *Handler) CreateOrUpdatePurchase(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
 	var pur store.Purchase
 	if err := json.NewDecoder(r.Body).Decode(&pur); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.Purchases.Get(pur.Id); !ok { notFoundFault(w, "Purchase", pur.Id); return }
+		h.store.Purchases.Delete(pur.Id); h.fireEvent("Purchase", pur.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("Purchase", pur)); return
 	}
 	if pur.Id != "" {
 		existing, ok := h.store.Purchases.Get(pur.Id)


### PR DESCRIPTION
## Summary
All transaction types now support `?operation=void` and/or `?operation=delete`. BillPayment void un-applies from linked bills (restores Balance).

## Test plan
- [x] 3 new tests: bill void, credit memo delete, sales receipt void
- [x] All 24 tests pass