### PR TITLE
feat(twin-qbo): validate minorversion parameter (GAP-011)

### DIFF
--- a/twin-qbo/internal/api/middleware.go
+++ b/twin-qbo/internal/api/middleware.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
+
+const minSupportedMinorVersion = 75
 
 // authMiddleware validates Bearer token presence (accepts any token).
 func authMiddleware(next http.Handler) http.Handler {
@@ -29,6 +32,30 @@ func realmIDMiddleware(next http.Handler) http.Handler {
 			qboFault(w, http.StatusBadRequest, "ValidationFault", "500",
 				"Invalid Company", "Company ID is required.")
 			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// minorVersionMiddleware validates the optional minorversion query parameter.
+// Rejects deprecated versions (< 75). Accepts or defaults to 75.
+func minorVersionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mvStr := r.URL.Query().Get("minorversion")
+		if mvStr != "" {
+			mv, err := strconv.Atoi(mvStr)
+			if err != nil {
+				qboFault(w, http.StatusBadRequest, "ValidationFault", "500",
+					"Invalid minor version",
+					"minorversion must be an integer.")
+				return
+			}
+			if mv < minSupportedMinorVersion {
+				qboFault(w, http.StatusBadRequest, "ValidationFault", "500",
+					"Deprecated minor version",
+					"Minor versions below 75 are deprecated. Use minorversion=75 or higher.")
+				return
+			}
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/twin-qbo/internal/api/router.go
+++ b/twin-qbo/internal/api/router.go
@@ -27,6 +27,7 @@ func (h *Handler) Routes(r chi.Router) {
 	r.Route("/v3/company/{realmId}", func(r chi.Router) {
 		r.Use(authMiddleware)
 		r.Use(realmIDMiddleware)
+		r.Use(minorVersionMiddleware)
 		r.Use(h.mw.FaultInjection)
 
 		// Query endpoint (SQL-like)


### PR DESCRIPTION
## Summary
Middleware validates `?minorversion=N`. Rejects < 75 (deprecated) and non-integer values. No behavioral variation — all v0.1 behavior is minorversion=75.

## Test plan
- [x] All tests pass, builds clean