### PR TITLE
feat(twin-stripe): add Payments surface

### DIFF
--- a/twin-stripe/internal/api/handlers_charges.go
+++ b/twin-stripe/internal/api/handlers_charges.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+)
+
+func (h *Handler) GetCharge(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ch, ok := h.store.Charges.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such charge: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, ch)
+}
+
+func (h *Handler) ListCharges(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Charges.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/charges",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}

--- a/twin-stripe/internal/api/handlers_payment_intents.go
+++ b/twin-stripe/internal/api/handlers_payment_intents.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreatePaymentIntent(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	amountStr := r.FormValue("amount")
+	currency := r.FormValue("currency")
+	if amountStr == "" || currency == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required params: amount, currency.")
+		return
+	}
+	amount, _ := strconv.ParseInt(amountStr, 10, 64)
+
+	id := h.store.PaymentIntents.NextID()
+	captureMethod := r.FormValue("capture_method")
+	if captureMethod == "" {
+		captureMethod = "automatic"
+	}
+	confirmMethod := r.FormValue("confirmation_method")
+	if confirmMethod == "" {
+		confirmMethod = "automatic"
+	}
+
+	pi := store.PaymentIntent{
+		ID:                 id,
+		Object:             "payment_intent",
+		Amount:             amount,
+		Currency:           currency,
+		Customer:           r.FormValue("customer"),
+		Description:        r.FormValue("description"),
+		Status:             "requires_payment_method",
+		CaptureMethod:      captureMethod,
+		ConfirmationMethod: confirmMethod,
+		ClientSecret:       id + "_secret_" + randomHex(12),
+		Livemode:           false,
+		Metadata:           parseMetadata(r),
+		Created:            store.Now(),
+	}
+
+	// If payment_method provided and confirm=true, auto-succeed.
+	pm := r.FormValue("payment_method")
+	confirm := r.FormValue("confirm")
+	if pm != "" {
+		pi.PaymentMethod = pm
+		pi.Status = "requires_confirmation"
+	}
+	if confirm == "true" && pm != "" {
+		pi.Status = "succeeded"
+		pi.AmountReceived = amount
+		// Create a charge.
+		chargeID := h.createChargeForPI(&pi)
+		pi.LatestCharge = chargeID
+		h.store.CreditBalance("", currency, amount)
+		h.store.RecordBalanceTransaction("charge", chargeID, currency, amount, 0)
+	}
+
+	h.store.PaymentIntents.Set(id, pi)
+	h.dispatcher.Enqueue("payment_intent.created", mapFromJSON(pi))
+	if pi.Status == "succeeded" {
+		h.dispatcher.Enqueue("payment_intent.succeeded", mapFromJSON(pi))
+	}
+	twincore.JSON(w, http.StatusOK, pi)
+}
+
+func (h *Handler) GetPaymentIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pi, ok := h.store.PaymentIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_intent: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, pi)
+}
+
+func (h *Handler) ConfirmPaymentIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pi, ok := h.store.PaymentIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_intent: "+id)
+		return
+	}
+	if pi.Status != "requires_payment_method" && pi.Status != "requires_confirmation" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "payment_intent_unexpected_state",
+			"This PaymentIntent's status is "+pi.Status+", which is not confirmable.")
+		return
+	}
+
+	if err := parseFormOrJSON(r); err == nil {
+		if pm := r.FormValue("payment_method"); pm != "" {
+			pi.PaymentMethod = pm
+		}
+	}
+
+	pi.Status = "succeeded"
+	pi.AmountReceived = pi.Amount
+	chargeID := h.createChargeForPI(&pi)
+	pi.LatestCharge = chargeID
+	h.store.CreditBalance("", pi.Currency, pi.Amount)
+	h.store.RecordBalanceTransaction("charge", chargeID, pi.Currency, pi.Amount, 0)
+
+	h.store.PaymentIntents.Set(id, pi)
+	h.dispatcher.Enqueue("payment_intent.succeeded", mapFromJSON(pi))
+	twincore.JSON(w, http.StatusOK, pi)
+}
+
+func (h *Handler) CancelPaymentIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pi, ok := h.store.PaymentIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_intent: "+id)
+		return
+	}
+	if pi.Status == "succeeded" || pi.Status == "canceled" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "payment_intent_unexpected_state",
+			"This PaymentIntent's status is "+pi.Status+", which is not cancelable.")
+		return
+	}
+
+	pi.Status = "canceled"
+	pi.CanceledAt = store.Now()
+	if err := parseFormOrJSON(r); err == nil {
+		if reason := r.FormValue("cancellation_reason"); reason != "" {
+			pi.CancellationReason = reason
+		}
+	}
+
+	h.store.PaymentIntents.Set(id, pi)
+	h.dispatcher.Enqueue("payment_intent.canceled", mapFromJSON(pi))
+	twincore.JSON(w, http.StatusOK, pi)
+}
+
+func (h *Handler) ListPaymentIntents(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.PaymentIntents.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/payment_intents",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}
+
+func (h *Handler) createChargeForPI(pi *store.PaymentIntent) string {
+	id := h.store.Charges.NextID()
+	ch := store.Charge{
+		ID:            id,
+		Object:        "charge",
+		Amount:        pi.Amount,
+		Currency:      pi.Currency,
+		Customer:      pi.Customer,
+		Description:   pi.Description,
+		PaymentIntent: pi.ID,
+		PaymentMethod: pi.PaymentMethod,
+		Status:        "succeeded",
+		Captured:      pi.CaptureMethod == "automatic",
+		Paid:          true,
+		Livemode:      false,
+		Metadata:      pi.Metadata,
+		Created:       store.Now(),
+	}
+	h.store.Charges.Set(id, ch)
+	h.dispatcher.Enqueue("charge.succeeded", mapFromJSON(ch))
+	return id
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}

--- a/twin-stripe/internal/api/handlers_payment_methods.go
+++ b/twin-stripe/internal/api/handlers_payment_methods.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreatePaymentMethod(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	pmType := r.FormValue("type")
+	if pmType == "" {
+		pmType = "card"
+	}
+
+	id := h.store.PaymentMethods.NextID()
+	pm := store.PaymentMethod{
+		ID:       id,
+		Object:   "payment_method",
+		Type:     pmType,
+		Livemode: false,
+		Metadata: parseMetadata(r),
+		Created:  store.Now(),
+	}
+
+	if pmType == "card" {
+		expMonth := 12
+		expYear := 2030
+		if v := r.FormValue("card[exp_month]"); v != "" {
+			expMonth, _ = strconv.Atoi(v)
+		}
+		if v := r.FormValue("card[exp_year]"); v != "" {
+			expYear, _ = strconv.Atoi(v)
+		}
+		number := r.FormValue("card[number]")
+		last4 := "4242"
+		brand := "visa"
+		if len(number) >= 4 {
+			last4 = number[len(number)-4:]
+			switch number[0] {
+			case '4':
+				brand = "visa"
+			case '5':
+				brand = "mastercard"
+			case '3':
+				brand = "amex"
+			}
+		}
+		pm.Card = &store.CardDetails{
+			Brand:    brand,
+			Last4:    last4,
+			ExpMonth: expMonth,
+			ExpYear:  expYear,
+			Funding:  "credit",
+		}
+	}
+
+	if name := r.FormValue("billing_details[name]"); name != "" {
+		pm.BillingDetails = &store.BillingDetails{
+			Name:  name,
+			Email: r.FormValue("billing_details[email]"),
+			Phone: r.FormValue("billing_details[phone]"),
+		}
+	}
+
+	h.store.PaymentMethods.Set(id, pm)
+	twincore.JSON(w, http.StatusOK, pm)
+}
+
+func (h *Handler) GetPaymentMethod(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pm, ok := h.store.PaymentMethods.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_method: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, pm)
+}
+
+func (h *Handler) AttachPaymentMethod(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pm, ok := h.store.PaymentMethods.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_method: "+id)
+		return
+	}
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+	customer := r.FormValue("customer")
+	if customer == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required param: customer.")
+		return
+	}
+	pm.Customer = customer
+	h.store.PaymentMethods.Set(id, pm)
+	twincore.JSON(w, http.StatusOK, pm)
+}
+
+func (h *Handler) DetachPaymentMethod(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	pm, ok := h.store.PaymentMethods.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such payment_method: "+id)
+		return
+	}
+	pm.Customer = ""
+	h.store.PaymentMethods.Set(id, pm)
+	twincore.JSON(w, http.StatusOK, pm)
+}
+
+func (h *Handler) ListPaymentMethods(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	customerFilter := r.URL.Query().Get("customer")
+	if customerFilter != "" {
+		items := h.store.PaymentMethods.Filter(func(_ string, pm store.PaymentMethod) bool {
+			return pm.Customer == customerFilter
+		})
+		twincore.JSON(w, http.StatusOK, map[string]any{
+			"object":   "list",
+			"url":      "/v1/payment_methods",
+			"has_more": false,
+			"data":     items,
+		})
+		return
+	}
+	page := h.store.PaymentMethods.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/payment_methods",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}

--- a/twin-stripe/internal/api/handlers_refunds.go
+++ b/twin-stripe/internal/api/handlers_refunds.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+func (h *Handler) CreateRefund(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	// Refund can reference a charge or payment_intent.
+	chargeID := r.FormValue("charge")
+	piID := r.FormValue("payment_intent")
+
+	var ch store.Charge
+	var found bool
+
+	if chargeID != "" {
+		ch, found = h.store.Charges.Get(chargeID)
+	} else if piID != "" {
+		pi, ok := h.store.PaymentIntents.Get(piID)
+		if !ok {
+			twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "resource_missing", "No such payment_intent: "+piID)
+			return
+		}
+		if pi.LatestCharge != "" {
+			ch, found = h.store.Charges.Get(pi.LatestCharge)
+			chargeID = pi.LatestCharge
+		}
+	}
+
+	if !found {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Must provide charge or payment_intent.")
+		return
+	}
+
+	amount := ch.Amount - ch.AmountRefunded
+	if v := r.FormValue("amount"); v != "" {
+		if a, err := strconv.ParseInt(v, 10, 64); err == nil {
+			amount = a
+		}
+	}
+
+	if amount > ch.Amount-ch.AmountRefunded {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "amount_too_large",
+			"Refund amount is greater than the unrefunded amount.")
+		return
+	}
+
+	id := h.store.Refunds.NextID()
+	ref := store.Refund{
+		ID:            id,
+		Object:        "refund",
+		Amount:        amount,
+		Currency:      ch.Currency,
+		Charge:        chargeID,
+		PaymentIntent: ch.PaymentIntent,
+		Reason:        r.FormValue("reason"),
+		Status:        "succeeded",
+		Metadata:      parseMetadata(r),
+		Created:       store.Now(),
+	}
+
+	// Update charge refund tracking.
+	ch.AmountRefunded += amount
+	if ch.AmountRefunded >= ch.Amount {
+		ch.Refunded = true
+	}
+	h.store.Charges.Set(chargeID, ch)
+
+	// Debit the platform balance.
+	h.store.DebitBalance("", ch.Currency, amount)
+	h.store.RecordBalanceTransaction("refund", id, ch.Currency, -amount, 0)
+
+	h.store.Refunds.Set(id, ref)
+	h.dispatcher.Enqueue("charge.refunded", mapFromJSON(ch))
+	twincore.JSON(w, http.StatusOK, ref)
+}
+
+func (h *Handler) GetRefund(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ref, ok := h.store.Refunds.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such refund: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, ref)
+}
+
+func (h *Handler) ListRefunds(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Refunds.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object":   "list",
+		"url":      "/v1/refunds",
+		"has_more": page.HasMore,
+		"data":     page.Data,
+	})
+}

