### PR TITLE
feat: Content API server, encrypted cache, and CLI integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,6 @@ validate-schemas: ## Validate all twin JSON files against their schemas
 
 verify-registry: ## Validate the live twin registry
 	go run ./cmd/verify-registry
+
+build-content-api: ## Build the content API server
+	go build $(LDFLAGS) -o bin/content-api ./cmd/content-api/

--- a/cmd/content-api/auth.go
+++ b/cmd/content-api/auth.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// authMiddleware validates Bearer tokens using the same structural checksum
+// logic as the CLI's ParseLicenseKey. Phase 1 — no DB lookup, format only.
+func authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			http.Error(w, `{"error":"missing or invalid Authorization header"}`, http.StatusUnauthorized)
+			return
+		}
+
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if !isValidLicenseKey(token) {
+			http.Error(w, `{"error":"invalid license key"}`, http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isValidLicenseKey validates the structural format of a license key:
+// wt_{tier}_{org}_{random}_{check} where check = sum of payload bytes mod 256 as 2-char hex.
+func isValidLicenseKey(key string) bool {
+	parts := strings.Split(key, "_")
+	if len(parts) < 5 {
+		return false
+	}
+
+	if parts[0] != "wt" {
+		return false
+	}
+
+	tier := parts[1]
+	if tier != "com" && tier != "ent" {
+		return false
+	}
+
+	if parts[2] == "" {
+		return false
+	}
+
+	check := parts[len(parts)-1]
+	if len(check) != 2 {
+		return false
+	}
+
+	random := strings.Join(parts[3:len(parts)-1], "_")
+	if len(random) < 6 {
+		return false
+	}
+
+	payload := strings.Join(parts[:len(parts)-1], "_")
+	var sum byte
+	for _, b := range []byte(payload) {
+		sum += b
+	}
+	expected := fmt.Sprintf("%02x", sum)
+	return check == expected
+}

--- a/cmd/content-api/auth_test.go
+++ b/cmd/content-api/auth_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsValidLicenseKey(t *testing.T) {
+	// Generate a valid key: wt_com_acme_{random}_{check}
+	// payload = "wt_com_acme_abcdef" => sum mod 256 as hex
+	validKey := makeTestKey("com", "acme", "abcdef")
+
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"valid key", validKey, true},
+		{"empty", "", false},
+		{"too few parts", "wt_com_acme", false},
+		{"bad prefix", "xx_com_acme_abcdef_00", false},
+		{"bad tier", "wt_xxx_acme_abcdef_00", false},
+		{"empty org", "wt_com__abcdef_00", false},
+		{"short random", "wt_com_acme_abc_00", false},
+		{"bad checksum", "wt_com_acme_abcdef_ff", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidLicenseKey(tt.key)
+			if got != tt.want {
+				t.Errorf("isValidLicenseKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidLicenseKeyEnterprise(t *testing.T) {
+	key := makeTestKey("ent", "bigcorp", "xyzxyzxyz")
+	if !isValidLicenseKey(key) {
+		t.Errorf("expected enterprise key %q to be valid", key)
+	}
+}
+
+// makeTestKey generates a structurally valid license key.
+func makeTestKey(tier, org, random string) string {
+	payload := "wt_" + tier + "_" + org + "_" + random
+	var sum byte
+	for _, b := range []byte(payload) {
+		sum += b
+	}
+	return payload + "_" + fmt.Sprintf("%02x", sum)
+}

--- a/cmd/content-api/data.go
+++ b/cmd/content-api/data.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed data/content
+var embeddedContent embed.FS
+
+// dataDir is set via the -data-dir flag for development/deployment without recompiling.
+var dataDir string
+
+// LoadFixture loads a content fixture for the given twin and version.
+// If dataDir is set, it reads from disk; otherwise it uses the embedded FS.
+func LoadFixture(twin, version string) ([]byte, error) {
+	relPath := filepath.Join("data", "content", twin, version+".json")
+
+	if dataDir != "" {
+		diskPath := filepath.Join(dataDir, twin, version+".json")
+		data, err := os.ReadFile(diskPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("content not found for %s@%s", twin, version)
+			}
+			return nil, fmt.Errorf("reading content fixture: %w", err)
+		}
+		return data, nil
+	}
+
+	data, err := embeddedContent.ReadFile(relPath)
+	if err != nil {
+		return nil, fmt.Errorf("content not found for %s@%s", twin, version)
+	}
+	return data, nil
+}

--- a/cmd/content-api/data/content/stripe/0.1.0.json
+++ b/cmd/content-api/data/content/stripe/0.1.0.json
@@ -1,0 +1,46 @@
+{
+  "twin": "stripe",
+  "version": "0.1.0",
+  "quirks": [
+    {
+      "id": "STRIPE-Q-001",
+      "service": "stripe",
+      "resource": "customer",
+      "type": "behavioral",
+      "severity": "moderate",
+      "summary": "Creating a customer with a duplicate email silently succeeds and creates a second customer record instead of returning an error."
+    },
+    {
+      "id": "STRIPE-Q-002",
+      "service": "stripe",
+      "resource": "subscription",
+      "type": "behavioral",
+      "severity": "critical",
+      "summary": "Canceling a subscription with prorate=true during a trial period still generates a zero-amount invoice rather than skipping invoice creation."
+    },
+    {
+      "id": "STRIPE-Q-003",
+      "service": "stripe",
+      "resource": "payment_intent",
+      "type": "behavioral",
+      "severity": "minor",
+      "summary": "PaymentIntent metadata is limited to 50 keys but the API accepts the request and silently drops keys beyond the limit without returning an error."
+    },
+    {
+      "id": "STRIPE-Q-004",
+      "service": "stripe",
+      "resource": "invoice",
+      "type": "temporal",
+      "severity": "moderate",
+      "summary": "Finalizing an invoice within 1 second of creation may return a 402 if the customer default payment method webhook has not yet propagated."
+    },
+    {
+      "id": "STRIPE-Q-005",
+      "service": "stripe",
+      "resource": "refund",
+      "type": "behavioral",
+      "severity": "moderate",
+      "summary": "Refunding a charge that was created with a connected account requires the Stripe-Account header even if the refund endpoint is called with the charge ID directly."
+    }
+  ]
+}

--- a/cmd/content-api/go.mod
+++ b/cmd/content-api/go.mod
@@ -1,0 +1,5 @@
+module github.com/wondertwin-ai/wondertwin/cmd/content-api
+
+go 1.25.7
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/cmd/content-api/go.sum
+++ b/cmd/content-api/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/cmd/content-api/handler.go
+++ b/cmd/content-api/handler.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// handleGetContent serves GET /v1/content/{spec} where spec = {twin}@{version}.
+func handleGetContent(w http.ResponseWriter, r *http.Request) {
+	spec := chi.URLParam(r, "spec")
+
+	twin, version, ok := parseSpec(spec)
+	if !ok {
+		http.Error(w, `{"error":"invalid spec format, expected {twin}@{version}"}`, http.StatusBadRequest)
+		return
+	}
+
+	data, err := LoadFixture(twin, version)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+// parseSpec splits "twin@version" into its components.
+func parseSpec(spec string) (twin, version string, ok bool) {
+	i := strings.LastIndex(spec, "@")
+	if i <= 0 || i >= len(spec)-1 {
+		return "", "", false
+	}
+	return spec[:i], spec[i+1:], true
+}

--- a/cmd/content-api/handler_test.go
+++ b/cmd/content-api/handler_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func newTestRouter() *chi.Mux {
+	r := chi.NewRouter()
+	r.Route("/v1", func(r chi.Router) {
+		r.Use(authMiddleware)
+		r.Get("/content/{spec}", handleGetContent)
+	})
+	return r
+}
+
+func validAuthHeader() string {
+	return "Bearer " + makeTestKey("com", "acme", "abcdef")
+}
+
+func TestHandlerValidRequest(t *testing.T) {
+	router := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/v1/content/stripe@0.1.0", nil)
+	req.Header.Set("Authorization", validAuthHeader())
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var payload ContentPayload
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if payload.Twin != "stripe" {
+		t.Fatalf("expected twin=stripe, got %q", payload.Twin)
+	}
+	if len(payload.Quirks) == 0 {
+		t.Fatal("expected at least one quirk")
+	}
+}
+
+func TestHandlerNoAuth(t *testing.T) {
+	router := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/v1/content/stripe@0.1.0", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandlerInvalidToken(t *testing.T) {
+	router := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/v1/content/stripe@0.1.0", nil)
+	req.Header.Set("Authorization", "Bearer invalid-key")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandlerNotFound(t *testing.T) {
+	router := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/v1/content/nonexistent@9.9.9", nil)
+	req.Header.Set("Authorization", validAuthHeader())
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerBadSpec(t *testing.T) {
+	router := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/v1/content/no-version-here", nil)
+	req.Header.Set("Authorization", validAuthHeader())
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestParseSpec(t *testing.T) {
+	tests := []struct {
+		spec    string
+		twin    string
+		version string
+		ok      bool
+	}{
+		{"stripe@0.1.0", "stripe", "0.1.0", true},
+		{"my-twin@1.2.3", "my-twin", "1.2.3", true},
+		{"bad-spec", "", "", false},
+		{"@0.1.0", "", "", false},
+		{"twin@", "", "", false},
+	}
+
+	for _, tt := range tests {
+		twin, version, ok := parseSpec(tt.spec)
+		if ok != tt.ok || twin != tt.twin || version != tt.version {
+			t.Errorf("parseSpec(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.spec, twin, version, ok, tt.twin, tt.version, tt.ok)
+		}
+	}
+}

--- a/cmd/content-api/main.go
+++ b/cmd/content-api/main.go
@@ -1,0 +1,45 @@
+// content-api is a standalone HTTP server that serves WonderTwin intelligence
+// (quirks, workflows, compatibility data) behind license-key authentication.
+//
+// Usage:
+//
+//	content-api [-port 8080] [-data-dir ./fixtures]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	port := flag.Int("port", 8080, "HTTP listen port")
+	flag.StringVar(&dataDir, "data-dir", "", "directory containing content fixtures (overrides embedded data)")
+	flag.Parse()
+
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	// Health endpoint (unauthenticated)
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// Content API (authenticated)
+	r.Route("/v1", func(r chi.Router) {
+		r.Use(authMiddleware)
+		r.Get("/content/{spec}", handleGetContent)
+	})
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("content-api listening on %s", addr)
+	if err := http.ListenAndServe(addr, r); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/cmd/content-api/types.go
+++ b/cmd/content-api/types.go
@@ -1,0 +1,18 @@
+package main
+
+// ContentPayload is the JSON response for GET /v1/content/{spec}.
+type ContentPayload struct {
+	Twin    string        `json:"twin"`
+	Version string        `json:"version"`
+	Quirks  []QuirkRecord `json:"quirks,omitempty"`
+}
+
+// QuirkRecord describes a single SDK quirk.
+type QuirkRecord struct {
+	ID       string `json:"id"`
+	Service  string `json:"service"`
+	Resource string `json:"resource"`
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+}

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -36,9 +36,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/wondertwin-ai/wondertwin/internal/cache"
 	"github.com/wondertwin-ai/wondertwin/internal/client"
 	"github.com/wondertwin-ai/wondertwin/internal/config"
 	"github.com/wondertwin-ai/wondertwin/internal/conformance"
+	"github.com/wondertwin-ai/wondertwin/internal/content"
 	"github.com/wondertwin-ai/wondertwin/internal/lockfile"
 	"github.com/wondertwin-ai/wondertwin/internal/manifest"
 	"github.com/wondertwin-ai/wondertwin/internal/mcp"
@@ -113,6 +115,8 @@ func main() {
 		err = cmdAuth(args)
 	case "registry":
 		err = cmdRegistry(args)
+	case "cache":
+		err = cmdCache(manifestPath, args)
 	case "conformance":
 		err = cmdConformance(args)
 	default:
@@ -176,6 +180,8 @@ Commands:
   registry add <n> <url>     Add a named registry (--token <t> for auth)
   registry remove <name>     Remove a named registry
   registry list              List configured registries
+  cache warm [twin...]       Fetch and cache content for manifest twins
+  cache clear [twin...]      Remove cached content
   conformance <binary>       Run conformance tests against a twin binary
   version                    Print the wt version
 
@@ -183,8 +189,9 @@ Options:
   --config <path>   Path to manifest (default: ./wondertwin.json, falls back to .yaml)
 
 Environment:
-  WT_CONFIG         Override default manifest path
-  WT_REGISTRY_URL   Override registry URL
+  WT_CONFIG              Override default manifest path
+  WT_REGISTRY_URL        Override registry URL
+  WONDERTWIN_CONTENT_URL Override content API URL (default: https://api.wondertwin.ai)
 `, version)
 }
 
@@ -214,6 +221,11 @@ func cmdUp(manifestPath string) error {
 		if err := cmdInstall(manifestPath, nil); err != nil {
 			return err
 		}
+	}
+
+	// Resolve content for commercial twins (non-fatal)
+	if err := resolveContent(m); err != nil {
+		fmt.Printf("warn: content resolution: %v\n", err)
 	}
 
 	pids, _ := procmgr.LoadPids()
@@ -267,6 +279,9 @@ func cmdUp(manifestPath string) error {
 			allHealthy = false
 		}
 	}
+
+	// Load cached content into healthy twins via /admin/state
+	loadContentIntoTwins(m, ac, names)
 
 	fmt.Println()
 	if allHealthy {
@@ -1148,6 +1163,207 @@ func cmdCI(manifestPath string) error {
 		return fmt.Errorf("failed to install: %s", strings.Join(failed, ", "))
 	}
 	fmt.Println("All twins installed from lock file.")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Content resolution helpers
+// ---------------------------------------------------------------------------
+
+const defaultContentURL = "https://api.wondertwin.ai"
+
+// contentURL returns the Content API base URL, checking env override first.
+func contentURL() string {
+	if u := os.Getenv("WONDERTWIN_CONTENT_URL"); u != "" {
+		return u
+	}
+	return defaultContentURL
+}
+
+// cacheDir returns the path to ~/.wondertwin/cache.
+func cacheDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".wondertwin/cache"
+	}
+	return filepath.Join(home, ".wondertwin", "cache")
+}
+
+// resolveContent fetches and caches content for all twins in the manifest
+// that have a version set. Returns nil if no license is configured.
+func resolveContent(m *manifest.Manifest) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if !cfg.HasValidLicense() {
+		return nil
+	}
+
+	store := cache.NewStore(cacheDir(), cfg.LicenseKey)
+	cc := content.NewClient(contentURL(), cfg.LicenseKey)
+
+	for _, name := range m.TwinNames() {
+		twin := m.Twins[name]
+		version := twin.Version
+		if version == "" || version == "latest" {
+			continue
+		}
+
+		if store.IsValid(name, version) {
+			continue
+		}
+
+		raw, _, err := cc.FetchContent(name, version)
+		if err != nil {
+			// Graceful degradation: check for stale cache
+			_, meta, cacheErr := store.Get(name, version)
+			if cacheErr == nil && meta != nil {
+				fmt.Printf("  warn: content fetch failed for %s@%s, using stale cache: %v\n", name, version, err)
+				continue
+			}
+			fmt.Printf("  warn: content fetch failed for %s@%s: %v\n", name, version, err)
+			continue
+		}
+
+		if err := store.Put(name, version, raw, 24); err != nil {
+			fmt.Printf("  warn: caching content for %s@%s: %v\n", name, version, err)
+		}
+	}
+
+	return nil
+}
+
+// loadContentIntoTwins posts cached content payloads to healthy twins via /admin/state.
+func loadContentIntoTwins(m *manifest.Manifest, ac *client.AdminClient, names []string) {
+	cfg, _ := config.Load()
+	if cfg == nil || !cfg.HasValidLicense() {
+		return
+	}
+
+	store := cache.NewStore(cacheDir(), cfg.LicenseKey)
+
+	for _, name := range names {
+		twin := m.Twins[name]
+		version := twin.Version
+		if version == "" || version == "latest" {
+			continue
+		}
+
+		payload, _, err := store.Get(name, version)
+		if err != nil || payload == nil {
+			continue
+		}
+
+		if _, err := ac.PostState(twin.AdminPort, payload); err != nil {
+			fmt.Printf("  warn: loading content into %s: %v\n", name, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// wt cache warm|clear
+// ---------------------------------------------------------------------------
+
+func cmdCache(manifestPath string, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: wt cache <warm|clear>")
+	}
+
+	switch args[0] {
+	case "warm":
+		return cmdCacheWarm(manifestPath, args[1:])
+	case "clear":
+		return cmdCacheClear(args[1:])
+	default:
+		return fmt.Errorf("unknown cache subcommand %q (expected warm or clear)", args[0])
+	}
+}
+
+func cmdCacheWarm(manifestPath string, args []string) error {
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if !cfg.HasValidLicense() {
+		return fmt.Errorf("no valid license key — run 'wt auth login' first")
+	}
+
+	store := cache.NewStore(cacheDir(), cfg.LicenseKey)
+	cc := content.NewClient(contentURL(), cfg.LicenseKey)
+
+	// If specific twins given, use those; otherwise use manifest
+	targets := args
+	if len(targets) == 0 {
+		targets = m.TwinNames()
+	}
+
+	fmt.Println("Warming content cache...")
+	fmt.Println()
+
+	for _, name := range targets {
+		twin, err := m.Twin(name)
+		if err != nil {
+			fmt.Printf("  %-20s skipped (not in manifest)\n", name)
+			continue
+		}
+		version := twin.Version
+		if version == "" || version == "latest" {
+			fmt.Printf("  %-20s skipped (no pinned version)\n", name)
+			continue
+		}
+
+		if store.IsValid(name, version) {
+			fmt.Printf("  %-20s cached (valid)\n", name)
+			continue
+		}
+
+		raw, _, err := cc.FetchContent(name, version)
+		if err != nil {
+			fmt.Printf("  %-20s FAILED — %v\n", name, err)
+			continue
+		}
+
+		if err := store.Put(name, version, raw, 24); err != nil {
+			fmt.Printf("  %-20s FAILED — %v\n", name, err)
+			continue
+		}
+		fmt.Printf("  %-20s cached %s@%s\n", name, name, version)
+	}
+
+	fmt.Println()
+	return nil
+}
+
+func cmdCacheClear(args []string) error {
+	cfg, _ := config.Load()
+	licenseKey := ""
+	if cfg != nil {
+		licenseKey = cfg.LicenseKey
+	}
+
+	store := cache.NewStore(cacheDir(), licenseKey)
+
+	if len(args) == 0 {
+		if err := store.Clear("", ""); err != nil {
+			return fmt.Errorf("clearing cache: %w", err)
+		}
+		fmt.Println("Content cache cleared.")
+		return nil
+	}
+
+	for _, name := range args {
+		if err := store.Clear(name, ""); err != nil {
+			fmt.Printf("  warn: clearing cache for %s: %v\n", name, err)
+			continue
+		}
+		fmt.Printf("  Cleared cache for %s\n", name)
+	}
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.25.7
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	golang.org/x/crypto v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/text v0.14.0 // indirect
+require golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.work
+++ b/go.work
@@ -2,6 +2,7 @@ go 1.25.7
 
 use (
 	.
+	./cmd/content-api
 	./twin-logodev
 	./twin-loyaltylion
 	./twin-posthog

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Store manages encrypted content cache files on disk.
+type Store struct {
+	Dir        string
+	LicenseKey string
+}
+
+// NewStore creates a Store rooted at cacheDir using licenseKey for encryption.
+func NewStore(cacheDir, licenseKey string) *Store {
+	return &Store{Dir: cacheDir, LicenseKey: licenseKey}
+}
+
+// encPath returns the path to the encrypted payload file.
+func (s *Store) encPath(twin, version string) string {
+	return filepath.Join(s.Dir, "content", twin, version+".enc")
+}
+
+// metaPath returns the path to the metadata file.
+func (s *Store) metaPath(twin, version string) string {
+	return filepath.Join(s.Dir, "content", twin, version+".meta")
+}
+
+// Get returns the decrypted payload and metadata for a cached entry.
+// If the cache is expired, it still returns the stale payload along with
+// the metadata (caller can check meta.IsExpired() for graceful degradation).
+// Returns os.ErrNotExist-wrapped error if no cache exists.
+func (s *Store) Get(twin, version string) ([]byte, *CacheMeta, error) {
+	meta, err := ReadMeta(s.metaPath(twin, version))
+	if err != nil {
+		return nil, nil, fmt.Errorf("cache miss for %s@%s: %w", twin, version, err)
+	}
+
+	enc, err := os.ReadFile(s.encPath(twin, version))
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading cached payload for %s@%s: %w", twin, version, err)
+	}
+
+	key, err := DeriveKey(s.LicenseKey, twin, version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payload, err := Decrypt(key, enc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decrypting cache for %s@%s: %w", twin, version, err)
+	}
+
+	return payload, meta, nil
+}
+
+// Put encrypts and writes the payload to the cache along with metadata.
+func (s *Store) Put(twin, version string, payload []byte, ttlHours int) error {
+	dir := filepath.Dir(s.encPath(twin, version))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating cache dir: %w", err)
+	}
+
+	key, err := DeriveKey(s.LicenseKey, twin, version)
+	if err != nil {
+		return err
+	}
+
+	enc, err := Encrypt(key, payload)
+	if err != nil {
+		return fmt.Errorf("encrypting payload for %s@%s: %w", twin, version, err)
+	}
+
+	if err := os.WriteFile(s.encPath(twin, version), enc, 0o600); err != nil {
+		return fmt.Errorf("writing cached payload: %w", err)
+	}
+
+	now := time.Now().UTC()
+	meta := &CacheMeta{
+		Twin:      twin,
+		Version:   version,
+		FetchedAt: now,
+		TTLHours:  ttlHours,
+		ExpiresAt: now.Add(time.Duration(ttlHours) * time.Hour),
+	}
+	if err := WriteMeta(s.metaPath(twin, version), meta); err != nil {
+		return fmt.Errorf("writing cache meta: %w", err)
+	}
+
+	return nil
+}
+
+// IsValid returns true if a non-expired cache entry exists.
+func (s *Store) IsValid(twin, version string) bool {
+	meta, err := ReadMeta(s.metaPath(twin, version))
+	if err != nil {
+		return false
+	}
+	return !meta.IsExpired()
+}
+
+// Clear removes cached content. If both twin and version are empty, all
+// content cache is removed. If only version is empty, all versions of the
+// twin are removed.
+func (s *Store) Clear(twin, version string) error {
+	if twin == "" && version == "" {
+		return os.RemoveAll(filepath.Join(s.Dir, "content"))
+	}
+	if version == "" {
+		return os.RemoveAll(filepath.Join(s.Dir, "content", twin))
+	}
+	os.Remove(s.encPath(twin, version))
+	os.Remove(s.metaPath(twin, version))
+	return nil
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,114 @@
+package cache
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestPutGetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "wt_com_acme_abcdef_xx")
+
+	payload := []byte(`{"quirks": []}`)
+	if err := store.Put("stripe", "0.1.0", payload, 24); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, meta, err := store.Get("stripe", "0.1.0")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if !bytes.Equal(payload, got) {
+		t.Fatalf("payload mismatch: got %q, want %q", got, payload)
+	}
+
+	if meta.Twin != "stripe" || meta.Version != "0.1.0" {
+		t.Fatalf("meta mismatch: %+v", meta)
+	}
+
+	if meta.IsExpired() {
+		t.Fatal("cache should not be expired yet")
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-key")
+
+	if store.IsValid("stripe", "0.1.0") {
+		t.Fatal("should not be valid before Put")
+	}
+
+	if err := store.Put("stripe", "0.1.0", []byte("data"), 24); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if !store.IsValid("stripe", "0.1.0") {
+		t.Fatal("should be valid after Put")
+	}
+}
+
+func TestExpiredCache(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-key")
+
+	if err := store.Put("stripe", "0.1.0", []byte("data"), 24); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Manually expire the cache by rewriting meta
+	meta, _ := ReadMeta(store.metaPath("stripe", "0.1.0"))
+	meta.ExpiresAt = time.Now().Add(-1 * time.Hour)
+	WriteMeta(store.metaPath("stripe", "0.1.0"), meta)
+
+	// Get should still return stale data
+	got, retMeta, err := store.Get("stripe", "0.1.0")
+	if err != nil {
+		t.Fatalf("Get should succeed for expired cache: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected stale payload")
+	}
+	if !retMeta.IsExpired() {
+		t.Fatal("meta should report expired")
+	}
+
+	if store.IsValid("stripe", "0.1.0") {
+		t.Fatal("IsValid should return false for expired cache")
+	}
+}
+
+func TestClear(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-key")
+
+	store.Put("stripe", "0.1.0", []byte("a"), 24)
+	store.Put("stripe", "0.2.0", []byte("b"), 24)
+	store.Put("twilio", "0.1.0", []byte("c"), 24)
+
+	// Clear specific version
+	store.Clear("stripe", "0.1.0")
+	if store.IsValid("stripe", "0.1.0") {
+		t.Fatal("stripe 0.1.0 should be cleared")
+	}
+	if !store.IsValid("stripe", "0.2.0") {
+		t.Fatal("stripe 0.2.0 should still exist")
+	}
+
+	// Clear all versions of a twin
+	store.Clear("stripe", "")
+	if store.IsValid("stripe", "0.2.0") {
+		t.Fatal("stripe 0.2.0 should be cleared")
+	}
+	if !store.IsValid("twilio", "0.1.0") {
+		t.Fatal("twilio should still exist")
+	}
+
+	// Clear all
+	store.Clear("", "")
+	if store.IsValid("twilio", "0.1.0") {
+		t.Fatal("everything should be cleared")
+	}
+}

--- a/internal/cache/crypto.go
+++ b/internal/cache/crypto.go
@@ -1,0 +1,76 @@
+// Package cache provides an encrypted local cache for content API payloads.
+package cache
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// DeriveKey derives a 32-byte AES-256 key from the license key, twin name,
+// and version using HKDF-SHA256.
+func DeriveKey(licenseKey, twin, version string) ([]byte, error) {
+	salt := sha256.Sum256([]byte(twin + ":" + version))
+	info := []byte("wondertwin-content-cache-v1")
+
+	hkdfReader := hkdf.New(sha256.New, []byte(licenseKey), salt[:], info)
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(hkdfReader, key); err != nil {
+		return nil, fmt.Errorf("deriving cache key: %w", err)
+	}
+	return key, nil
+}
+
+// Encrypt encrypts plaintext using AES-256-GCM with a random 12-byte nonce
+// prepended to the ciphertext.
+func Encrypt(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("creating GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generating nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// Decrypt reverses Encrypt: extracts the 12-byte nonce prefix and decrypts
+// the remaining ciphertext using AES-256-GCM.
+func Decrypt(key, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("creating GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertextBody := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertextBody, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/internal/cache/crypto_test.go
+++ b/internal/cache/crypto_test.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key, err := DeriveKey("wt_com_acme_abcdef_xx", "stripe", "0.1.0")
+	if err != nil {
+		t.Fatalf("DeriveKey: %v", err)
+	}
+
+	plaintext := []byte(`{"quirks": [{"id": "STRIPE-Q-001"}]}`)
+	enc, err := Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	dec, err := Decrypt(key, enc)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, dec) {
+		t.Fatalf("round-trip mismatch: got %q, want %q", dec, plaintext)
+	}
+}
+
+func TestDecryptWrongKeyFails(t *testing.T) {
+	key1, _ := DeriveKey("key-one", "stripe", "0.1.0")
+	key2, _ := DeriveKey("key-two", "stripe", "0.1.0")
+
+	enc, err := Encrypt(key1, []byte("secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	_, err = Decrypt(key2, enc)
+	if err == nil {
+		t.Fatal("expected decryption to fail with wrong key")
+	}
+}
+
+func TestDeriveKeyDeterministic(t *testing.T) {
+	k1, _ := DeriveKey("license", "twin", "1.0.0")
+	k2, _ := DeriveKey("license", "twin", "1.0.0")
+
+	if !bytes.Equal(k1, k2) {
+		t.Fatal("DeriveKey is not deterministic")
+	}
+}
+
+func TestDeriveKeyDifferentInputs(t *testing.T) {
+	k1, _ := DeriveKey("license", "stripe", "1.0.0")
+	k2, _ := DeriveKey("license", "twilio", "1.0.0")
+
+	if bytes.Equal(k1, k2) {
+		t.Fatal("different twins should produce different keys")
+	}
+}

--- a/internal/cache/meta.go
+++ b/internal/cache/meta.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// CacheMeta stores metadata about a cached content payload.
+type CacheMeta struct {
+	Twin            string    `json:"twin"`
+	Version         string    `json:"version"`
+	FetchedAt       time.Time `json:"fetched_at"`
+	TTLHours        int       `json:"ttl_hours"`
+	ExpiresAt       time.Time `json:"expires_at"`
+	TaxonomyVersion string    `json:"taxonomy_version,omitempty"`
+}
+
+// IsExpired returns true if the cache entry has passed its expiration time.
+func (m *CacheMeta) IsExpired() bool {
+	return time.Now().After(m.ExpiresAt)
+}
+
+// ReadMeta reads a CacheMeta from the given file path.
+func ReadMeta(path string) (*CacheMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading cache meta: %w", err)
+	}
+
+	var meta CacheMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parsing cache meta: %w", err)
+	}
+	return &meta, nil
+}
+
+// WriteMeta writes a CacheMeta to the given file path.
+func WriteMeta(path string, meta *CacheMeta) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cache meta: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -88,6 +88,24 @@ func (c *AdminClient) adminGet(adminPort int, path string) (string, error) {
 	return string(body), nil
 }
 
+// PostState POSTs raw JSON bytes to POST /admin/state on a twin.
+func (c *AdminClient) PostState(adminPort int, data []byte) (string, error) {
+	resp, err := c.http.Post(
+		fmt.Sprintf("http://localhost:%d/admin/state", adminPort),
+		"application/json",
+		bytes.NewReader(data),
+	)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("POST /admin/state returned status %d: %s", resp.StatusCode, body)
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
 // Seed POSTs the contents of a JSON file to POST /admin/state on a twin.
 func (c *AdminClient) Seed(adminPort int, filePath string) (string, error) {
 	data, err := os.ReadFile(filePath)

--- a/internal/content/client.go
+++ b/internal/content/client.go
@@ -1,0 +1,67 @@
+package content
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client fetches content payloads from the Content API.
+type Client struct {
+	BaseURL string
+	Token   string
+	http    *http.Client
+}
+
+// NewClient creates a content API client.
+func NewClient(baseURL, token string) *Client {
+	return &Client{
+		BaseURL: baseURL,
+		Token:   token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// FetchContent retrieves the content payload for a twin at a specific version.
+// It returns both the raw bytes (suitable for caching) and the parsed payload.
+func (c *Client) FetchContent(twin, version string) ([]byte, *ContentPayload, error) {
+	url := fmt.Sprintf("%s/v1/content/%s@%s", c.BaseURL, twin, version)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating content request: %w", err)
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching content for %s@%s: %w", twin, version, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading content response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, nil, fmt.Errorf("content API returned 401: invalid or missing license key")
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil, fmt.Errorf("content not found for %s@%s", twin, version)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("content API returned HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var payload ContentPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, nil, fmt.Errorf("parsing content payload: %w", err)
+	}
+
+	return body, &payload, nil
+}

--- a/internal/content/client_test.go
+++ b/internal/content/client_test.go
@@ -1,0 +1,83 @@
+package content
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchContentSuccess(t *testing.T) {
+	payload := ContentPayload{
+		Twin:    "stripe",
+		Version: "0.1.0",
+		Quirks: []QuirkRecord{
+			{ID: "STRIPE-Q-001", Service: "stripe", Resource: "customer", Type: "behavioral", Severity: "moderate", Summary: "test quirk"},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/content/stripe@0.1.0" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	raw, got, err := client.FetchContent("stripe", "0.1.0")
+	if err != nil {
+		t.Fatalf("FetchContent: %v", err)
+	}
+	if raw == nil {
+		t.Fatal("expected raw bytes")
+	}
+	if got.Twin != "stripe" || len(got.Quirks) != 1 {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+}
+
+func TestFetchContent401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("unauthorized"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "bad-token")
+	_, _, err := client.FetchContent("stripe", "0.1.0")
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+}
+
+func TestFetchContent404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "token")
+	_, _, err := client.FetchContent("nonexistent", "0.0.0")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestFetchContent500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "token")
+	_, _, err := client.FetchContent("stripe", "0.1.0")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -1,0 +1,19 @@
+// Package content provides a client for the WonderTwin Content API.
+package content
+
+// ContentPayload is the top-level response from the Content API.
+type ContentPayload struct {
+	Twin    string          `json:"twin"`
+	Version string          `json:"version"`
+	Quirks  []QuirkRecord   `json:"quirks,omitempty"`
+}
+
+// QuirkRecord describes a single SDK quirk.
+type QuirkRecord struct {
+	ID       string `json:"id"`
+	Service  string `json:"service"`
+	Resource string `json:"resource"`
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+}

--- a/schemas/quirk.schema.json
+++ b/schemas/quirk.schema.json
@@ -22,16 +22,7 @@
     },
     "type": {
       "type": "string",
-      "description": "Category of the quirk.",
-      "enum": [
-        "silent_ignore",
-        "state_dependent",
-        "temporal",
-        "side_effect",
-        "undocumented_default",
-        "race_condition",
-        "inconsistency"
-      ]
+      "description": "Category of the quirk."
     },
     "severity": {
       "type": "string",


### PR DESCRIPTION
## Summary

- Adds standalone Content API server (`cmd/content-api/`) with chi/v5, license-key auth middleware, embedded fixture data, and `GET /v1/content/{twin}@{version}`
- Adds encrypted local cache (`internal/cache/`) using AES-256-GCM with HKDF key derivation from license key, TTL-based expiry, and graceful stale-cache fallback
- Adds content client (`internal/content/`) following the existing registry client pattern
- Integrates into CLI: content preflight in `wt up`, post-healthcheck content loading via `/admin/state`, new `wt cache warm|clear` commands
- Removes quirk type enum from schema — vocabulary is now server-side per ADR

## Test plan

- [x] `go test ./internal/cache/...` — crypto round-trips, cache TTL, clear (4 tests)
- [x] `go test ./internal/content/...` — client against httptest server (4 tests)
- [x] `go test ./cmd/content-api/...` — handler + auth middleware tests (8 tests)
- [x] `go vet ./...` — clean
- [x] Both `cmd/wt` and `cmd/content-api` compile
- [ ] Manual: start content-api with `-port 8090`, set `WONDERTWIN_CONTENT_URL`, run `wt cache warm` and `wt up`