### PR TITLE
feat: accounting conformance suite + generator finalization phase + CI update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build all twins
         run: |
-          for twin in stripe twilio resend posthog logodev; do
+          for twin in stripe twilio resend posthog logodev loyaltylion smile xero qbo; do
             echo "Building twin-$twin..."
             go build -o bin/twin-$twin ./twin-$twin/cmd/twin-$twin/
           done

--- a/skills/twin-generator.md
+++ b/skills/twin-generator.md
@@ -1215,7 +1215,60 @@ This validates all 8 standard checks: health, reset, state POST/GET, fault injec
 make build && wt down && wt up && wt test
 ```
 
-### Phase 12: Publish (Optional)
+### Phase 12: Integration Finalization (Required)
+
+After the twin passes local testing, complete these integration steps. **This phase is not optional.** A twin that builds and tests but isn't integrated into the monorepo infrastructure is not complete.
+
+**1. Verify `go.work` includes the twin:**
+
+```bash
+grep "twin-{name}" go.work || echo "MISSING: add ./twin-{name} to go.work"
+```
+
+**2. Update CI twin list** in `.github/workflows/ci.yml`:
+
+Find the "Build all twins" step and add the new twin:
+
+```yaml
+for twin in stripe twilio resend posthog logodev loyaltylion smile xero qbo {name}; do
+```
+
+Failure mode: if you skip this, CI won't build or test the twin. It will silently rot.
+
+**3. Run engine conformance suites** (for fintech twins):
+
+If the twin uses a `twinkit/` engine (e.g., `twinkit/ledger/accounting`), run the engine's conformance suite against the twin's engine instance:
+
+```bash
+go test ./twinkit/ledger/accounting/... # engine invariants still hold
+go test ./twin-{name}/...              # twin-specific tests pass
+```
+
+**4. Verify full workspace builds:**
+
+```bash
+go build ./...        # entire workspace compiles
+go test ./...         # no regressions anywhere
+```
+
+**5. Update `twin-manifest.json`** with final coverage numbers — endpoint count, entity count, coverage percentage.
+
+**6. Update `provenance.json`** with final scope (implemented/not_implemented lists).
+
+**7. Commit with a descriptive message** following the repo convention:
+
+```
+feat: add twin-{name} — {Service} API twin
+
+{Brief description of what the twin simulates, key behavioral
+features, port number, and API prefix.}
+```
+
+This phase produces no new code — it verifies and records that the twin is fully integrated. Only after this phase is the twin considered complete.
+
+---
+
+### Phase 13: Publish (Optional)
 
 Once the twin passes local testing and conformance, publish it to make it installable via `wt install`.
 
@@ -1261,10 +1314,11 @@ The recommended workflow emphasizes **offline-first local development**:
  5. Generate Arazzo workflows               (Phase 9)
  6. Scaffold starter scenarios              (Phase 10)
  7. Build and test locally with wt          (Phase 11) ← Primary loop
- 8. Publish to registry when ready          (Phase 12) ← Optional
+ 8. Finalize: CI, go.work, conformance      (Phase 12) ← Required gate
+ 9. Publish to registry when ready          (Phase 13) ← Optional
 ```
 
-For private/internal twins, Phase 12 is entirely optional. The `binary:` field in `wondertwin.json` supports any local path, so you can develop and use twins without ever publishing them.
+For private/internal twins, Phase 13 is entirely optional. Phase 12 is always required — it ensures the twin is integrated into CI, the workspace builds cleanly, and conformance suites pass. The `binary:` field in `wondertwin.json` supports any local path, so you can develop and use twins without ever publishing them.
 
 ---
 
@@ -1302,6 +1356,15 @@ Before considering a twin complete, verify:
 **Webhooks (if applicable):**
 - [ ] Signer implements `webhook.Signer`, dispatcher integrated
 - [ ] `adminHandler.SetFlusher(dispatcher)` called