--- a/twin-stripe/internal/api/router.go
+++ b/twin-stripe/internal/api/router.go
@@ -53,6 +53,29 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Post("/prices/{id}", h.UpdatePrice)
 		r.Get("/prices", h.ListPrices)
 
+		// Payment Intents
+		r.Post("/payment_intents", h.CreatePaymentIntent)
+		r.Get("/payment_intents/{id}", h.GetPaymentIntent)
+		r.Post("/payment_intents/{id}/confirm", h.ConfirmPaymentIntent)
+		r.Post("/payment_intents/{id}/cancel", h.CancelPaymentIntent)
+		r.Get("/payment_intents", h.ListPaymentIntents)
+
+		// Payment Methods
+		r.Post("/payment_methods", h.CreatePaymentMethod)
+		r.Get("/payment_methods/{id}", h.GetPaymentMethod)
+		r.Post("/payment_methods/{id}/attach", h.AttachPaymentMethod)
+		r.Post("/payment_methods/{id}/detach", h.DetachPaymentMethod)
+		r.Get("/payment_methods", h.ListPaymentMethods)
+
+		// Charges
+		r.Get("/charges/{id}", h.GetCharge)
+		r.Get("/charges", h.ListCharges)
+
+		// Refunds
+		r.Post("/refunds", h.CreateRefund)
+		r.Get("/refunds/{id}", h.GetRefund)
+		r.Get("/refunds", h.ListRefunds)
+
 		// Accounts
 		r.Post("/accounts", h.CreateAccount)
 		r.Get("/accounts/{id}", h.GetAccount)

