### PR TITLE
feat(twin-qbo): add supporting entities (GAP-006)

### DIFF
--- a/twin-qbo/internal/api/handlers_query.go
+++ b/twin-qbo/internal/api/handlers_query.go
@@ -118,6 +118,18 @@ func (h *Handler) Query(w http.ResponseWriter, r *http.Request) {
 		items := FilterItems(h.store.TaxRates.List(), pq)
 		page := Paginate(items, pq.StartPosition, pq.MaxResults)
 		qboJSON(w, http.StatusOK, queryResponse("TaxRate", page, pq.StartPosition, len(page), len(items)))
+	case "refundreceipt":
+		items := FilterItems(h.store.RefundReceipts.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("RefundReceipt", page, pq.StartPosition, len(page), len(items)))
+	case "purchaseorder":
+		items := FilterItems(h.store.PurchaseOrders.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("PurchaseOrder", page, pq.StartPosition, len(page), len(items)))
+	case "timeactivity":
+		items := FilterItems(h.store.TimeActivities.List(), pq)
+		page := Paginate(items, pq.StartPosition, pq.MaxResults)
+		qboJSON(w, http.StatusOK, queryResponse("TimeActivity", page, pq.StartPosition, len(page), len(items)))
 	default:
 		validationFault(w, "500", "Invalid entity", "Entity '"+pq.Entity+"' is not supported.")
 	}

