### PR TITLE
docs: add agent permissions guidance to twin-researcher skill

### DIFF
--- a/skills/twin-researcher.md
+++ b/skills/twin-researcher.md
@@ -30,6 +30,19 @@ This skill produces two categories of output:
 2. Access to public internet for documentation, SDK repos, and community sources
 3. The `wondertwin-docs/` repo for storing research archives
 
+## Agent Permissions
+
+When this skill runs as a subagent, it needs write access to `wondertwin-docs/research/` which is **outside** the main `wondertwin/` working directory. To avoid permission denials:
+
+- The **parent conversation** should pre-create the research directory structure before launching the agent:
+  ```bash
+  platform="{platform}"
+  base="/Users/tela/dev/wondertwin-docs/research/${platform}"
+  mkdir -p "${base}/archive/"{official-docs,schemas,sdks,release-notes,community,observations}
+  ```
+- Alternatively, the parent should write all artifact files itself after the agent completes research, since the parent conversation has broader file permissions than subagents.
+- Subagents spawned from the `wondertwin/` directory cannot write to `wondertwin-docs/` due to sandbox scoping. This is a known limitation.
+
 ## Inputs
 
 The user will provide:


### PR DESCRIPTION
## Summary
- Document sandbox scoping limitation where subagents spawned from `wondertwin/` cannot write to `wondertwin-docs/`
- Add workaround instructions: parent pre-creates dirs or writes artifacts itself after agent research completes
- Discovered during candidate research of 6 accounting platforms (FreshBooks, Sage, Wave, Zoho Books, Puzzle.io, Kashoo)

## Test plan
- [ ] Verify twin-researcher skill renders correctly
- [ ] Confirm guidance matches observed agent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)