### PR TITLE
feat(twin-qbo): add name list entities (GAP-005)

### DIFF
--- a/twin-qbo/internal/api/handlers_name_lists.go
+++ b/twin-qbo/internal/api/handlers_name_lists.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-qbo/internal/store"
+)
+
+// --- Employee ---
+
+func (h *Handler) CreateOrUpdateEmployee(w http.ResponseWriter, r *http.Request) {
+	var e store.Employee
+	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if e.Id != "" {
+		existing, ok := h.store.Employees.Get(e.Id)
+		if !ok { notFoundFault(w, "Employee", e.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, e.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		e.SyncToken = IncrementSyncToken(existing.SyncToken)
+		e.MetaData.CreateTime = existing.MetaData.CreateTime
+		e.MetaData.LastUpdatedTime = h.store.Now()
+		e.Domain = "QBO"
+		h.store.Employees.Set(e.Id, e)
+	} else {
+		e.Id = h.store.NextID(); e.SyncToken = "0"; e.Active = true; e.Domain = "QBO"
+		e.MetaData = h.store.NewMetaData()
+		h.store.Employees.Set(e.Id, e)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("Employee", e))
+}
+
+func (h *Handler) GetEmployee(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	e, ok := h.store.Employees.Get(id)
+	if !ok { notFoundFault(w, "Employee", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("Employee", e))
+}
+
+// --- Class ---
+
+func (h *Handler) CreateOrUpdateClass(w http.ResponseWriter, r *http.Request) {
+	var c store.Class
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if c.Id != "" {
+		existing, ok := h.store.Classes.Get(c.Id)
+		if !ok { notFoundFault(w, "Class", c.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, c.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		c.SyncToken = IncrementSyncToken(existing.SyncToken)
+		c.MetaData.CreateTime = existing.MetaData.CreateTime
+		c.MetaData.LastUpdatedTime = h.store.Now()
+		c.Domain = "QBO"
+		h.store.Classes.Set(c.Id, c)
+	} else {
+		c.Id = h.store.NextID(); c.SyncToken = "0"; c.Active = true; c.Domain = "QBO"
+		c.MetaData = h.store.NewMetaData()
+		h.store.Classes.Set(c.Id, c)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("Class", c))
+}
+
+func (h *Handler) GetClass(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, ok := h.store.Classes.Get(id)
+	if !ok { notFoundFault(w, "Class", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("Class", c))
+}
+
+// --- Department ---
+
+func (h *Handler) CreateOrUpdateDepartment(w http.ResponseWriter, r *http.Request) {
+	var d store.Department
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if d.Id != "" {
+		existing, ok := h.store.Departments.Get(d.Id)
+		if !ok { notFoundFault(w, "Department", d.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, d.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		d.SyncToken = IncrementSyncToken(existing.SyncToken)
+		d.MetaData.CreateTime = existing.MetaData.CreateTime
+		d.MetaData.LastUpdatedTime = h.store.Now()
+		d.Domain = "QBO"
+		h.store.Departments.Set(d.Id, d)
+	} else {
+		d.Id = h.store.NextID(); d.SyncToken = "0"; d.Active = true; d.Domain = "QBO"
+		d.MetaData = h.store.NewMetaData()
+		h.store.Departments.Set(d.Id, d)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("Department", d))
+}
+
+func (h *Handler) GetDepartment(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	d, ok := h.store.Departments.Get(id)
+	if !ok { notFoundFault(w, "Department", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("Department", d))
+}
+
+// --- Term ---
+
+func (h *Handler) CreateOrUpdateTerm(w http.ResponseWriter, r *http.Request) {
+	var t store.Term
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if t.Id != "" {
+		existing, ok := h.store.Terms.Get(t.Id)
+		if !ok { notFoundFault(w, "Term", t.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, t.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		t.SyncToken = IncrementSyncToken(existing.SyncToken)
+		t.MetaData.CreateTime = existing.MetaData.CreateTime
+		t.MetaData.LastUpdatedTime = h.store.Now()
+		t.Domain = "QBO"
+		h.store.Terms.Set(t.Id, t)
+	} else {
+		t.Id = h.store.NextID(); t.SyncToken = "0"; t.Active = true; t.Domain = "QBO"
+		t.MetaData = h.store.NewMetaData()
+		h.store.Terms.Set(t.Id, t)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("Term", t))
+}
+
+func (h *Handler) GetTerm(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	t, ok := h.store.Terms.Get(id)
+	if !ok { notFoundFault(w, "Term", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("Term", t))
+}
+
+// --- PaymentMethod ---
+
+func (h *Handler) CreateOrUpdatePaymentMethod(w http.ResponseWriter, r *http.Request) {
+	var pm store.PaymentMethod
+	if err := json.NewDecoder(r.Body).Decode(&pm); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if pm.Id != "" {
+		existing, ok := h.store.PaymentMethods.Get(pm.Id)
+		if !ok { notFoundFault(w, "PaymentMethod", pm.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, pm.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		pm.SyncToken = IncrementSyncToken(existing.SyncToken)
+		pm.MetaData.CreateTime = existing.MetaData.CreateTime
+		pm.MetaData.LastUpdatedTime = h.store.Now()
+		pm.Domain = "QBO"
+		h.store.PaymentMethods.Set(pm.Id, pm)
+	} else {
+		pm.Id = h.store.NextID(); pm.SyncToken = "0"; pm.Active = true; pm.Domain = "QBO"
+		pm.MetaData = h.store.NewMetaData()
+		h.store.PaymentMethods.Set(pm.Id, pm)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("PaymentMethod", pm))
+}
+
+func (h *Handler) GetPaymentMethod(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pm, ok := h.store.PaymentMethods.Get(id)
+	if !ok { notFoundFault(w, "PaymentMethod", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("PaymentMethod", pm))
+}
+
+// --- TaxCode (read-only in US) ---
+
+func (h *Handler) GetTaxCode(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	tc, ok := h.store.TaxCodes.Get(id)
+	if !ok { notFoundFault(w, "TaxCode", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("TaxCode", tc))
+}
+
+// --- TaxRate (read-only in US) ---
+
+func (h *Handler) GetTaxRate(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	tr, ok := h.store.TaxRates.Get(id)
+	if !ok { notFoundFault(w, "TaxRate", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("TaxRate", tr))
+}
+
+// --- Preferences ---
+
+func (h *Handler) GetPreferences(w http.ResponseWriter, r *http.Request) {
+	prefs, ok := h.store.PreferencesStore.Get("1")
+	if !ok {
+		prefs = store.Preferences{
+			Id: "1", SyncToken: "0", Domain: "QBO", MetaData: h.store.NewMetaData(),
+		}
+		h.store.PreferencesStore.Set("1", prefs)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("Preferences", prefs))
+}
+
+func (h *Handler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
+	var prefs store.Preferences
+	if err := json.NewDecoder(r.Body).Decode(&prefs); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if prefs.Id == "" { prefs.Id = "1" }
+	existing, ok := h.store.PreferencesStore.Get(prefs.Id)
+	if !ok {
+		existing = store.Preferences{Id: "1", SyncToken: "0", Domain: "QBO", MetaData: h.store.NewMetaData()}
+	}
+	if err := ValidateSyncToken(existing.SyncToken, prefs.SyncToken); err != nil { staleSyncTokenFault(w); return }
+	prefs.SyncToken = IncrementSyncToken(existing.SyncToken)
+	prefs.MetaData.CreateTime = existing.MetaData.CreateTime
+	prefs.MetaData.LastUpdatedTime = h.store.Now()
+	prefs.Domain = "QBO"
+	h.store.PreferencesStore.Set(prefs.Id, prefs)
+	qboJSON(w, http.StatusOK, entityResponse("Preferences", prefs))
+}

--- a/twin-qbo/internal/api/handlers_query.go
+++ b/twin-qbo/internal/api/handlers_query.go
@@ -90,6 +90,34 @@ func (h *Handler) Query(w http.ResponseWriter, r *http.Request) {
 		items := FilterItems(h.store.Purchases.List(), pq)
 		page := Paginate(items, pq.StartPosition, pq.MaxResults)
 		qboJSON(w, http.StatusOK, queryResponse("Purchase", page, pq.StartPosition, len(page), len(items)))
+	case "employee":
+		items := FilterItems(h.store.Employees.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("Employee", page, pq.StartPosition, len(page), len(items)))
+	case "class":
+		items := FilterItems(h.store.Classes.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("Class", page, pq.StartPosition, len(page), len(items)))
+	case "department":
+		items := FilterItems(h.store.Departments.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("Department", page, pq.StartPosition, len(page), len(items)))
+	case "term":
+		items := FilterItems(h.store.Terms.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("Term", page, pq.StartPosition, len(page), len(items)))
+	case "paymentmethod":
+		items := FilterItems(h.store.PaymentMethods.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("PaymentMethod", page, pq.StartPosition, len(page), len(items)))
+	case "taxcode":
+		items := FilterItems(h.store.TaxCodes.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("TaxCode", page, pq.StartPosition, len(page), len(items)))
+	case "taxrate":
+		items := FilterItems(h.store.TaxRates.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("TaxRate", page, pq.StartPosition, len(page), len(items)))
 	default:
 		validationFault(w, "500", "Invalid entity", "Entity '"+pq.Entity+"' is not supported.")
 	}

--- a/twin-qbo/internal/api/router.go
+++ b/twin-qbo/internal/api/router.go
@@ -96,6 +96,36 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Post("/purchase", h.CreateOrUpdatePurchase)
 		r.Get("/purchase/{id}", h.GetPurchase)
 
+		// Employees
+		r.Post("/employee", h.CreateOrUpdateEmployee)
+		r.Get("/employee/{id}", h.GetEmployee)
+
+		// Classes
+		r.Post("/class", h.CreateOrUpdateClass)
+		r.Get("/class/{id}", h.GetClass)
+
+		// Departments
+		r.Post("/department", h.CreateOrUpdateDepartment)
+		r.Get("/department/{id}", h.GetDepartment)
+
+		// Terms
+		r.Post("/term", h.CreateOrUpdateTerm)
+		r.Get("/term/{id}", h.GetTerm)
+
+		// Payment Methods
+		r.Post("/paymentmethod", h.CreateOrUpdatePaymentMethod)
+		r.Get("/paymentmethod/{id}", h.GetPaymentMethod)
+
+		// Tax Codes (read-only)
+		r.Get("/taxcode/{id}", h.GetTaxCode)
+
+		// Tax Rates (read-only)
+		r.Get("/taxrate/{id}", h.GetTaxRate)
+
+		// Preferences
+		r.Get("/preferences", h.GetPreferences)
+		r.Post("/preferences", h.UpdatePreferences)
+
 		// Reports
 		r.Get("/reports/ProfitAndLoss", h.ProfitAndLoss)
 		r.Get("/reports/BalanceSheet", h.BalanceSheet)

--- a/twin-qbo/internal/store/memory.go
+++ b/twin-qbo/internal/store/memory.go
@@ -28,8 +28,16 @@ type MemoryStore struct {
 	JournalEntries *pkgstore.Store[JournalEntry]
 	Estimates    *pkgstore.Store[Estimate]
 	Purchases    *pkgstore.Store[Purchase]
-	CompanyInfos *pkgstore.Store[CompanyInfo]
-	Journal      *journal.Journal
+	CompanyInfos   *pkgstore.Store[CompanyInfo]
+	Employees      *pkgstore.Store[Employee]
+	Classes        *pkgstore.Store[Class]
+	Departments    *pkgstore.Store[Department]
+	Terms          *pkgstore.Store[Term]
+	PaymentMethods *pkgstore.Store[PaymentMethod]
+	TaxCodes       *pkgstore.Store[TaxCode]
+	TaxRates       *pkgstore.Store[TaxRate]
+	PreferencesStore *pkgstore.Store[Preferences]
+	Journal        *journal.Journal
 	Clock        *pkgstore.Clock
 	idCounter    atomic.Uint64
 }
@@ -54,8 +62,16 @@ func New() *MemoryStore {
 		JournalEntries: pkgstore.New[JournalEntry]("je"),
 		Estimates:     pkgstore.New[Estimate]("est"),
 		Purchases:     pkgstore.New[Purchase]("pur"),
-		CompanyInfos:  pkgstore.New[CompanyInfo]("co"),
-		Journal:       journal.New(clock),
+		CompanyInfos:    pkgstore.New[CompanyInfo]("co"),
+		Employees:       pkgstore.New[Employee]("emp"),
+		Classes:         pkgstore.New[Class]("cls"),
+		Departments:     pkgstore.New[Department]("dept"),
+		Terms:           pkgstore.New[Term]("term"),
+		PaymentMethods:  pkgstore.New[PaymentMethod]("pmeth"),
+		TaxCodes:        pkgstore.New[TaxCode]("tc"),
+		TaxRates:        pkgstore.New[TaxRate]("tr"),
+		PreferencesStore: pkgstore.New[Preferences]("pref"),
+		Journal:         journal.New(clock),
 		Clock:         clock,
 	}
 }
@@ -93,7 +109,15 @@ type stateSnapshot struct {
 	JournalEntries map[string]JournalEntry `json:"journal_entries"`
 	Estimates     map[string]Estimate     `json:"estimates"`
 	Purchases     map[string]Purchase     `json:"purchases"`
-	CompanyInfos  map[string]CompanyInfo  `json:"company_info"`
+	CompanyInfos   map[string]CompanyInfo   `json:"company_info"`
+	Employees      map[string]Employee      `json:"employees"`
+	Classes        map[string]Class         `json:"classes"`
+	Departments    map[string]Department    `json:"departments"`
+	Terms          map[string]Term          `json:"terms"`
+	PaymentMethods map[string]PaymentMethod `json:"payment_methods"`
+	TaxCodes       map[string]TaxCode       `json:"tax_codes"`
+	TaxRates       map[string]TaxRate       `json:"tax_rates"`
+	Preferences    map[string]Preferences   `json:"preferences"`
 }
 
 func (s *MemoryStore) Snapshot() any {
@@ -114,7 +138,15 @@ func (s *MemoryStore) Snapshot() any {
 		JournalEntries: s.JournalEntries.Snapshot(),
 		Estimates:     s.Estimates.Snapshot(),
 		Purchases:     s.Purchases.Snapshot(),
-		CompanyInfos:  s.CompanyInfos.Snapshot(),
+		CompanyInfos:   s.CompanyInfos.Snapshot(),
+		Employees:      s.Employees.Snapshot(),
+		Classes:        s.Classes.Snapshot(),
+		Departments:    s.Departments.Snapshot(),
+		Terms:          s.Terms.Snapshot(),
+		PaymentMethods: s.PaymentMethods.Snapshot(),
+		TaxCodes:       s.TaxCodes.Snapshot(),
+		TaxRates:       s.TaxRates.Snapshot(),
+		Preferences:    s.PreferencesStore.Snapshot(),
 	}
 }
 
@@ -140,6 +172,14 @@ func (s *MemoryStore) LoadState(data []byte) error {
 	s.Estimates.LoadSnapshot(snap.Estimates)
 	s.Purchases.LoadSnapshot(snap.Purchases)
 	s.CompanyInfos.LoadSnapshot(snap.CompanyInfos)
+	s.Employees.LoadSnapshot(snap.Employees)
+	s.Classes.LoadSnapshot(snap.Classes)
+	s.Departments.LoadSnapshot(snap.Departments)
+	s.Terms.LoadSnapshot(snap.Terms)
+	s.PaymentMethods.LoadSnapshot(snap.PaymentMethods)
+	s.TaxCodes.LoadSnapshot(snap.TaxCodes)
+	s.TaxRates.LoadSnapshot(snap.TaxRates)
+	s.PreferencesStore.LoadSnapshot(snap.Preferences)
 	return nil
 }
 
@@ -161,6 +201,14 @@ func (s *MemoryStore) Reset() {
 	s.Estimates.Reset()
 	s.Purchases.Reset()
 	s.CompanyInfos.Reset()
+	s.Employees.Reset()
+	s.Classes.Reset()
+	s.Departments.Reset()
+	s.Terms.Reset()
+	s.PaymentMethods.Reset()
+	s.TaxCodes.Reset()
+	s.TaxRates.Reset()
+	s.PreferencesStore.Reset()
 	s.Journal.Reset()
 	s.Clock.Reset()
 	s.idCounter.Store(0)

--- a/twin-qbo/internal/store/types.go
+++ b/twin-qbo/internal/store/types.go
@@ -298,6 +298,95 @@ type Purchase struct {
 	Domain      string   `json:"domain"`
 }
 
+// Employee represents a QBO employee.
+type Employee struct {
+	Id          string   `json:"Id"`
+	SyncToken   string   `json:"SyncToken"`
+	DisplayName string   `json:"DisplayName"`
+	GivenName   string   `json:"GivenName,omitempty"`
+	FamilyName  string   `json:"FamilyName,omitempty"`
+	Active      bool     `json:"Active"`
+	MetaData    MetaData `json:"MetaData"`
+	Domain      string   `json:"domain"`
+}
+
+// Class represents a QBO classification for tracking.
+type Class struct {
+	Id        string   `json:"Id"`
+	SyncToken string   `json:"SyncToken"`
+	Name      string   `json:"Name"`
+	Active    bool     `json:"Active"`
+	ParentRef *Ref     `json:"ParentRef,omitempty"`
+	MetaData  MetaData `json:"MetaData"`
+	Domain    string   `json:"domain"`
+}
+
+// Department represents a QBO department/location.
+type Department struct {
+	Id        string   `json:"Id"`
+	SyncToken string   `json:"SyncToken"`
+	Name      string   `json:"Name"`
+	Active    bool     `json:"Active"`
+	ParentRef *Ref     `json:"ParentRef,omitempty"`
+	MetaData  MetaData `json:"MetaData"`
+	Domain    string   `json:"domain"`
+}
+
+// Term represents a QBO payment term (e.g., Net 30).
+type Term struct {
+	Id        string   `json:"Id"`
+	SyncToken string   `json:"SyncToken"`
+	Name      string   `json:"Name"`
+	DueDays   int      `json:"DueDays,omitempty"`
+	Active    bool     `json:"Active"`
+	MetaData  MetaData `json:"MetaData"`
+	Domain    string   `json:"domain"`
+}
+
+// PaymentMethod represents a QBO payment method (Cash, Check, etc.).
+type PaymentMethod struct {
+	Id        string   `json:"Id"`
+	SyncToken string   `json:"SyncToken"`
+	Name      string   `json:"Name"`
+	Type      string   `json:"Type,omitempty"` // CREDIT_CARD or NON_CREDIT_CARD
+	Active    bool     `json:"Active"`
+	MetaData  MetaData `json:"MetaData"`
+	Domain    string   `json:"domain"`
+}
+
+// TaxCode represents a QBO tax code (read-only in US).
+type TaxCode struct {
+	Id          string `json:"Id"`
+	SyncToken   string `json:"SyncToken"`
+	Name        string `json:"Name"`
+	Description string `json:"Description,omitempty"`
+	Active      bool   `json:"Active"`
+	Taxable     bool   `json:"Taxable"`
+	Domain      string `json:"domain"`
+}
+
+// TaxRate represents a QBO tax rate (read-only in US).
+type TaxRate struct {
+	Id          string  `json:"Id"`
+	SyncToken   string  `json:"SyncToken"`
+	Name        string  `json:"Name"`
+	Description string  `json:"Description,omitempty"`
+	RateValue   float64 `json:"RateValue"`
+	Active      bool    `json:"Active"`
+	Domain      string  `json:"domain"`
+}
+
+// Preferences holds company-wide QBO settings.
+type Preferences struct {
+	Id                    string   `json:"Id"`
+	SyncToken             string   `json:"SyncToken"`
+	AccountingInfoPrefs   map[string]any `json:"AccountingInfoPrefs,omitempty"`
+	SalesFormsPrefs       map[string]any `json:"SalesFormsPrefs,omitempty"`
+	VendorAndPurchasesPrefs map[string]any `json:"VendorAndPurchasesPrefs,omitempty"`
+	MetaData              MetaData `json:"MetaData"`
+	Domain                string   `json:"domain"`
+}
+
 // CompanyInfo holds the company settings (single record, Id="1").
 type CompanyInfo struct {
 	Id                string   `json:"Id"`


### PR DESCRIPTION
## Summary
Adds 8 missing name list entities: Employee, Class, Department, Term, PaymentMethod (full CRUD with SyncToken), TaxCode, TaxRate (read-only + query), Preferences (read + update).

All entities integrated into query endpoint, state snapshot, load, and reset.

## Test plan
- [x] All 25 existing tests pass
- [x] `go build ./twin-qbo/cmd/twin-qbo` succeeds
- [x] New entity routes compile and are queryable