--- a/twin-qbo/internal/api/handlers_supporting.go
+++ b/twin-qbo/internal/api/handlers_supporting.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-qbo/internal/store"
+)
+
+// --- RefundReceipt ---
+
+func (h *Handler) CreateOrUpdateRefundReceipt(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
+	var rr store.RefundReceipt
+	if err := json.NewDecoder(r.Body).Decode(&rr); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.RefundReceipts.Get(rr.Id); !ok { notFoundFault(w, "RefundReceipt", rr.Id); return }
+		h.store.RefundReceipts.Delete(rr.Id); h.fireEvent("RefundReceipt", rr.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("RefundReceipt", rr)); return
+	}
+	if rr.Id != "" {
+		existing, ok := h.store.RefundReceipts.Get(rr.Id)
+		if !ok { notFoundFault(w, "RefundReceipt", rr.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, rr.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		rr.SyncToken = IncrementSyncToken(existing.SyncToken)
+		rr.MetaData.CreateTime = existing.MetaData.CreateTime
+		rr.MetaData.LastUpdatedTime = h.store.Now()
+		rr.Domain = "QBO"
+		h.store.RefundReceipts.Set(rr.Id, rr)
+	} else {
+		rr.Id = h.store.NextID(); rr.SyncToken = "0"; rr.Domain = "QBO"
+		rr.MetaData = h.store.NewMetaData()
+		var total float64
+		for _, line := range rr.Line { total += line.Amount }
+		rr.TotalAmt = total
+		h.store.RefundReceipts.Set(rr.Id, rr)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("RefundReceipt", rr))
+}
+
+func (h *Handler) GetRefundReceipt(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	rr, ok := h.store.RefundReceipts.Get(id)
+	if !ok { notFoundFault(w, "RefundReceipt", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("RefundReceipt", rr))
+}
+
+// --- PurchaseOrder ---
+
+func (h *Handler) CreateOrUpdatePurchaseOrder(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
+	var po store.PurchaseOrder
+	if err := json.NewDecoder(r.Body).Decode(&po); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.PurchaseOrders.Get(po.Id); !ok { notFoundFault(w, "PurchaseOrder", po.Id); return }
+		h.store.PurchaseOrders.Delete(po.Id); h.fireEvent("PurchaseOrder", po.Id, "Delete")
+		qboJSON(w, http.StatusOK, entityResponse("PurchaseOrder", po)); return
+	}
+	if po.Id != "" {
+		existing, ok := h.store.PurchaseOrders.Get(po.Id)
+		if !ok { notFoundFault(w, "PurchaseOrder", po.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, po.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		po.SyncToken = IncrementSyncToken(existing.SyncToken)
+		po.MetaData.CreateTime = existing.MetaData.CreateTime
+		po.MetaData.LastUpdatedTime = h.store.Now()
+		po.Domain = "QBO"
+		h.store.PurchaseOrders.Set(po.Id, po)
+	} else {
+		po.Id = h.store.NextID(); po.SyncToken = "0"; po.Domain = "QBO"
+		if po.POStatus == "" { po.POStatus = "Open" }
+		po.MetaData = h.store.NewMetaData()
+		var total float64
+		for _, line := range po.Line { total += line.Amount }
+		po.TotalAmt = total
+		h.store.PurchaseOrders.Set(po.Id, po)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("PurchaseOrder", po))
+}
+
+func (h *Handler) GetPurchaseOrder(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	po, ok := h.store.PurchaseOrders.Get(id)
+	if !ok { notFoundFault(w, "PurchaseOrder", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("PurchaseOrder", po))
+}
+
+// --- TimeActivity ---
+
+func (h *Handler) CreateOrUpdateTimeActivity(w http.ResponseWriter, r *http.Request) {
+	op := r.URL.Query().Get("operation")
+	var ta store.TimeActivity
+	if err := json.NewDecoder(r.Body).Decode(&ta); err != nil {
+		validationFault(w, "500", "Invalid JSON", err.Error())
+		return
+	}
+	if op == "delete" {
+		if _, ok := h.store.TimeActivities.Get(ta.Id); !ok { notFoundFault(w, "TimeActivity", ta.Id); return }
+		h.store.TimeActivities.Delete(ta.Id)
+		qboJSON(w, http.StatusOK, entityResponse("TimeActivity", ta)); return
+	}
+	if ta.Id != "" {
+		existing, ok := h.store.TimeActivities.Get(ta.Id)
+		if !ok { notFoundFault(w, "TimeActivity", ta.Id); return }
+		if err := ValidateSyncToken(existing.SyncToken, ta.SyncToken); err != nil { staleSyncTokenFault(w); return }
+		ta.SyncToken = IncrementSyncToken(existing.SyncToken)
+		ta.MetaData.CreateTime = existing.MetaData.CreateTime
+		ta.MetaData.LastUpdatedTime = h.store.Now()
+		ta.Domain = "QBO"
+		h.store.TimeActivities.Set(ta.Id, ta)
+	} else {
+		ta.Id = h.store.NextID(); ta.SyncToken = "0"; ta.Domain = "QBO"
+		ta.MetaData = h.store.NewMetaData()
+		h.store.TimeActivities.Set(ta.Id, ta)
+	}
+	qboJSON(w, http.StatusOK, entityResponse("TimeActivity", ta))
+}
+
+func (h *Handler) GetTimeActivity(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ta, ok := h.store.TimeActivities.Get(id)
+	if !ok { notFoundFault(w, "TimeActivity", id); return }
+	qboJSON(w, http.StatusOK, entityResponse("TimeActivity", ta))
+}

--- a/twin-qbo/internal/api/router.go
+++ b/twin-qbo/internal/api/router.go
@@ -126,6 +126,18 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Get("/preferences", h.GetPreferences)
 		r.Post("/preferences", h.UpdatePreferences)
 
+		// Refund Receipts
+		r.Post("/refundreceipt", h.CreateOrUpdateRefundReceipt)
+		r.Get("/refundreceipt/{id}", h.GetRefundReceipt)
+
+		// Purchase Orders
+		r.Post("/purchaseorder", h.CreateOrUpdatePurchaseOrder)
+		r.Get("/purchaseorder/{id}", h.GetPurchaseOrder)
+
+		// Time Activities
+		r.Post("/timeactivity", h.CreateOrUpdateTimeActivity)
+		r.Get("/timeactivity/{id}", h.GetTimeActivity)
+
 		// Reports
 		r.Get("/reports/ProfitAndLoss", h.ProfitAndLoss)
 		r.Get("/reports/BalanceSheet", h.BalanceSheet)

--- a/twin-qbo/internal/store/memory.go
+++ b/twin-qbo/internal/store/memory.go
@@ -37,7 +37,10 @@ type MemoryStore struct {
 	TaxCodes       *pkgstore.Store[TaxCode]
 	TaxRates       *pkgstore.Store[TaxRate]
 	PreferencesStore *pkgstore.Store[Preferences]
-	Journal        *journal.Journal
+	RefundReceipts   *pkgstore.Store[RefundReceipt]
+	PurchaseOrders   *pkgstore.Store[PurchaseOrder]
+	TimeActivities   *pkgstore.Store[TimeActivity]
+	Journal          *journal.Journal
 	Clock        *pkgstore.Clock
 	idCounter    atomic.Uint64
 }
@@ -71,7 +74,10 @@ func New() *MemoryStore {
 		TaxCodes:        pkgstore.New[TaxCode]("tc"),
 		TaxRates:        pkgstore.New[TaxRate]("tr"),
 		PreferencesStore: pkgstore.New[Preferences]("pref"),
-		Journal:         journal.New(clock),
+		RefundReceipts:   pkgstore.New[RefundReceipt]("rr"),
+		PurchaseOrders:   pkgstore.New[PurchaseOrder]("po"),
+		TimeActivities:   pkgstore.New[TimeActivity]("ta"),
+		Journal:          journal.New(clock),
 		Clock:         clock,
 	}
 }
@@ -118,6 +124,9 @@ type stateSnapshot struct {
 	TaxCodes       map[string]TaxCode       `json:"tax_codes"`
 	TaxRates       map[string]TaxRate       `json:"tax_rates"`
 	Preferences    map[string]Preferences   `json:"preferences"`
+	RefundReceipts map[string]RefundReceipt `json:"refund_receipts"`
+	PurchaseOrders map[string]PurchaseOrder `json:"purchase_orders"`
+	TimeActivities map[string]TimeActivity  `json:"time_activities"`
 }
 
 func (s *MemoryStore) Snapshot() any {
@@ -147,6 +156,9 @@ func (s *MemoryStore) Snapshot() any {
 		TaxCodes:       s.TaxCodes.Snapshot(),
 		TaxRates:       s.TaxRates.Snapshot(),
 		Preferences:    s.PreferencesStore.Snapshot(),
+		RefundReceipts: s.RefundReceipts.Snapshot(),
+		PurchaseOrders: s.PurchaseOrders.Snapshot(),
+		TimeActivities: s.TimeActivities.Snapshot(),
 	}
 }
 
@@ -180,6 +192,9 @@ func (s *MemoryStore) LoadState(data []byte) error {
 	s.TaxCodes.LoadSnapshot(snap.TaxCodes)
 	s.TaxRates.LoadSnapshot(snap.TaxRates)
 	s.PreferencesStore.LoadSnapshot(snap.Preferences)
+	s.RefundReceipts.LoadSnapshot(snap.RefundReceipts)
+	s.PurchaseOrders.LoadSnapshot(snap.PurchaseOrders)
+	s.TimeActivities.LoadSnapshot(snap.TimeActivities)
 	return nil
 }
 
@@ -209,6 +224,9 @@ func (s *MemoryStore) Reset() {
 	s.TaxCodes.Reset()
 	s.TaxRates.Reset()
 	s.PreferencesStore.Reset()
+	s.RefundReceipts.Reset()
+	s.PurchaseOrders.Reset()
+	s.TimeActivities.Reset()
 	s.Journal.Reset()
 	s.Clock.Reset()
 	s.idCounter.Store(0)

--- a/twin-qbo/internal/store/types.go
+++ b/twin-qbo/internal/store/types.go
@@ -387,6 +387,49 @@ type Preferences struct {
 	Domain                string   `json:"domain"`
 }
 
+// RefundReceipt represents a QBO refund.
+type RefundReceipt struct {
+	Id                  string   `json:"Id"`
+	SyncToken           string   `json:"SyncToken"`
+	DocNumber           string   `json:"DocNumber,omitempty"`
+	TxnDate             string   `json:"TxnDate,omitempty"`
+	CustomerRef         *Ref     `json:"CustomerRef"`
+	Line                []Line   `json:"Line"`
+	TotalAmt            float64  `json:"TotalAmt"`
+	DepositToAccountRef *Ref     `json:"DepositToAccountRef,omitempty"`
+	MetaData            MetaData `json:"MetaData"`
+	Domain              string   `json:"domain"`
+}
+
+// PurchaseOrder represents a QBO purchase order.
+type PurchaseOrder struct {
+	Id        string   `json:"Id"`
+	SyncToken string   `json:"SyncToken"`
+	DocNumber string   `json:"DocNumber,omitempty"`
+	TxnDate   string   `json:"TxnDate,omitempty"`
+	VendorRef *Ref     `json:"VendorRef"`
+	Line      []Line   `json:"Line"`
+	TotalAmt  float64  `json:"TotalAmt"`
+	POStatus  string   `json:"POStatus"` // Open, Closed
+	MetaData  MetaData `json:"MetaData"`
+	Domain    string   `json:"domain"`
+}
+
+// TimeActivity represents a QBO time tracking entry.
+type TimeActivity struct {
+	Id          string   `json:"Id"`
+	SyncToken   string   `json:"SyncToken"`
+	TxnDate     string   `json:"TxnDate,omitempty"`
+	EmployeeRef *Ref     `json:"EmployeeRef,omitempty"`
+	CustomerRef *Ref     `json:"CustomerRef,omitempty"`
+	ItemRef     *Ref     `json:"ItemRef,omitempty"`
+	Hours       int      `json:"Hours,omitempty"`
+	Minutes     int      `json:"Minutes,omitempty"`
+	Description string   `json:"Description,omitempty"`
+	MetaData    MetaData `json:"MetaData"`
+	Domain      string   `json:"domain"`
+}
+
 // CompanyInfo holds the company settings (single record, Id="1").
 type CompanyInfo struct {
 	Id                string   `json:"Id"`


### PR DESCRIPTION
## Summary
Adds RefundReceipt, PurchaseOrder (with POStatus), TimeActivity. Full CRUD, SyncToken, query support.

## Test plan
- [x] All 25 existing tests pass
- [x] `go build ./twin-qbo/cmd/twin-qbo` succeeds