### PR TITLE
feat(twin-stripe): add Customers, Products, Prices

### DIFF
--- a/twin-stripe/internal/api/handlers_customers.go
+++ b/twin-stripe/internal/api/handlers_customers.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreateCustomer(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	id := h.store.Customers.NextID()
+	cus := store.Customer{
+		ID:          id,
+		Object:      "customer",
+		Name:        r.FormValue("name"),
+		Email:       r.FormValue("email"),
+		Phone:       r.FormValue("phone"),
+		Description: r.FormValue("description"),
+		Livemode:    false,
+		Created:     store.Now(),
+	}
+	cus.Metadata = parseMetadata(r)
+
+	h.store.Customers.Set(id, cus)
+	h.dispatcher.Enqueue("customer.created", mapFromJSON(cus))
+	twincore.JSON(w, http.StatusOK, cus)
+}
+
+func (h *Handler) GetCustomer(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	cus, ok := h.store.Customers.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such customer: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, cus)
+}
+
+func (h *Handler) UpdateCustomer(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	cus, ok := h.store.Customers.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such customer: "+id)
+		return
+	}
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	if v := r.FormValue("name"); v != "" {
+		cus.Name = v
+	}
+	if v := r.FormValue("email"); v != "" {
+		cus.Email = v
+	}
+	if v := r.FormValue("phone"); v != "" {
+		cus.Phone = v
+	}
+	if v := r.FormValue("description"); v != "" {
+		cus.Description = v
+	}
+	if meta := parseMetadata(r); len(meta) > 0 {
+		cus.Metadata = meta
+	}
+
+	h.store.Customers.Set(id, cus)
+	h.dispatcher.Enqueue("customer.updated", mapFromJSON(cus))
+	twincore.JSON(w, http.StatusOK, cus)
+}
+
+func (h *Handler) DeleteCustomer(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if !h.store.Customers.Delete(id) {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such customer: "+id)
+		return
+	}
+	h.dispatcher.Enqueue("customer.deleted", map[string]any{"id": id})
+	twincore.JSON(w, http.StatusOK, map[string]any{"id": id, "object": "customer", "deleted": true})
+}
+
+func (h *Handler) ListCustomers(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Customers.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/customers",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}
+
+// parseMetadata extracts metadata[key]=value from form data.
+func parseMetadata(r *http.Request) map[string]string {
+	meta := map[string]string{}
+	for key, vals := range r.Form {
+		if len(key) > 9 && key[:9] == "metadata[" && key[len(key)-1] == ']' {
+			meta[key[9:len(key)-1]] = vals[0]
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+// parseLimit extracts the limit query parameter.
+func parseLimit(r *http.Request, defaultLimit int) int {
+	if v := r.URL.Query().Get("limit"); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 100 {
+			return n
+		}
+	}
+	return defaultLimit
+}
+
+// mapFromJSON marshals a struct to map[string]any for event payloads.
+func mapFromJSON(v any) map[string]any {
+	data, _ := json.Marshal(v)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m
+}

--- a/twin-stripe/internal/api/handlers_prices.go
+++ b/twin-stripe/internal/api/handlers_prices.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreatePrice(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	currency := r.FormValue("currency")
+	product := r.FormValue("product")
+	if currency == "" || product == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required params: currency, product.")
+		return
+	}
+
+	id := h.store.Prices.NextID()
+	price := store.Price{
+		ID:            id,
+		Object:        "price",
+		Active:        true,
+		Currency:      currency,
+		Product:       product,
+		Type:          "one_time",
+		BillingScheme: "per_unit",
+		Nickname:      r.FormValue("nickname"),
+		Livemode:      false,
+		Metadata:      parseMetadata(r),
+		Created:       store.Now(),
+	}
+
+	if v := r.FormValue("unit_amount"); v != "" {
+		if amt, err := strconv.ParseInt(v, 10, 64); err == nil {
+			price.UnitAmount = amt
+		}
+	}
+
+	// Recurring configuration.
+	interval := r.FormValue("recurring[interval]")
+	if interval != "" {
+		price.Type = "recurring"
+		intervalCount := 1
+		if v := r.FormValue("recurring[interval_count]"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				intervalCount = n
+			}
+		}
+		usageType := r.FormValue("recurring[usage_type]")
+		if usageType == "" {
+			usageType = "licensed"
+		}
+		price.Recurring = &store.PriceRecurring{
+			Interval:      interval,
+			IntervalCount: intervalCount,
+			UsageType:     usageType,
+		}
+	}
+
+	h.store.Prices.Set(id, price)
+	h.dispatcher.Enqueue("price.created", mapFromJSON(price))
+	twincore.JSON(w, http.StatusOK, price)
+}
+
+func (h *Handler) GetPrice(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	price, ok := h.store.Prices.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such price: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, price)
+}
+
+func (h *Handler) UpdatePrice(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	price, ok := h.store.Prices.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such price: "+id)
+		return
+	}
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	if v := r.FormValue("active"); v == "false" {
+		price.Active = false
+	} else if v == "true" {
+		price.Active = true
+	}
+	if v := r.FormValue("nickname"); v != "" {
+		price.Nickname = v
+	}
+	if meta := parseMetadata(r); len(meta) > 0 {
+		price.Metadata = meta
+	}
+
+	h.store.Prices.Set(id, price)
+	h.dispatcher.Enqueue("price.updated", mapFromJSON(price))
+	twincore.JSON(w, http.StatusOK, price)
+}
+
+func (h *Handler) ListPrices(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+
+	// Optional product filter.
+	productFilter := r.URL.Query().Get("product")
+	if productFilter != "" {
+		items := h.store.Prices.Filter(func(_ string, p store.Price) bool {
+			return p.Product == productFilter
+		})
+		twincore.JSON(w, http.StatusOK, map[string]any{
+			"object":   "list",
+			"url":      "/v1/prices",
+			"has_more": false,
+			"data":     items,
+		})
+		return
+	}
+
+	page := h.store.Prices.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/prices",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}

--- a/twin-stripe/internal/api/handlers_products.go
+++ b/twin-stripe/internal/api/handlers_products.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreateProduct(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	name := r.FormValue("name")
+	if name == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required param: name.")
+		return
+	}
+
+	id := h.store.Products.NextID()
+	prod := store.Product{
+		ID:          id,
+		Object:      "product",
+		Name:        name,
+		Active:      true,
+		Description: r.FormValue("description"),
+		Livemode:    false,
+		Metadata:    parseMetadata(r),
+		Created:     store.Now(),
+		Updated:     store.Now(),
+	}
+
+	h.store.Products.Set(id, prod)
+	h.dispatcher.Enqueue("product.created", mapFromJSON(prod))
+	twincore.JSON(w, http.StatusOK, prod)
+}
+
+func (h *Handler) GetProduct(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	prod, ok := h.store.Products.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such product: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, prod)
+}
+
+func (h *Handler) UpdateProduct(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	prod, ok := h.store.Products.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such product: "+id)
+		return
+	}
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	if v := r.FormValue("name"); v != "" {
+		prod.Name = v
+	}
+	if v := r.FormValue("description"); v != "" {
+		prod.Description = v
+	}
+	if v := r.FormValue("active"); v == "false" {
+		prod.Active = false
+	} else if v == "true" {
+		prod.Active = true
+	}
+	if meta := parseMetadata(r); len(meta) > 0 {
+		prod.Metadata = meta
+	}
+	prod.Updated = store.Now()
+
+	h.store.Products.Set(id, prod)
+	h.dispatcher.Enqueue("product.updated", mapFromJSON(prod))
+	twincore.JSON(w, http.StatusOK, prod)
+}
+
+func (h *Handler) DeleteProduct(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if !h.store.Products.Delete(id) {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such product: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, map[string]any{"id": id, "object": "product", "deleted": true})
+}
+
+func (h *Handler) ListProducts(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Products.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/products",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}

--- a/twin-stripe/internal/api/router.go
+++ b/twin-stripe/internal/api/router.go
@@ -33,6 +33,26 @@ func (h *Handler) Routes(r chi.Router) {
 		// Fault injection for API routes (not admin)
 		r.Use(h.mw.FaultInjection)
 
+		// Customers
+		r.Post("/customers", h.CreateCustomer)
+		r.Get("/customers/{id}", h.GetCustomer)
+		r.Post("/customers/{id}", h.UpdateCustomer)
+		r.Delete("/customers/{id}", h.DeleteCustomer)
+		r.Get("/customers", h.ListCustomers)
+
+		// Products
+		r.Post("/products", h.CreateProduct)
+		r.Get("/products/{id}", h.GetProduct)
+		r.Post("/products/{id}", h.UpdateProduct)
+		r.Delete("/products/{id}", h.DeleteProduct)
+		r.Get("/products", h.ListProducts)
+
+		// Prices
+		r.Post("/prices", h.CreatePrice)
+		r.Get("/prices/{id}", h.GetPrice)
+		r.Post("/prices/{id}", h.UpdatePrice)
+		r.Get("/prices", h.ListPrices)
+
 		// Accounts
 		r.Post("/accounts", h.CreateAccount)
 		r.Get("/accounts/{id}", h.GetAccount)

--- a/twin-stripe/internal/store/memory.go
+++ b/twin-stripe/internal/store/memory.go
@@ -19,6 +19,9 @@ type MemoryStore struct {
 	Payouts          *pkgstore.Store[Payout]
 	Events               *pkgstore.Store[Event]
 	BalanceTransactions  *pkgstore.Store[BalanceTransaction]
+	Customers            *pkgstore.Store[Customer]
+	Products             *pkgstore.Store[Product]
+	Prices               *pkgstore.Store[Price]
 
 	// Per-account balances (account ID -> balance)
 	Balances         map[string]*AccountBalance
@@ -38,6 +41,9 @@ func New() *MemoryStore {
 		Payouts:         pkgstore.New[Payout]("po"),
 		Events:              pkgstore.New[Event]("evt"),
 		BalanceTransactions: pkgstore.New[BalanceTransaction]("txn"),
+		Customers:           pkgstore.New[Customer]("cus"),
+		Products:            pkgstore.New[Product]("prod"),
+		Prices:              pkgstore.New[Price]("price"),
 		Balances:        make(map[string]*AccountBalance),
 		PlatformBalance: NewAccountBalance(),
 		Clock:           pkgstore.NewClock(),
@@ -153,6 +159,9 @@ type stateSnapshot struct {
 	Payouts             map[string]Payout              `json:"payouts"`
 	Events              map[string]Event               `json:"events"`
 	BalanceTransactions map[string]BalanceTransaction   `json:"balance_transactions"`
+	Customers           map[string]Customer            `json:"customers"`
+	Products            map[string]Product             `json:"products"`
+	Prices              map[string]Price               `json:"prices"`
 	Balances            map[string]*AccountBalance     `json:"balances"`
 	PlatformBalance     *AccountBalance                `json:"platform_balance"`
 }
@@ -166,6 +175,9 @@ func (s *MemoryStore) Snapshot() any {
 		Payouts:             s.Payouts.Snapshot(),
 		Events:              s.Events.Snapshot(),
 		BalanceTransactions: s.BalanceTransactions.Snapshot(),
+		Customers:           s.Customers.Snapshot(),
+		Products:            s.Products.Snapshot(),
+		Prices:              s.Prices.Snapshot(),
 		Balances:            s.snapshotBalances(),
 		PlatformBalance:     s.PlatformBalance,
 	}
@@ -194,6 +206,9 @@ func (s *MemoryStore) LoadState(data []byte) error {
 	s.Payouts.LoadSnapshot(snap.Payouts)
 	s.Events.LoadSnapshot(snap.Events)
 	s.BalanceTransactions.LoadSnapshot(snap.BalanceTransactions)
+	s.Customers.LoadSnapshot(snap.Customers)
+	s.Products.LoadSnapshot(snap.Products)
+	s.Prices.LoadSnapshot(snap.Prices)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -214,6 +229,9 @@ func (s *MemoryStore) Reset() {
 	s.Payouts.Reset()
 	s.Events.Reset()
 	s.BalanceTransactions.Reset()
+	s.Customers.Reset()
+	s.Products.Reset()
+	s.Prices.Reset()
 	s.Clock.Reset()
 
 	s.mu.Lock()

--- a/twin-stripe/internal/store/types.go
+++ b/twin-stripe/internal/store/types.go
@@ -150,6 +150,64 @@ type EventReq struct {
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
+// Customer represents a Stripe customer.
+type Customer struct {
+	ID             string            `json:"id"`
+	Object         string            `json:"object"`
+	Name           string            `json:"name,omitempty"`
+	Email          string            `json:"email,omitempty"`
+	Phone          string            `json:"phone,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	Currency       string            `json:"currency,omitempty"`
+	DefaultSource  string            `json:"default_source,omitempty"`
+	InvoicePrefix  string            `json:"invoice_prefix,omitempty"`
+	Balance        int64             `json:"balance"`
+	Delinquent     bool              `json:"delinquent"`
+	Livemode       bool              `json:"livemode"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	Created        int64             `json:"created"`
+}
+
+// Product represents a Stripe product.
+type Product struct {
+	ID          string            `json:"id"`
+	Object      string            `json:"object"`
+	Name        string            `json:"name"`
+	Active      bool              `json:"active"`
+	Description string            `json:"description,omitempty"`
+	Images      []string          `json:"images,omitempty"`
+	Livemode    bool              `json:"livemode"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	DefaultPrice string           `json:"default_price,omitempty"`
+	Created     int64             `json:"created"`
+	Updated     int64             `json:"updated"`
+}
+
+// Price represents a Stripe price.
+type Price struct {
+	ID                string            `json:"id"`
+	Object            string            `json:"object"`
+	Active            bool              `json:"active"`
+	Currency          string            `json:"currency"`
+	Product           string            `json:"product"`
+	UnitAmount        int64             `json:"unit_amount,omitempty"`
+	UnitAmountDecimal string            `json:"unit_amount_decimal,omitempty"`
+	Type              string            `json:"type"` // one_time or recurring
+	BillingScheme     string            `json:"billing_scheme"` // per_unit or tiered
+	Recurring         *PriceRecurring   `json:"recurring,omitempty"`
+	Nickname          string            `json:"nickname,omitempty"`
+	Livemode          bool              `json:"livemode"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	Created           int64             `json:"created"`
+}
+
+// PriceRecurring holds recurring price configuration.
+type PriceRecurring struct {
+	Interval      string `json:"interval"` // day, week, month, year
+	IntervalCount int    `json:"interval_count"`
+	UsageType     string `json:"usage_type,omitempty"` // licensed or metered
+}
+
 // AccountBalance tracks per-account balance (available and pending).
 type AccountBalance struct {
 	Available map[string]int64 // currency -> amount


### PR DESCRIPTION
## Summary
Foundation entities for Stripe Billing and Payments. PR 1 of 5 for full platform parity.

- **Customers**: full CRUD, metadata, cursor pagination
- **Products**: full CRUD, active toggle
- **Prices**: create/read/update/list, one_time and recurring types, product filtering

All follow existing Stripe form-encoded request pattern with proper Stripe error format.

## Test plan
- [x] All existing tests pass
- [x] `go build ./twin-stripe/cmd/twin-stripe` succeeds