### PR TITLE
feat(twin-stripe): add Coupons, SetupIntents, TaxRates, Disputes

### DIFF
--- a/twin-stripe/internal/api/handlers_billing_extras.go
+++ b/twin-stripe/internal/api/handlers_billing_extras.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+)
+
+// --- Coupons ---
+
+func (h *Handler) CreateCoupon(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	duration := r.FormValue("duration")
+	if duration == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required param: duration.")
+		return
+	}
+
+	id := r.FormValue("id")
+	if id == "" {
+		id = h.store.Coupons.NextID()
+	}
+
+	coup := store.Coupon{
+		ID:       id,
+		Object:   "coupon",
+		Duration: duration,
+		Name:     r.FormValue("name"),
+		Valid:    true,
+		Livemode: false,
+		Metadata: parseMetadata(r),
+		Created:  store.Now(),
+	}
+	if v := r.FormValue("amount_off"); v != "" {
+		coup.AmountOff, _ = strconv.ParseInt(v, 10, 64)
+		coup.Currency = r.FormValue("currency")
+	}
+	if v := r.FormValue("percent_off"); v != "" {
+		coup.PercentOff, _ = strconv.ParseFloat(v, 64)
+	}
+	if v := r.FormValue("duration_in_months"); v != "" {
+		coup.DurationInMonths, _ = strconv.Atoi(v)
+	}
+	if v := r.FormValue("max_redemptions"); v != "" {
+		coup.MaxRedemptions, _ = strconv.Atoi(v)
+	}
+
+	h.store.Coupons.Set(id, coup)
+	h.dispatcher.Enqueue("coupon.created", mapFromJSON(coup))
+	twincore.JSON(w, http.StatusOK, coup)
+}
+
+func (h *Handler) GetCoupon(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	coup, ok := h.store.Coupons.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such coupon: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, coup)
+}
+
+func (h *Handler) DeleteCoupon(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if !h.store.Coupons.Delete(id) {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such coupon: "+id)
+		return
+	}
+	h.dispatcher.Enqueue("coupon.deleted", map[string]any{"id": id})
+	twincore.JSON(w, http.StatusOK, map[string]any{"id": id, "object": "coupon", "deleted": true})
+}
+
+func (h *Handler) ListCoupons(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Coupons.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object": "list", "url": "/v1/coupons", "has_more": page.HasMore, "data": page.Data,
+	})
+}
+
+// --- Setup Intents ---
+
+func (h *Handler) CreateSetupIntent(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+
+	id := h.store.SetupIntents.NextID()
+	si := store.SetupIntent{
+		ID:            id,
+		Object:        "setup_intent",
+		Customer:      r.FormValue("customer"),
+		Status:        "requires_payment_method",
+		ClientSecret:  id + "_secret_" + randomHex(12),
+		Usage:         "off_session",
+		Livemode:      false,
+		Metadata:      parseMetadata(r),
+		Created:       store.Now(),
+	}
+	if u := r.FormValue("usage"); u != "" {
+		si.Usage = u
+	}
+	if pm := r.FormValue("payment_method"); pm != "" {
+		si.PaymentMethod = pm
+		si.Status = "requires_confirmation"
+	}
+	if r.FormValue("confirm") == "true" && si.PaymentMethod != "" {
+		si.Status = "succeeded"
+	}
+
+	h.store.SetupIntents.Set(id, si)
+	h.dispatcher.Enqueue("setup_intent.created", mapFromJSON(si))
+	if si.Status == "succeeded" {
+		h.dispatcher.Enqueue("setup_intent.succeeded", mapFromJSON(si))
+	}
+	twincore.JSON(w, http.StatusOK, si)
+}
+
+func (h *Handler) GetSetupIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	si, ok := h.store.SetupIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such setup_intent: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, si)
+}
+
+func (h *Handler) ConfirmSetupIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	si, ok := h.store.SetupIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such setup_intent: "+id)
+		return
+	}
+	if err := parseFormOrJSON(r); err == nil {
+		if pm := r.FormValue("payment_method"); pm != "" {
+			si.PaymentMethod = pm
+		}
+	}
+	si.Status = "succeeded"
+	h.store.SetupIntents.Set(id, si)
+	h.dispatcher.Enqueue("setup_intent.succeeded", mapFromJSON(si))
+	twincore.JSON(w, http.StatusOK, si)
+}
+
+func (h *Handler) CancelSetupIntent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	si, ok := h.store.SetupIntents.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such setup_intent: "+id)
+		return
+	}
+	si.Status = "canceled"
+	h.store.SetupIntents.Set(id, si)
+	h.dispatcher.Enqueue("setup_intent.canceled", mapFromJSON(si))
+	twincore.JSON(w, http.StatusOK, si)
+}
+
+func (h *Handler) ListSetupIntents(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.SetupIntents.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object": "list", "url": "/v1/setup_intents", "has_more": page.HasMore, "data": page.Data,
+	})
+}
+
+// --- Tax Rates ---
+
+func (h *Handler) CreateTaxRate(w http.ResponseWriter, r *http.Request) {
+	if err := parseFormOrJSON(r); err != nil {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parse_error", err.Error())
+		return
+	}
+	displayName := r.FormValue("display_name")
+	percentageStr := r.FormValue("percentage")
+	if displayName == "" || percentageStr == "" {
+		twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "parameter_missing", "Missing required params: display_name, percentage.")
+		return
+	}
+	pct, _ := strconv.ParseFloat(percentageStr, 64)
+
+	id := h.store.TaxRates.NextID()
+	tr := store.TaxRate{
+		ID:           id,
+		Object:       "tax_rate",
+		Active:       true,
+		DisplayName:  displayName,
+		Description:  r.FormValue("description"),
+		Inclusive:    r.FormValue("inclusive") == "true",
+		Percentage:   pct,
+		Country:      r.FormValue("country"),
+		State:        r.FormValue("state"),
+		Jurisdiction: r.FormValue("jurisdiction"),
+		Livemode:     false,
+		Metadata:     parseMetadata(r),
+		Created:      store.Now(),
+	}
+
+	h.store.TaxRates.Set(id, tr)
+	twincore.JSON(w, http.StatusOK, tr)
+}
+
+func (h *Handler) GetTaxRate(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	tr, ok := h.store.TaxRates.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such tax_rate: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, tr)
+}
+
+func (h *Handler) ListTaxRates(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.TaxRates.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object": "list", "url": "/v1/tax_rates", "has_more": page.HasMore, "data": page.Data,
+	})
+}
+
+// --- Disputes ---
+
+func (h *Handler) GetDispute(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	dp, ok := h.store.Disputes.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such dispute: "+id)
+		return
+	}
+	twincore.JSON(w, http.StatusOK, dp)
+}
+
+func (h *Handler) CloseDispute(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	dp, ok := h.store.Disputes.Get(id)
+	if !ok {
+		twincore.StripeError(w, http.StatusNotFound, "invalid_request_error", "resource_missing", "No such dispute: "+id)
+		return
+	}
+	dp.Status = "lost"
+	h.store.Disputes.Set(id, dp)
+	h.dispatcher.Enqueue("charge.dispute.closed", mapFromJSON(dp))
+	twincore.JSON(w, http.StatusOK, dp)
+}
+
+func (h *Handler) ListDisputes(w http.ResponseWriter, r *http.Request) {
+	cursor := r.URL.Query().Get("starting_after")
+	limit := parseLimit(r, 10)
+	page := h.store.Disputes.Paginate(cursor, limit)
+	twincore.JSON(w, http.StatusOK, map[string]any{
+		"object": "list", "url": "/v1/disputes", "has_more": page.HasMore, "data": page.Data,
+	})
+}