+
+**Integration (Phase 12 — required):**
+- [ ] `go.work` includes `./twin-{name}`
+- [ ] `.github/workflows/ci.yml` "Build all twins" includes the twin
+- [ ] `go build ./...` succeeds (full workspace)
+- [ ] `go test ./...` passes (no regressions)
+- [ ] Engine conformance suites pass (if using twinkit engines)
+- [ ] `twin-manifest.json` coverage fields are final
+- [ ] `provenance.json` scope lists are final
 
 **Validation:**
 - [ ] Passes `wt conformance` (all 8 checks)

--- a/twinkit/ledger/accounting/conformance/suite.go
+++ b/twinkit/ledger/accounting/conformance/suite.go
@@ -1,0 +1,399 @@
+// Package conformance provides a test suite that validates accounting engine
+// invariants. Any twin using twinkit/ledger/accounting must pass this suite.
+//
+// Usage in a twin's test file:
+//
+//	func TestAccountingConformance(t *testing.T) {
+//	    engine := setupMyEngine() // your twin's engine setup
+//	    conformance.Run(t, engine)
+//	}
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/ledger/accounting"
+	"github.com/wondertwin-ai/wondertwin/twinkit/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/store/journal"
+)
+
+// Run executes the full accounting engine conformance suite against the given engine.
+// The engine should be freshly created with no pre-existing state.
+func Run(t *testing.T, engine *accounting.Engine) {
+	t.Helper()
+	t.Run("Conformance/AccountManagement", func(t *testing.T) { testAccountManagement(t, engine) })
+	t.Run("Conformance/JournalBalancing", func(t *testing.T) { testJournalBalancing(t, engine) })
+	t.Run("Conformance/DocumentStateTransitions", func(t *testing.T) { testDocumentStateTransitions(t, engine) })
+	t.Run("Conformance/PaymentApplication", func(t *testing.T) { testPaymentApplication(t, engine) })
+	t.Run("Conformance/PeriodLocking", func(t *testing.T) { testPeriodLocking(t, engine) })
+	t.Run("Conformance/ReportsFromJournal", func(t *testing.T) { testReportsFromJournal(t, engine) })
+	t.Run("Conformance/ManualJournal", func(t *testing.T) { testManualJournal(t, engine) })
+}
+
+// RunWithFactory creates a fresh engine for each sub-test using the provided factory.
+// This is the preferred method — it isolates sub-tests from each other.
+func RunWithFactory(t *testing.T, factory func() *accounting.Engine) {
+	t.Helper()
+	t.Run("Conformance/AccountManagement", func(t *testing.T) { testAccountManagement(t, factory()) })
+	t.Run("Conformance/JournalBalancing", func(t *testing.T) { testJournalBalancing(t, factory()) })
+	t.Run("Conformance/DocumentStateTransitions", func(t *testing.T) { testDocumentStateTransitions(t, factory()) })
+	t.Run("Conformance/PaymentApplication", func(t *testing.T) { testPaymentApplication(t, factory()) })
+	t.Run("Conformance/PeriodLocking", func(t *testing.T) { testPeriodLocking(t, factory()) })
+	t.Run("Conformance/ReportsFromJournal", func(t *testing.T) { testReportsFromJournal(t, factory()) })
+	t.Run("Conformance/ManualJournal", func(t *testing.T) { testManualJournal(t, factory()) })
+}
+
+// NewTestEngine creates a standard engine for conformance testing with
+// a basic chart of accounts pre-configured.
+func NewTestEngine() *accounting.Engine {
+	clock := store.NewClock()
+	j := journal.New(clock)
+	engine := accounting.NewEngine(
+		accounting.WithJournal(j),
+		accounting.WithClock(clock),
+	)
+
+	engine.CreateAccount(accounting.Account{ID: "ar", Name: "Accounts Receivable", Type: accounting.AccountTypeAsset, Class: accounting.ClassCurrentAsset})
+	engine.CreateAccount(accounting.Account{ID: "ap", Name: "Accounts Payable", Type: accounting.AccountTypeLiability, Class: accounting.ClassCurrentLiability})
+	engine.CreateAccount(accounting.Account{ID: "rev", Name: "Revenue", Type: accounting.AccountTypeRevenue, Class: accounting.ClassRevenue})
+	engine.CreateAccount(accounting.Account{ID: "exp", Name: "Expenses", Type: accounting.AccountTypeExpense, Class: accounting.ClassExpense})
+	engine.CreateAccount(accounting.Account{ID: "bank", Name: "Bank", Type: accounting.AccountTypeAsset, Class: accounting.ClassCurrentAsset})
+
+	engine.SetReceivableAccount("ar")
+	engine.SetPayableAccount("ap")
+
+	return engine
+}
+
+func testAccountManagement(t *testing.T, engine *accounting.Engine) {
+	// Invariant: accounts can be created and retrieved.
+	acct, err := engine.CreateAccount(accounting.Account{
+		Name: "Test Account", Type: accounting.AccountTypeAsset, Class: accounting.ClassCurrentAsset,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if acct.ID == "" {
+		t.Fatal("account ID should be assigned")
+	}
+
+	got, err := engine.GetAccount(acct.ID)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if got.Name != "Test Account" {
+		t.Errorf("Name = %s, want 'Test Account'", got.Name)
+	}
+
+	// Invariant: duplicate IDs are rejected.
+	_, err = engine.CreateAccount(accounting.Account{ID: acct.ID, Name: "Dup", Type: accounting.AccountTypeAsset})
+	if err == nil {
+		t.Fatal("duplicate account ID should be rejected")
+	}
+
+	// Invariant: missing name is rejected.
+	_, err = engine.CreateAccount(accounting.Account{Type: accounting.AccountTypeAsset})
+	if err == nil {
+		t.Fatal("missing name should be rejected")
+	}
+
+	// Invariant: accounts appear in list.
+	accts := engine.ListAccounts()
+	if len(accts) == 0 {
+		t.Fatal("ListAccounts should return at least one account")
+	}
+}
+
+func testJournalBalancing(t *testing.T, engine *accounting.Engine) {
+	// Invariant: journal rejects unbalanced entries.
+	j := engine.Journal()
+
+	err := j.Append(journal.Transaction{
+		Entries: []journal.Entry{
+			{AccountID: "a", Type: journal.Debit, Amount: 100, Currency: "USD"},
+			{AccountID: "b", Type: journal.Credit, Amount: 50, Currency: "USD"},
+		},
+	})
+	if err == nil {
+		t.Fatal("journal should reject unbalanced transaction")
+	}
+
+	// Invariant: journal accepts balanced entries.
+	err = j.Append(journal.Transaction{
+		Entries: []journal.Entry{
+			{AccountID: "a", Type: journal.Debit, Amount: 100, Currency: "USD"},
+			{AccountID: "b", Type: journal.Credit, Amount: 100, Currency: "USD"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("balanced transaction should be accepted: %v", err)
+	}
+
+	// Invariant: balance is computed from entries, not stored.
+	d, c, net := j.Balance("a")
+	if d != 100 || c != 0 || net != 100 {
+		t.Errorf("Balance(a) = d:%d c:%d net:%d, want 100/0/100", d, c, net)
+	}
+
+	// Invariant: zero-amount entries are rejected.
+	err = j.Append(journal.Transaction{
+		Entries: []journal.Entry{
+			{AccountID: "a", Type: journal.Debit, Amount: 0, Currency: "USD"},
+			{AccountID: "b", Type: journal.Credit, Amount: 0, Currency: "USD"},
+		},
+	})
+	if err == nil {
+		t.Fatal("journal should reject zero-amount entries")
+	}
+
+	// Invariant: mixed currencies are rejected.
+	err = j.Append(journal.Transaction{
+		Entries: []journal.Entry{
+			{AccountID: "a", Type: journal.Debit, Amount: 100, Currency: "USD"},
+			{AccountID: "b", Type: journal.Credit, Amount: 100, Currency: "EUR"},
+		},
+	})
+	if err == nil {
+		t.Fatal("journal should reject mixed-currency transaction")
+	}
+}
+
+func testDocumentStateTransitions(t *testing.T, engine *accounting.Engine) {
+	ctx := context.Background()
+
+	doc := &accounting.Document{
+		ID: "inv_test", Type: accounting.DocTypeInvoice, Status: accounting.StatusDraft,
+		Currency: "USD", Date: time.Now(),
+		LineItems: []accounting.LineItem{
+			{AccountID: "rev", Quantity: 100, UnitAmount: 10000, Amount: 10000},
+		},
+		SubTotal: 10000, Total: 10000, AmountDue: 10000,
+	}
+
+	// Invariant: valid transitions succeed.
+	if err := engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted); err != nil {
+		t.Fatalf("DRAFT→SUBMITTED: %v", err)
+	}
+	if doc.Status != accounting.StatusSubmitted {
+		t.Errorf("status = %s, want SUBMITTED", doc.Status)
+	}
+
+	if err := engine.TransitionDocument(ctx, doc, accounting.StatusAuthorised); err != nil {
+		t.Fatalf("SUBMITTED→AUTHORISED: %v", err)
+	}
+
+	// Invariant: AUTHORISED generates journal entries.
+	txs := engine.Journal().Transactions()
+	if len(txs) == 0 {
+		t.Fatal("AUTHORISED should generate journal entries")
+	}
+
+	// Invariant: invalid transitions are rejected.
+	err := engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted)
+	if err == nil {
+		t.Fatal("AUTHORISED→SUBMITTED should be rejected")
+	}
+
+	// Invariant: AUTHORISED→VOIDED is valid.
+	if err := engine.TransitionDocument(ctx, doc, accounting.StatusVoided); err != nil {
+		t.Fatalf("AUTHORISED→VOIDED: %v", err)
+	}
+
+	// Invariant: terminal states reject all transitions.
+	err = engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted)
+	if err == nil {
+		t.Fatal("VOIDED→SUBMITTED should be rejected (terminal)")
+	}
+}
+
+func testPaymentApplication(t *testing.T, engine *accounting.Engine) {
+	ctx := context.Background()
+
+	doc := &accounting.Document{
+		ID: "inv_pay", Type: accounting.DocTypeInvoice, Status: accounting.StatusDraft,
+		Currency: "USD", Date: time.Now(),
+		LineItems: []accounting.LineItem{
+			{AccountID: "rev", Quantity: 100, UnitAmount: 50000, Amount: 50000},
+		},
+		SubTotal: 50000, Total: 50000, AmountDue: 50000,
+	}
+	engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted)
+	engine.TransitionDocument(ctx, doc, accounting.StatusAuthorised)
+
+	// Invariant: partial payment reduces AmountDue.
+	pmt := &accounting.Payment{
+		ID: "pmt_1", DocumentID: "inv_pay", DocumentType: accounting.DocTypeInvoice,
+		BankAccountID: "bank", Amount: 30000, Currency: "USD",
+	}
+	if err := engine.ApplyPayment(ctx, pmt, doc); err != nil {
+		t.Fatalf("partial payment: %v", err)
+	}
+	if doc.AmountDue != 20000 {
+		t.Errorf("AmountDue after partial = %d, want 20000", doc.AmountDue)
+	}
+	if doc.Status != accounting.StatusAuthorised {
+		t.Errorf("status after partial = %s, want AUTHORISED", doc.Status)
+	}
+
+	// Invariant: full payment sets AmountDue to 0 and transitions to PAID.
+	pmt2 := &accounting.Payment{
+		ID: "pmt_2", DocumentID: "inv_pay", DocumentType: accounting.DocTypeInvoice,
+		BankAccountID: "bank", Amount: 20000, Currency: "USD",
+	}
+	if err := engine.ApplyPayment(ctx, pmt2, doc); err != nil {
+		t.Fatalf("full payment: %v", err)
+	}
+	if doc.AmountDue != 0 {
+		t.Errorf("AmountDue after full = %d, want 0", doc.AmountDue)
+	}
+	if doc.Status != accounting.StatusPaid {
+		t.Errorf("status after full = %s, want PAID", doc.Status)
+	}
+
+	// Invariant: overpayment is rejected.
+	pmt3 := &accounting.Payment{
+		ID: "pmt_3", DocumentID: "inv_pay", DocumentType: accounting.DocTypeInvoice,
+		BankAccountID: "bank", Amount: 1, Currency: "USD",
+	}
+	err := engine.ApplyPayment(ctx, pmt3, doc)
+	if err == nil {
+		t.Fatal("payment on PAID document should be rejected")
+	}
+
+	// Invariant: payment on wrong status is rejected.
+	draft := &accounting.Document{
+		ID: "inv_draft", Type: accounting.DocTypeInvoice, Status: accounting.StatusDraft,
+		Currency: "USD", Total: 10000, AmountDue: 10000,
+	}
+	err = engine.ApplyPayment(ctx, &accounting.Payment{
+		ID: "pmt_bad", Amount: 10000, Currency: "USD", BankAccountID: "bank",
+	}, draft)
+	if err == nil {
+		t.Fatal("payment on DRAFT document should be rejected")
+	}
+}
+
+func testPeriodLocking(t *testing.T, engine *accounting.Engine) {
+	ctx := context.Background()
+	lockDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	engine.LockPeriod(lockDate)
+
+	if engine.PeriodLock() != lockDate {
+		t.Fatalf("PeriodLock = %v, want %v", engine.PeriodLock(), lockDate)
+	}
+
+	// Invariant: documents in locked period are rejected.
+	doc := &accounting.Document{
+		ID: "inv_locked", Type: accounting.DocTypeInvoice, Status: accounting.StatusDraft,
+		Currency: "USD", Date: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+		LineItems: []accounting.LineItem{{AccountID: "rev", Quantity: 100, UnitAmount: 100, Amount: 100}},
+		SubTotal: 100, Total: 100, AmountDue: 100,
+	}
+	err := engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted)
+	if err == nil {
+		t.Fatal("document in locked period should be rejected")
+	}
+
+	// Invariant: documents after lock period are accepted.
+	doc.Date = time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	if err := engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted); err != nil {
+		t.Fatalf("document after lock should be accepted: %v", err)
+	}
+
+	// Invariant: manual journals in locked period are rejected.
+	mj := &accounting.ManualJournal{
+		ID: "mj_locked", Date: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+		Lines: []accounting.ManualJournalLine{
+			{AccountID: "bank", DebitAmount: 100},
+			{AccountID: "rev", CreditAmount: 100},
+		},
+	}
+	err = engine.PostManualJournal(ctx, mj)
+	if err == nil {
+		t.Fatal("manual journal in locked period should be rejected")
+	}
+}
+
+func testReportsFromJournal(t *testing.T, engine *accounting.Engine) {
+	ctx := context.Background()
+
+	// Create an authorised invoice to generate journal entries.
+	doc := &accounting.Document{
+		ID: "inv_report", Type: accounting.DocTypeInvoice, Status: accounting.StatusDraft,
+		Currency: "USD", Date: time.Now(),
+		LineItems: []accounting.LineItem{
+			{AccountID: "rev", Quantity: 100, UnitAmount: 25000, Amount: 25000},
+		},
+		SubTotal: 25000, Total: 25000, AmountDue: 25000,
+	}
+	engine.TransitionDocument(ctx, doc, accounting.StatusSubmitted)
+	engine.TransitionDocument(ctx, doc, accounting.StatusAuthorised)
+
+	// Invariant: trial balance debits equal credits.
+	tb := engine.TrialBalanceReport(time.Time{})
+	if tb.TotalDebit != tb.TotalCredit {
+		t.Errorf("trial balance unequal: debit=%d credit=%d", tb.TotalDebit, tb.TotalCredit)
+	}
+	if tb.TotalDebit == 0 {
+		t.Error("trial balance should have non-zero totals after authorised invoice")
+	}
+
+	// Invariant: P&L reports revenue from invoice.
+	from := time.Now().Add(-time.Hour)
+	to := time.Now().Add(time.Hour)
+	pnl := engine.ProfitAndLossReport(from, to)
+	if pnl.Revenue.Total == 0 {
+		t.Error("P&L should show revenue after authorised invoice")
+	}
+
+	// Invariant: balance sheet shows AR.
+	bs := engine.BalanceSheetReport(time.Time{})
+	if bs.Assets.Total == 0 {
+		t.Error("balance sheet should show AR as asset after authorised invoice")
+	}
+}
+
+func testManualJournal(t *testing.T, engine *accounting.Engine) {
+	ctx := context.Background()
+
+	// Invariant: balanced manual journal is accepted.
+	mj := &accounting.ManualJournal{
+		ID: "mj_ok", Narration: "Test",
+		Lines: []accounting.ManualJournalLine{
+			{AccountID: "bank", DebitAmount: 5000},
+			{AccountID: "rev", CreditAmount: 5000},
+		},
+	}
+	if err := engine.PostManualJournal(ctx, mj); err != nil {
+		t.Fatalf("balanced manual journal: %v", err)
+	}
+	if mj.Status != "POSTED" {
+		t.Errorf("status = %s, want POSTED", mj.Status)
+	}
+
+	// Invariant: unbalanced manual journal is rejected.
+	mjBad := &accounting.ManualJournal{
+		ID: "mj_bad",
+		Lines: []accounting.ManualJournalLine{
+			{AccountID: "bank", DebitAmount: 5000},
+			{AccountID: "rev", CreditAmount: 3000},
+		},
+	}
+	if err := engine.PostManualJournal(ctx, mjBad); err == nil {
+		t.Fatal("unbalanced manual journal should be rejected")
+	}
+
+	// Invariant: unknown accounts are rejected.
+	mjUnk := &accounting.ManualJournal{
+		ID: "mj_unk",
+		Lines: []accounting.ManualJournalLine{
+			{AccountID: "nonexistent", DebitAmount: 1000},
+			{AccountID: "rev", CreditAmount: 1000},
+		},
+	}
+	if err := engine.PostManualJournal(ctx, mjUnk); err == nil {
+		t.Fatal("manual journal with unknown account should be rejected")
+	}
+}

