### PR TITLE
fix(twin-qbo): support sparse update (GAP-004)

### DIFF
--- a/twin-qbo/internal/api/handlers_customers.go
+++ b/twin-qbo/internal/api/handlers_customers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -9,8 +10,13 @@ import (
 )
 
 func (h *Handler) CreateOrUpdateCustomer(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		validationFault(w, "500", "Failed to read body", err.Error())
+		return
+	}
 	var c store.Customer
-	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+	if err := json.Unmarshal(body, &c); err != nil {
 		validationFault(w, "500", "Invalid JSON", err.Error())
 		return
 	}
@@ -25,6 +31,15 @@ func (h *Handler) CreateOrUpdateCustomer(w http.ResponseWriter, r *http.Request)
 		if err := ValidateSyncToken(existing.SyncToken, c.SyncToken); err != nil {
 			staleSyncTokenFault(w)
 			return
+		}
+		// Sparse update: merge only provided fields.
+		if IsSparse(body) {
+			merged, err := SparseUpdate(existing, body)
+			if err != nil {
+				validationFault(w, "500", "Sparse merge failed", err.Error())
+				return
+			}
+			c = merged
 		}
 		c.SyncToken = IncrementSyncToken(existing.SyncToken)
 		c.MetaData.CreateTime = existing.MetaData.CreateTime

--- a/twin-qbo/internal/api/handlers_test.go
+++ b/twin-qbo/internal/api/handlers_test.go
@@ -125,6 +125,42 @@ func TestCustomer_UpdateWithSyncToken(t *testing.T) {
 	}
 }
 
+func TestCustomer_SparseUpdate(t *testing.T) {
+	_, r := setupTestHandler()
+	// Create with full fields.
+	w := doReq(r, "POST", "/v3/company/123/customer", map[string]any{
+		"DisplayName": "Alice Smith",
+		"GivenName":   "Alice",
+		"FamilyName":  "Smith",
+		"CompanyName": "Acme Corp",
+	})
+	resp := parseResp(t, w)
+	id := resp["Customer"].(map[string]any)["Id"].(string)
+
+	// Sparse update — only change DisplayName, keep everything else.
+	w = doReq(r, "POST", "/v3/company/123/customer", map[string]any{
+		"Id":          id,
+		"SyncToken":   "0",
+		"sparse":      true,
+		"DisplayName": "Alice Johnson",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("sparse update: %d %s", w.Code, w.Body.String())
+	}
+	resp = parseResp(t, w)
+	cust := resp["Customer"].(map[string]any)
+	if cust["DisplayName"] != "Alice Johnson" {
+		t.Errorf("DisplayName = %v, want 'Alice Johnson'", cust["DisplayName"])
+	}
+	// GivenName should be preserved from the original.
+	if cust["GivenName"] != "Alice" {
+		t.Errorf("GivenName = %v, want 'Alice' (should be preserved in sparse update)", cust["GivenName"])
+	}
+	if cust["CompanyName"] != "Acme Corp" {
+		t.Errorf("CompanyName = %v, want 'Acme Corp' (should be preserved)", cust["CompanyName"])
+	}
+}
+
 func TestCustomer_StaleSyncToken(t *testing.T) {
 	_, r := setupTestHandler()
 	w := doReq(r, "POST", "/v3/company/123/customer", map[string]any{

--- a/twin-qbo/internal/api/sparse.go
+++ b/twin-qbo/internal/api/sparse.go
@@ -1,0 +1,57 @@
+package api
+
+import "encoding/json"
+
+// SparseUpdate detects if the raw JSON has "sparse": true and if so,
+// merges the request fields into the existing entity. Returns the merged
+// entity. If not sparse, returns the request entity unchanged.
+//
+// The merge works by: marshal existing → overlay request fields → unmarshal.
+// This preserves existing fields not present in the request.
+func SparseUpdate[T any](existing T, requestJSON []byte) (T, error) {
+	// Marshal existing to a map.
+	existingBytes, err := json.Marshal(existing)
+	if err != nil {
+		return existing, err
+	}
+	var base map[string]any
+	if err := json.Unmarshal(existingBytes, &base); err != nil {
+		return existing, err
+	}
+
+	// Unmarshal request to a map (only has the fields the client sent).
+	var overlay map[string]any
+	if err := json.Unmarshal(requestJSON, &overlay); err != nil {
+		return existing, err
+	}
+
+	// Overlay request fields onto base.
+	for k, v := range overlay {
+		base[k] = v
+	}
+
+	// Marshal merged map back to the entity type.
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return existing, err
+	}
+	var result T
+	if err := json.Unmarshal(merged, &result); err != nil {
+		return existing, err
+	}
+	return result, nil
+}
+
+// IsSparse checks if the raw JSON contains "sparse": true.
+func IsSparse(raw []byte) bool {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	v, ok := m["sparse"]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
+}


### PR DESCRIPTION
## Summary
Adds `"sparse": true` support for partial updates. When present, only the provided fields are merged into the existing entity — unprovided fields are preserved.

Implemented on Customer as the exemplar with reusable `SparseUpdate[T]` and `IsSparse()` helpers. Same pattern applies to all entity types.

## Test plan
- [x] 1 new test: sparse update preserves GivenName/CompanyName while changing DisplayName
- [x] All 25 tests pass