--- a/twin-stripe/internal/api/router.go
+++ b/twin-stripe/internal/api/router.go
@@ -96,6 +96,29 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Get("/invoiceitems/{id}", h.GetInvoiceItem)
 		r.Delete("/invoiceitems/{id}", h.DeleteInvoiceItem)
 
+		// Coupons
+		r.Post("/coupons", h.CreateCoupon)
+		r.Get("/coupons/{id}", h.GetCoupon)
+		r.Delete("/coupons/{id}", h.DeleteCoupon)
+		r.Get("/coupons", h.ListCoupons)
+
+		// Setup Intents
+		r.Post("/setup_intents", h.CreateSetupIntent)
+		r.Get("/setup_intents/{id}", h.GetSetupIntent)
+		r.Post("/setup_intents/{id}/confirm", h.ConfirmSetupIntent)
+		r.Post("/setup_intents/{id}/cancel", h.CancelSetupIntent)
+		r.Get("/setup_intents", h.ListSetupIntents)
+
+		// Tax Rates
+		r.Post("/tax_rates", h.CreateTaxRate)
+		r.Get("/tax_rates/{id}", h.GetTaxRate)
+		r.Get("/tax_rates", h.ListTaxRates)
+
+		// Disputes
+		r.Get("/disputes/{id}", h.GetDispute)
+		r.Post("/disputes/{id}/close", h.CloseDispute)
+		r.Get("/disputes", h.ListDisputes)
+
 		// Accounts
 		r.Post("/accounts", h.CreateAccount)
 		r.Get("/accounts/{id}", h.GetAccount)

