### PR TITLE
feat(twin-qbo): add multi-currency support (GAP-013)

### DIFF
--- a/twin-qbo/internal/api/handlers_bills.go
+++ b/twin-qbo/internal/api/handlers_bills.go
@@ -101,4 +101,9 @@ func computeBillTotals(bill *store.Bill) {
 		tax = bill.TxnTaxDetail.TotalTax
 	}
 	bill.TotalAmt = subTotal + tax
+	if bill.ExchangeRate > 0 {
+		bill.HomeTotalAmt = bill.TotalAmt * bill.ExchangeRate
+	} else {
+		bill.HomeTotalAmt = bill.TotalAmt
+	}
 }

--- a/twin-qbo/internal/api/handlers_invoices.go
+++ b/twin-qbo/internal/api/handlers_invoices.go
@@ -110,4 +110,9 @@ func computeInvoiceTotals(inv *store.Invoice) {
 		tax = inv.TxnTaxDetail.TotalTax
 	}
 	inv.TotalAmt = subTotal + tax
+	if inv.ExchangeRate > 0 {
+		inv.HomeTotalAmt = inv.TotalAmt * inv.ExchangeRate
+	} else {
+		inv.HomeTotalAmt = inv.TotalAmt
+	}
 }

--- a/twin-qbo/internal/store/types.go
+++ b/twin-qbo/internal/store/types.go
@@ -155,6 +155,8 @@ type Invoice struct {
 	TxnTaxDetail  *TxnTaxDetail  `json:"TxnTaxDetail,omitempty"`
 	TotalAmt      float64        `json:"TotalAmt"`
 	Balance       float64        `json:"Balance"`
+	HomeTotalAmt  float64        `json:"HomeTotalAmt,omitempty"`
+	ExchangeRate  float64        `json:"ExchangeRate,omitempty"`
 	EmailStatus   string         `json:"EmailStatus,omitempty"`
 	CurrencyRef   *Ref           `json:"CurrencyRef,omitempty"`
 	SalesTermRef  *Ref           `json:"SalesTermRef,omitempty"`
@@ -175,6 +177,8 @@ type Bill struct {
 	TxnTaxDetail *TxnTaxDetail  `json:"TxnTaxDetail,omitempty"`
 	TotalAmt     float64        `json:"TotalAmt"`
 	Balance      float64        `json:"Balance"`
+	HomeTotalAmt float64        `json:"HomeTotalAmt,omitempty"`
+	ExchangeRate float64        `json:"ExchangeRate,omitempty"`
 	CurrencyRef  *Ref           `json:"CurrencyRef,omitempty"`
 	APAccountRef *Ref           `json:"APAccountRef,omitempty"`
 	MetaData     MetaData       `json:"MetaData"`


### PR DESCRIPTION
## Summary
ExchangeRate and HomeTotalAmt fields on Invoice and Bill. HomeTotalAmt = TotalAmt * ExchangeRate when set. CurrencyRef already accepted on all entity types.

## Test plan
- [x] All tests pass, builds clean