--- a/twinkit/ledger/accounting/conformance/suite_test.go
+++ b/twinkit/ledger/accounting/conformance/suite_test.go
@@ -1,0 +1,9 @@
+package conformance
+
+import "testing"
+
+// TestConformanceSuite runs the full conformance suite against
+// the standard test engine. This verifies the suite itself works.
+func TestConformanceSuite(t *testing.T) {
+	RunWithFactory(t, NewTestEngine)
+}


### PR DESCRIPTION
## Summary

### 1. Twin generator skill — mandatory finalization phase
New Phase 12 (Integration Finalization) gates twin completion on:
- go.work includes the twin
- CI build list updated
- Engine conformance suites pass
- Full workspace builds and tests
- Manifest and provenance are final

This was the gap that caused twin-xero and twin-qbo to ship without CI coverage. The phase is explicitly marked as required and appears in the checklist.

### 2. CI pipeline update
Added loyaltylion, smile, xero, qbo to the "Build all twins" step. These existed but weren't being built.

### 3. Accounting engine conformance suite
`twinkit/ledger/accounting/conformance/` — 7 invariant checks:
- Account management
- Journal balancing (debit=credit, positive amounts, same currency)
- Document state transitions (valid/invalid, AUTHORISED generates entries)
- Payment application (partial, full, overpayment, wrong status)
- Period locking
- Reports computed from journal
- Manual journals

Any twin using `twinkit/ledger/accounting` imports and runs this suite.

## Test plan
- [x] `go test ./twinkit/ledger/accounting/conformance/...` — all 7 checks pass
- [x] `go build ./...` — full workspace compiles