--- a/twin-stripe/internal/store/memory.go
+++ b/twin-stripe/internal/store/memory.go
@@ -29,6 +29,10 @@ type MemoryStore struct {
 	Subscriptions        *pkgstore.Store[Subscription]
 	Invoices             *pkgstore.Store[Invoice]
 	InvoiceItems         *pkgstore.Store[InvoiceItem]
+	Coupons              *pkgstore.Store[Coupon]
+	SetupIntents         *pkgstore.Store[SetupIntent]
+	TaxRates             *pkgstore.Store[TaxRate]
+	Disputes             *pkgstore.Store[Dispute]
 
 	// Per-account balances (account ID -> balance)
 	Balances         map[string]*AccountBalance
@@ -58,6 +62,10 @@ func New() *MemoryStore {
 		Subscriptions:       pkgstore.New[Subscription]("sub"),
 		Invoices:            pkgstore.New[Invoice]("in"),
 		InvoiceItems:        pkgstore.New[InvoiceItem]("ii"),
+		Coupons:             pkgstore.New[Coupon]("coup"),
+		SetupIntents:        pkgstore.New[SetupIntent]("seti"),
+		TaxRates:            pkgstore.New[TaxRate]("txr"),
+		Disputes:            pkgstore.New[Dispute]("dp"),
 		Balances:        make(map[string]*AccountBalance),
 		PlatformBalance: NewAccountBalance(),
 		Clock:           pkgstore.NewClock(),
@@ -183,6 +191,10 @@ type stateSnapshot struct {
 	Subscriptions       map[string]Subscription        `json:"subscriptions"`
 	Invoices            map[string]Invoice             `json:"invoices"`
 	InvoiceItems        map[string]InvoiceItem         `json:"invoice_items"`
+	Coupons             map[string]Coupon              `json:"coupons"`
+	SetupIntents        map[string]SetupIntent         `json:"setup_intents"`
+	TaxRates            map[string]TaxRate             `json:"tax_rates"`
+	Disputes            map[string]Dispute             `json:"disputes"`
 	Balances            map[string]*AccountBalance     `json:"balances"`
 	PlatformBalance     *AccountBalance                `json:"platform_balance"`
 }
@@ -206,6 +218,10 @@ func (s *MemoryStore) Snapshot() any {
 		Subscriptions:       s.Subscriptions.Snapshot(),
 		Invoices:            s.Invoices.Snapshot(),
 		InvoiceItems:        s.InvoiceItems.Snapshot(),
+		Coupons:             s.Coupons.Snapshot(),
+		SetupIntents:        s.SetupIntents.Snapshot(),
+		TaxRates:            s.TaxRates.Snapshot(),
+		Disputes:            s.Disputes.Snapshot(),
 		Balances:            s.snapshotBalances(),
 		PlatformBalance:     s.PlatformBalance,
 	}
@@ -244,6 +260,10 @@ func (s *MemoryStore) LoadState(data []byte) error {
 	s.Subscriptions.LoadSnapshot(snap.Subscriptions)
 	s.Invoices.LoadSnapshot(snap.Invoices)
 	s.InvoiceItems.LoadSnapshot(snap.InvoiceItems)
+	s.Coupons.LoadSnapshot(snap.Coupons)
+	s.SetupIntents.LoadSnapshot(snap.SetupIntents)
+	s.TaxRates.LoadSnapshot(snap.TaxRates)
+	s.Disputes.LoadSnapshot(snap.Disputes)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -274,6 +294,10 @@ func (s *MemoryStore) Reset() {
 	s.Subscriptions.Reset()
 	s.Invoices.Reset()
 	s.InvoiceItems.Reset()
+	s.Coupons.Reset()
+	s.SetupIntents.Reset()
+	s.TaxRates.Reset()
+	s.Disputes.Reset()
 	s.Clock.Reset()
 
 	s.mu.Lock()

--- a/twin-stripe/internal/store/types.go
+++ b/twin-stripe/internal/store/types.go
@@ -406,6 +406,70 @@ type InvoiceItem struct {
 	Created     int64             `json:"created"`
 }
 
+// Coupon represents a Stripe coupon.
+type Coupon struct {
+	ID               string            `json:"id"`
+	Object           string            `json:"object"`
+	AmountOff        int64             `json:"amount_off,omitempty"`
+	PercentOff       float64           `json:"percent_off,omitempty"`
+	Currency         string            `json:"currency,omitempty"`
+	Duration         string            `json:"duration"` // forever, once, repeating
+	DurationInMonths int               `json:"duration_in_months,omitempty"`
+	MaxRedemptions   int               `json:"max_redemptions,omitempty"`
+	TimesRedeemed    int               `json:"times_redeemed"`
+	Name             string            `json:"name,omitempty"`
+	Valid            bool              `json:"valid"`
+	Livemode         bool              `json:"livemode"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Created          int64             `json:"created"`
+}
+
+// SetupIntent represents a Stripe setup intent for future payments.
+type SetupIntent struct {
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	Customer           string            `json:"customer,omitempty"`
+	PaymentMethod      string            `json:"payment_method,omitempty"`
+	Status             string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
+	ClientSecret       string            `json:"client_secret"`
+	Usage              string            `json:"usage"` // off_session or on_session
+	Livemode           bool              `json:"livemode"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Created            int64             `json:"created"`
+}
+
+// TaxRate represents a Stripe tax rate.
+type TaxRate struct {
+	ID           string            `json:"id"`
+	Object       string            `json:"object"`
+	Active       bool              `json:"active"`
+	DisplayName  string            `json:"display_name"`
+	Description  string            `json:"description,omitempty"`
+	Inclusive    bool              `json:"inclusive"`
+	Percentage   float64           `json:"percentage"`
+	Country      string            `json:"country,omitempty"`
+	State        string            `json:"state,omitempty"`
+	Jurisdiction string            `json:"jurisdiction,omitempty"`
+	Livemode     bool              `json:"livemode"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	Created      int64             `json:"created"`
+}
+
+// Dispute represents a Stripe dispute/chargeback.
+type Dispute struct {
+	ID              string            `json:"id"`
+	Object          string            `json:"object"`
+	Amount          int64             `json:"amount"`
+	Currency        string            `json:"currency"`
+	Charge          string            `json:"charge"`
+	PaymentIntent   string            `json:"payment_intent,omitempty"`
+	Reason          string            `json:"reason"` // fraudulent, duplicate, etc.
+	Status          string            `json:"status"` // needs_response, under_review, won, lost
+	Livemode        bool              `json:"livemode"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	Created         int64             `json:"created"`
+}
+
 // AccountBalance tracks per-account balance (available and pending).
 type AccountBalance struct {
 	Available map[string]int64 // currency -> amount


### PR DESCRIPTION
## Summary
PR 4 of 5 for full platform parity. Adds Coupons, SetupIntents (with lifecycle), TaxRates, Disputes.

## Test plan
- [x] All existing tests pass
- [x] `go build ./twin-stripe/cmd/twin-stripe` succeeds