--- a/twin-stripe/internal/store/memory.go
+++ b/twin-stripe/internal/store/memory.go
@@ -22,6 +22,10 @@ type MemoryStore struct {
 	Customers            *pkgstore.Store[Customer]
 	Products             *pkgstore.Store[Product]
 	Prices               *pkgstore.Store[Price]
+	PaymentIntents       *pkgstore.Store[PaymentIntent]
+	PaymentMethods       *pkgstore.Store[PaymentMethod]
+	Charges              *pkgstore.Store[Charge]
+	Refunds              *pkgstore.Store[Refund]
 
 	// Per-account balances (account ID -> balance)
 	Balances         map[string]*AccountBalance
@@ -44,6 +48,10 @@ func New() *MemoryStore {
 		Customers:           pkgstore.New[Customer]("cus"),
 		Products:            pkgstore.New[Product]("prod"),
 		Prices:              pkgstore.New[Price]("price"),
+		PaymentIntents:      pkgstore.New[PaymentIntent]("pi"),
+		PaymentMethods:      pkgstore.New[PaymentMethod]("pm"),
+		Charges:             pkgstore.New[Charge]("ch"),
+		Refunds:             pkgstore.New[Refund]("re"),
 		Balances:        make(map[string]*AccountBalance),
 		PlatformBalance: NewAccountBalance(),
 		Clock:           pkgstore.NewClock(),
@@ -162,6 +170,10 @@ type stateSnapshot struct {
 	Customers           map[string]Customer            `json:"customers"`
 	Products            map[string]Product             `json:"products"`
 	Prices              map[string]Price               `json:"prices"`
+	PaymentIntents      map[string]PaymentIntent       `json:"payment_intents"`
+	PaymentMethods      map[string]PaymentMethod       `json:"payment_methods"`
+	Charges             map[string]Charge              `json:"charges"`
+	Refunds             map[string]Refund              `json:"refunds"`
 	Balances            map[string]*AccountBalance     `json:"balances"`
 	PlatformBalance     *AccountBalance                `json:"platform_balance"`
 }
@@ -178,6 +190,10 @@ func (s *MemoryStore) Snapshot() any {
 		Customers:           s.Customers.Snapshot(),
 		Products:            s.Products.Snapshot(),
 		Prices:              s.Prices.Snapshot(),
+		PaymentIntents:      s.PaymentIntents.Snapshot(),
+		PaymentMethods:      s.PaymentMethods.Snapshot(),
+		Charges:             s.Charges.Snapshot(),
+		Refunds:             s.Refunds.Snapshot(),
 		Balances:            s.snapshotBalances(),
 		PlatformBalance:     s.PlatformBalance,
 	}
@@ -209,6 +225,10 @@ func (s *MemoryStore) LoadState(data []byte) error {
 	s.Customers.LoadSnapshot(snap.Customers)
 	s.Products.LoadSnapshot(snap.Products)
 	s.Prices.LoadSnapshot(snap.Prices)
+	s.PaymentIntents.LoadSnapshot(snap.PaymentIntents)
+	s.PaymentMethods.LoadSnapshot(snap.PaymentMethods)
+	s.Charges.LoadSnapshot(snap.Charges)
+	s.Refunds.LoadSnapshot(snap.Refunds)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -232,6 +252,10 @@ func (s *MemoryStore) Reset() {
 	s.Customers.Reset()
 	s.Products.Reset()
 	s.Prices.Reset()
+	s.PaymentIntents.Reset()
+	s.PaymentMethods.Reset()
+	s.Charges.Reset()
+	s.Refunds.Reset()
 	s.Clock.Reset()
 
 	s.mu.Lock()

--- a/twin-stripe/internal/store/types.go
+++ b/twin-stripe/internal/store/types.go
@@ -208,6 +208,93 @@ type PriceRecurring struct {
 	UsageType     string `json:"usage_type,omitempty"` // licensed or metered
 }
 
+// PaymentIntent represents a Stripe payment intent.
+type PaymentIntent struct {
+	ID                    string            `json:"id"`
+	Object                string            `json:"object"`
+	Amount                int64             `json:"amount"`
+	AmountReceived        int64             `json:"amount_received"`
+	Currency              string            `json:"currency"`
+	Customer              string            `json:"customer,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	Status                string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
+	PaymentMethod         string            `json:"payment_method,omitempty"`
+	CaptureMethod         string            `json:"capture_method"` // automatic or manual
+	ConfirmationMethod    string            `json:"confirmation_method"` // automatic or manual
+	ClientSecret          string            `json:"client_secret"`
+	LatestCharge          string            `json:"latest_charge,omitempty"`
+	CanceledAt            int64             `json:"canceled_at,omitempty"`
+	CancellationReason    string            `json:"cancellation_reason,omitempty"`
+	Livemode              bool              `json:"livemode"`
+	Metadata              map[string]string `json:"metadata,omitempty"`
+	Created               int64             `json:"created"`
+}
+
+// PaymentMethod represents a Stripe payment method.
+type PaymentMethod struct {
+	ID          string            `json:"id"`
+	Object      string            `json:"object"`
+	Type        string            `json:"type"` // card, us_bank_account, etc.
+	Customer    string            `json:"customer,omitempty"`
+	Card        *CardDetails      `json:"card,omitempty"`
+	BillingDetails *BillingDetails `json:"billing_details,omitempty"`
+	Livemode    bool              `json:"livemode"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Created     int64             `json:"created"`
+}
+
+// CardDetails holds card payment method details.
+type CardDetails struct {
+	Brand    string `json:"brand"`
+	Last4    string `json:"last4"`
+	ExpMonth int    `json:"exp_month"`
+	ExpYear  int    `json:"exp_year"`
+	Funding  string `json:"funding"` // credit, debit, prepaid
+	Country  string `json:"country,omitempty"`
+}
+
+// BillingDetails holds customer billing information.
+type BillingDetails struct {
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+	Phone string `json:"phone,omitempty"`
+}
+
+// Charge represents a Stripe charge.
+type Charge struct {
+	ID              string            `json:"id"`
+	Object          string            `json:"object"`
+	Amount          int64             `json:"amount"`
+	AmountRefunded  int64             `json:"amount_refunded"`
+	Currency        string            `json:"currency"`
+	Customer        string            `json:"customer,omitempty"`
+	Description     string            `json:"description,omitempty"`
+	PaymentIntent   string            `json:"payment_intent,omitempty"`
+	PaymentMethod   string            `json:"payment_method,omitempty"`
+	Status          string            `json:"status"` // succeeded, pending, failed
+	Captured        bool              `json:"captured"`
+	Refunded        bool              `json:"refunded"`
+	Paid            bool              `json:"paid"`
+	Disputed        bool              `json:"disputed"`
+	Livemode        bool              `json:"livemode"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	Created         int64             `json:"created"`
+}
+
+// Refund represents a Stripe refund.
+type Refund struct {
+	ID            string            `json:"id"`
+	Object        string            `json:"object"`
+	Amount        int64             `json:"amount"`
+	Currency      string            `json:"currency"`
+	Charge        string            `json:"charge"`
+	PaymentIntent string            `json:"payment_intent,omitempty"`
+	Reason        string            `json:"reason,omitempty"` // duplicate, fraudulent, requested_by_customer
+	Status        string            `json:"status"` // succeeded, pending, failed, canceled
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Created       int64             `json:"created"`
+}
+
 // AccountBalance tracks per-account balance (available and pending).
 type AccountBalance struct {
 	Available map[string]int64 // currency -> amount


### PR DESCRIPTION
## Summary
Core Stripe Payments: PaymentIntents (create/confirm/cancel lifecycle), PaymentMethods (card with brand detection, attach/detach), Charges (auto-created on PI confirmation), Refunds (full/partial, by charge or PI). PR 2 of 5 for full platform parity.

## Test plan
- [x] All existing tests pass
- [x] `go build ./twin-stripe/cmd/twin-stripe` succeeds