### PR TITLE
feat: skill/schema versioning and CI safety system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Validate twin schemas
         run: go run ./cmd/validate-schemas/
 
+      - name: Validate skill-schema pins
+        run: go run ./cmd/validate-skill-pins/
+
+      - name: Validate skill JSON templates
+        run: go run ./cmd/validate-skill-templates/
+
       - name: Build wt CLI
         run: go build ./cmd/wt/
 

--- a/cmd/validate-skill-pins/main.go
+++ b/cmd/validate-skill-pins/main.go
@@ -1,0 +1,198 @@
+// Command validate-skill-pins checks that skill frontmatter schema pins
+// match the $version declared in each schema file.
+//
+// A MAJOR version mismatch (schema > skill) is a FAIL.
+// A MINOR version mismatch (schema > skill) is a WARN.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type skillFrontmatter struct {
+	Skill        string            `yaml:"skill"`
+	SkillVersion string            `yaml:"skill_version"`
+	Schemas      map[string]string `yaml:"schemas"`
+}
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	skillsDir := filepath.Join(root, "skills")
+	schemasDir := filepath.Join(root, "schemas")
+
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: cannot read skills directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	var fails []string
+	var warns []string
+	checked := 0
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(skillsDir, e.Name())
+		fm, err := parseFrontmatter(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: %s: %v\n", e.Name(), err)
+			continue
+		}
+
+		if len(fm.Schemas) == 0 {
+			fmt.Printf("  skip  %s (no schema pins)\n", e.Name())
+			continue
+		}
+
+		for schemaFile, pinnedVersion := range fm.Schemas {
+			schemaPath := filepath.Join(schemasDir, schemaFile)
+			schemaVersion, err := extractSchemaVersion(schemaPath)
+			if err != nil {
+				fails = append(fails, fmt.Sprintf("%s → %s: %v", e.Name(), schemaFile, err))
+				continue
+			}
+
+			cmp, err := compareVersions(schemaVersion, pinnedVersion)
+			if err != nil {
+				fails = append(fails, fmt.Sprintf("%s → %s: version parse error: %v", e.Name(), schemaFile, err))
+				continue
+			}
+
+			checked++
+			switch {
+			case cmp.majorDrift:
+				fails = append(fails, fmt.Sprintf("%s → %s: pinned %s but schema is %s (MAJOR drift)", e.Name(), schemaFile, pinnedVersion, schemaVersion))
+			case cmp.minorDrift:
+				warns = append(warns, fmt.Sprintf("%s → %s: pinned %s but schema is %s (minor drift)", e.Name(), schemaFile, pinnedVersion, schemaVersion))
+				fmt.Printf("  warn  %s → %s: pinned %s, schema %s\n", e.Name(), schemaFile, pinnedVersion, schemaVersion)
+			default:
+				fmt.Printf("  ok    %s → %s: %s\n", e.Name(), schemaFile, pinnedVersion)
+			}
+		}
+	}
+
+	fmt.Printf("\n%d pins checked\n", checked)
+
+	if len(warns) > 0 {
+		fmt.Printf("%d warnings:\n", len(warns))
+		for _, w := range warns {
+			fmt.Printf("  WARN  %s\n", w)
+		}
+	}
+
+	if len(fails) > 0 {
+		fmt.Printf("%d failures:\n", len(fails))
+		for _, f := range fails {
+			fmt.Printf("  FAIL  %s\n", f)
+		}
+		os.Exit(1)
+	}
+}
+
+// parseFrontmatter extracts YAML frontmatter from a markdown file.
+func parseFrontmatter(path string) (skillFrontmatter, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return skillFrontmatter{}, err
+	}
+
+	content := string(data)
+	if !strings.HasPrefix(content, "---\n") {
+		return skillFrontmatter{}, fmt.Errorf("no frontmatter found")
+	}
+
+	end := strings.Index(content[4:], "\n---")
+	if end < 0 {
+		return skillFrontmatter{}, fmt.Errorf("unterminated frontmatter")
+	}
+
+	var fm skillFrontmatter
+	if err := yaml.Unmarshal([]byte(content[4:4+end]), &fm); err != nil {
+		return skillFrontmatter{}, fmt.Errorf("invalid frontmatter YAML: %w", err)
+	}
+
+	return fm, nil
+}
+
+// extractSchemaVersion reads a JSON schema file and returns the $version field.
+func extractSchemaVersion(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot read schema: %w", err)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return "", fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	v, ok := schema["$version"]
+	if !ok {
+		return "", fmt.Errorf("no $version field")
+	}
+
+	version, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("$version is not a string")
+	}
+
+	return version, nil
+}
+
+type versionComparison struct {
+	majorDrift bool
+	minorDrift bool
+}
+
+// compareVersions checks if the schema version has drifted from the pinned version.
+// Returns majorDrift if schema MAJOR > pin MAJOR, minorDrift if schema MINOR > pin MINOR.
+func compareVersions(schemaVersion, pinnedVersion string) (versionComparison, error) {
+	schemaMajor, schemaMinor, err := parseVersion(schemaVersion)
+	if err != nil {
+		return versionComparison{}, fmt.Errorf("schema version %q: %w", schemaVersion, err)
+	}
+
+	pinMajor, pinMinor, err := parseVersion(pinnedVersion)
+	if err != nil {
+		return versionComparison{}, fmt.Errorf("pinned version %q: %w", pinnedVersion, err)
+	}
+
+	return versionComparison{
+		majorDrift: schemaMajor > pinMajor,
+		minorDrift: !((schemaMajor > pinMajor)) && schemaMinor > pinMinor,
+	}, nil
+}
+
+// parseVersion splits "MAJOR.MINOR" into integers.
+func parseVersion(v string) (int, int, error) {
+	parts := strings.Split(v, ".")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR format, got %q", v)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid major: %w", err)
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minor: %w", err)
+	}
+
+	return major, minor, nil
+}

--- a/cmd/validate-skill-templates/main.go
+++ b/cmd/validate-skill-templates/main.go
@@ -1,0 +1,270 @@
+// Command validate-skill-templates validates JSON template blocks in skill
+// markdown files against their declared schemas.
+//
+// It finds <!-- schema: X.schema.json --> annotations followed by ```json
+// code blocks, substitutes {placeholder} values with valid dummy data,
+// and validates the result against the referenced schema.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// placeholders maps known placeholder patterns to valid substitution values.
+// String placeholders are substituted as-is. The validator also handles
+// special cases like {port} which need to become integers.
+var placeholders = map[string]string{
+	// Names and identifiers
+	"{name}":             "test",
+	"{Service}":          "Test Service",
+	"{category}":         "testing",
+	"{Platform}":         "Test Platform",
+
+	// SDK fields
+	"{sdk_import_path}":  "github.com/example/sdk",
+	"{sdk_version}":      "v1.0.0",
+	"{org}":              "example",
+	"{sdk-repo}":         "sdk-repo",
+
+	// Timestamps
+	"{ISO 8601 timestamp}": "2026-01-01T00:00:00Z",
+	"{ISO 8601}":           "2026-01-01T00:00:00Z",
+	"{date}":               "2026-01-01",
+
+	// Hashes and refs
+	"{hash of spec content}":  "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+	"{hash of arazzo file}":   "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+	"{SHA-256 of spec}":       "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+	"{tag or commit}":         "v1.0.0",
+	"{pinned version}":        "v1.0.0",
+	"{pinned API version}":    "2024-01-01",
+	"{git commit of archive}": "abc123def456",
+
+	// Researcher-specific
+	"{developer docs URL}":    "https://developer.example.com",
+	"{platform}":              "test-platform",
+	"{source_type}":           "official_docs",
+	"{url}":                   "https://example.com/docs",
+	"{archive_path}":          "archive/official-docs/2026-01-01",
+	"{scope}":                 "candidate",
+
+	// Ports (handled specially — substituted as integer)
+	"{port}": "4200",
+}
+
+var (
+	// Matches <!-- schema: something.schema.json -->
+	annotationRe = regexp.MustCompile(`<!--\s*schema:\s*(\S+\.schema\.json)\s*-->`)
+	// Matches ```json ... ``` blocks
+	codeBlockRe = regexp.MustCompile("```json\\s*\\n([\\s\\S]*?)\\n```")
+	// Matches {placeholder} patterns in strings (single-line, no nested braces/newlines)
+	placeholderRe = regexp.MustCompile(`\{[^{}\n]+\}`)
+)
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	skillsDir := filepath.Join(root, "skills")
+	schemasDir := filepath.Join(root, "schemas")
+
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: cannot read skills directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	var failures []string
+	validated := 0
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(skillsDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: cannot read %s: %v\n", e.Name(), err)
+			continue
+		}
+
+		content := string(data)
+		blocks := findAnnotatedBlocks(content)
+
+		if len(blocks) == 0 {
+			fmt.Printf("  skip  %s (no annotated blocks)\n", e.Name())
+			continue
+		}
+
+		for _, block := range blocks {
+			schemaPath := filepath.Join(schemasDir, block.schema)
+			sch, err := compileSchema(schemaPath)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("%s [%s]: cannot compile schema: %v", e.Name(), block.schema, err))
+				continue
+			}
+
+			substituted, err := substitutePlaceholders(block.json)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("%s [%s]: %v", e.Name(), block.schema, err))
+				continue
+			}
+
+			var v any
+			if err := json.Unmarshal([]byte(substituted), &v); err != nil {
+				failures = append(failures, fmt.Sprintf("%s [%s]: invalid JSON after substitution: %v\nSubstituted JSON:\n%s", e.Name(), block.schema, err, substituted))
+				continue
+			}
+
+			if err := sch.Validate(v); err != nil {
+				failures = append(failures, fmt.Sprintf("%s [%s]: validation failed: %v", e.Name(), block.schema, err))
+				continue
+			}
+
+			validated++
+			fmt.Printf("  ok    %s [%s]\n", e.Name(), block.schema)
+		}
+	}
+
+	fmt.Printf("\n%d template blocks validated\n", validated)
+
+	if len(failures) > 0 {
+		fmt.Printf("%d failures:\n", len(failures))
+		for _, f := range failures {
+			fmt.Printf("  FAIL  %s\n", f)
+		}
+		os.Exit(1)
+	}
+}
+
+type annotatedBlock struct {
+	schema string
+	json   string
+}
+
+// findAnnotatedBlocks finds <!-- schema: X --> annotations followed by ```json blocks.
+func findAnnotatedBlocks(content string) []annotatedBlock {
+	var blocks []annotatedBlock
+
+	annotations := annotationRe.FindAllStringSubmatchIndex(content, -1)
+	for _, loc := range annotations {
+		schema := content[loc[2]:loc[3]]
+		// Look for the next ```json block after this annotation
+		rest := content[loc[1]:]
+		match := codeBlockRe.FindStringSubmatch(rest)
+		if match == nil {
+			continue
+		}
+		// Verify the code block comes before any other annotation
+		nextAnnotation := annotationRe.FindStringIndex(rest[1:])
+		codeBlockIdx := strings.Index(rest, "```json")
+		if nextAnnotation != nil && nextAnnotation[0]+1 < codeBlockIdx {
+			continue // Another annotation comes before this code block
+		}
+
+		blocks = append(blocks, annotatedBlock{
+			schema: schema,
+			json:   match[1],
+		})
+	}
+
+	return blocks
+}
+
+// substitutePlaceholders replaces {placeholder} values with valid dummy data.
+// It handles both string and integer contexts.
+func substitutePlaceholders(jsonStr string) (string, error) {
+	// Find all unique placeholders in the template
+	matches := placeholderRe.FindAllString(jsonStr, -1)
+	seen := make(map[string]bool)
+
+	for _, m := range matches {
+		if seen[m] {
+			continue
+		}
+		seen[m] = true
+
+		replacement, ok := findPlaceholder(m)
+		if !ok {
+			return "", fmt.Errorf("unrecognized placeholder: %s", m)
+		}
+
+		// Check if this placeholder appears in a non-string context (e.g., as a bare value)
+		// by looking for patterns like `: {placeholder}` without surrounding quotes
+		barePattern := regexp.MustCompile(`:\s*` + regexp.QuoteMeta(m))
+		quotedPattern := regexp.MustCompile(`"[^"]*` + regexp.QuoteMeta(m) + `[^"]*"`)
+
+		bareLocs := barePattern.FindAllStringIndex(jsonStr, -1)
+		for _, loc := range bareLocs {
+			segment := jsonStr[loc[0]:loc[1]]
+			// Check if this bare occurrence is inside a quoted string
+			inQuotes := false
+			for _, qloc := range quotedPattern.FindAllStringIndex(jsonStr, -1) {
+				if loc[0] >= qloc[0] && loc[1] <= qloc[1] {
+					inQuotes = true
+					break
+				}
+			}
+			if !inQuotes {
+				// This is a bare value (integer context) — replace with unquoted number
+				jsonStr = strings.Replace(jsonStr, segment, ": "+replacement, 1)
+			}
+		}
+
+		// Replace remaining occurrences (inside quoted strings) with just the value
+		jsonStr = strings.ReplaceAll(jsonStr, m, replacement)
+	}
+
+	return jsonStr, nil
+}
+
+// findPlaceholder looks up a placeholder in the known map. It also handles
+// pattern-based matching for variations like {hash ...}, {SHA-256 ...}, etc.
+func findPlaceholder(p string) (string, bool) {
+	// Direct lookup
+	if v, ok := placeholders[p]; ok {
+		return v, true
+	}
+
+	inner := strings.ToLower(p[1 : len(p)-1])
+
+	// Pattern matching for common variations
+	switch {
+	case strings.HasPrefix(inner, "hash"):
+		return "abc123def456abc123def456abc123def456abc123def456abc123def456abcd", true
+	case strings.HasPrefix(inner, "sha-256"):
+		return "abc123def456abc123def456abc123def456abc123def456abc123def456abcd", true
+	case strings.HasPrefix(inner, "pinned"):
+		return "v1.0.0", true
+	case strings.HasPrefix(inner, "iso 8601"):
+		return "2026-01-01T00:00:00Z", true
+	case strings.Contains(inner, "timestamp"):
+		return "2026-01-01T00:00:00Z", true
+	case strings.Contains(inner, "version"):
+		return "v1.0.0", true
+	case strings.Contains(inner, "url"):
+		return "https://example.com", true
+	}
+
+	return "", false
+}
+
+func compileSchema(path string) (*jsonschema.Schema, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	c := jsonschema.NewCompiler()
+	return c.Compile("file://" + absPath)
+}

--- a/schemas/provenance.schema.json
+++ b/schemas/provenance.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/provenance.schema.json",
+  "$version": "1.1",
   "title": "Twin Provenance",
   "description": "Schema for twin provenance tracking, recording how a twin was generated.",
   "type": "object",
@@ -9,6 +10,35 @@
     "twin": {
       "type": "string",
       "description": "Name of the twin."
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the twin (e.g., 0.1.0). Used by researcher-originated provenance."
+    },
+    "platform": {
+      "type": "string",
+      "description": "Display name of the target platform (e.g., QuickBooks Online)."
+    },
+    "platform_url": {
+      "type": "string",
+      "description": "URL of the platform's developer documentation."
+    },
+    "api_version": {
+      "type": "string",
+      "description": "Version of the upstream API this twin targets."
+    },
+    "category": {
+      "type": "string",
+      "description": "Functional category of the platform (e.g., accounting, payments)."
+    },
+    "research_archive": {
+      "type": "string",
+      "description": "Path to the research archive directory for this twin."
+    },
+    "research_completed": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when research was completed."
     },
     "sdk_target": {
       "type": "object",
@@ -43,97 +73,162 @@
       "type": "string",
       "description": "Version of the WonderTwin skill used for generation."
     },
-    "sources": {
+    "fintech_primitives": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of fintech primitives this twin maps to (e.g., ledger, billing)."
+    },
+    "twinkit_packages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of twinkit packages used by this twin."
+    },
+    "scope": {
       "type": "object",
-      "description": "Sources used during twin generation.",
+      "description": "What the twin implements and what it does not.",
       "properties": {
-        "openapi": {
-          "type": "object",
-          "description": "OpenAPI specification source.",
-          "properties": {
-            "origin": {
-              "type": "string",
-              "enum": ["vendor_published", "community_maintained", "derived", "manual", "none", "unknown"],
-              "description": "Origin of the OpenAPI spec."
-            },
-            "url": {
-              "type": "string",
-              "description": "URL where the spec was retrieved from."
-            },
-            "retrieved_at": {
-              "type": "string",
-              "format": "date-time",
-              "description": "When the spec was retrieved."
-            },
-            "sha256": {
-              "type": "string",
-              "description": "SHA-256 hash of the spec content."
-            },
-            "api_version": {
-              "type": "string",
-              "description": "Version of the API described by the spec."
-            }
+        "implemented": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false
+          "description": "List of implemented capabilities."
         },
-        "sdk_analysis": {
-          "type": "object",
-          "description": "SDK analysis source.",
-          "properties": {
-            "method": {
-              "type": "string",
-              "enum": ["deepwiki", "direct_repo", "manual", "none"],
-              "description": "Analysis method used."
-            },
-            "repo": {
-              "type": "string",
-              "description": "Repository URL of the SDK."
-            },
-            "repo_ref": {
-              "type": "string",
-              "description": "Git ref (tag, branch, commit) analyzed."
-            },
-            "retrieved_at": {
-              "type": "string",
-              "format": "date-time",
-              "description": "When the SDK was retrieved for analysis."
-            },
-            "sha256": {
-              "type": "string",
-              "description": "SHA-256 hash of the analyzed content."
-            },
-            "fallback_used": {
-              "type": "boolean",
-              "description": "Whether a fallback analysis method was used."
-            }
+        "not_implemented": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false
-        },
-        "arazzo": {
-          "type": "object",
-          "description": "Arazzo workflow source.",
-          "properties": {
-            "origin": {
-              "type": "string",
-              "enum": ["vendor_published", "community_contributed", "generated", "manual"],
-              "description": "Origin of the Arazzo workflow."
-            },
-            "generated_from": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "List of sources used to generate the Arazzo workflow."
-            },
-            "sha256": {
-              "type": "string",
-              "description": "SHA-256 hash of the Arazzo workflow."
-            }
-          },
-          "additionalProperties": false
+          "description": "List of capabilities not yet implemented."
         }
       },
       "additionalProperties": false
+    },
+    "sources": {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Sources used during twin generation (generator format).",
+          "properties": {
+            "openapi": {
+              "type": "object",
+              "description": "OpenAPI specification source.",
+              "properties": {
+                "origin": {
+                  "type": "string",
+                  "enum": ["vendor_published", "community_maintained", "derived", "manual", "none", "unknown"],
+                  "description": "Origin of the OpenAPI spec."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL where the spec was retrieved from."
+                },
+                "retrieved_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "When the spec was retrieved."
+                },
+                "sha256": {
+                  "type": "string",
+                  "description": "SHA-256 hash of the spec content."
+                },
+                "api_version": {
+                  "type": "string",
+                  "description": "Version of the API described by the spec."
+                }
+              },
+              "additionalProperties": false
+            },
+            "sdk_analysis": {
+              "type": "object",
+              "description": "SDK analysis source.",
+              "properties": {
+                "method": {
+                  "type": "string",
+                  "enum": ["deepwiki", "direct_repo", "manual", "none"],
+                  "description": "Analysis method used."
+                },
+                "repo": {
+                  "type": "string",
+                  "description": "Repository URL of the SDK."
+                },
+                "repo_ref": {
+                  "type": "string",
+                  "description": "Git ref (tag, branch, commit) analyzed."
+                },
+                "retrieved_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "When the SDK was retrieved for analysis."
+                },
+                "sha256": {
+                  "type": "string",
+                  "description": "SHA-256 hash of the analyzed content."
+                },
+                "fallback_used": {
+                  "type": "boolean",
+                  "description": "Whether a fallback analysis method was used."
+                }
+              },
+              "additionalProperties": false
+            },
+            "arazzo": {
+              "type": "object",
+              "description": "Arazzo workflow source.",
+              "properties": {
+                "origin": {
+                  "type": "string",
+                  "enum": ["vendor_published", "community_contributed", "generated", "manual"],
+                  "description": "Origin of the Arazzo workflow."
+                },
+                "generated_from": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of sources used to generate the Arazzo workflow."
+                },
+                "sha256": {
+                  "type": "string",
+                  "description": "SHA-256 hash of the Arazzo workflow."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "array",
+          "description": "Sources used during research (researcher format).",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Source type (e.g., official_docs, sdk, openapi, community)."
+              },
+              "url": {
+                "type": "string",
+                "description": "URL of the source."
+              },
+              "accessed": {
+                "type": "string",
+                "description": "Date the source was accessed."
+              },
+              "archived_at": {
+                "type": "string",
+                "description": "Path where the source was archived."
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
     }
   },
   "additionalProperties": false

--- a/schemas/quirk.schema.json
+++ b/schemas/quirk.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/quirk.schema.json",
+  "$version": "1.0",
   "title": "SDK Quirk",
   "description": "Schema for documenting SDK quirks and edge cases observed in real services.",
   "type": "object",

--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/scenario.schema.json",
+  "$version": "1.0",
   "title": "Test Scenario",
   "description": "Schema for defining test scenarios that validate twin behavior.",
   "type": "object",

--- a/schemas/twin-manifest.schema.json
+++ b/schemas/twin-manifest.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/twin-manifest.schema.json",
+  "$version": "1.0",
   "title": "Twin Contribution Manifest",
   "description": "Schema for twin contribution manifests describing a twin's capabilities and coverage.",
   "type": "object",

--- a/schemas/twin.schema.json
+++ b/schemas/twin.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/twin.schema.json",
+  "$version": "1.0",
   "title": "Twin Configuration",
   "description": "Schema for twin.json files that define a twin's identity, SDK target, and default port.",
   "type": "object",

--- a/schemas/wondertwin.schema.json
+++ b/schemas/wondertwin.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wondertwin.dev/schemas/wondertwin.schema.json",
+  "$version": "1.0",
   "title": "WonderTwin Project Manifest",
   "description": "Schema for the WonderTwin project manifest file (wondertwin.yaml).",
   "type": "object",

--- a/skills/twin-extender.md
+++ b/skills/twin-extender.md
@@ -1,3 +1,9 @@
+---
+skill: twin-extender
+skill_version: "1.0"
+schemas: {}
+---
+
 # SKILL: WonderTwin Twin Extender
 
 ## Purpose

--- a/skills/twin-generator.md
+++ b/skills/twin-generator.md
@@ -1,3 +1,12 @@
+---
+skill: twin-generator
+skill_version: "2.1"
+schemas:
+  provenance.schema.json: "1.1"
+  twin-manifest.schema.json: "1.0"
+  twin.schema.json: "1.0"
+---
+
 # SKILL: WonderTwin Twin Generator
 
 ## Purpose
@@ -95,6 +104,7 @@ Before any code generation, gather and record all available sources. This phase 
 
 Create the initial `provenance.json` (validated against `schemas/provenance.schema.json`):
 
+<!-- schema: provenance.schema.json -->
 ```json
 {
   "twin": "{name}",
@@ -104,7 +114,7 @@ Create the initial `provenance.json` (validated against `schemas/provenance.sche
     "version": "{sdk_version}"
   },
   "generated_at": "{ISO 8601 timestamp}",
-  "skill_version": "2.0",
+  "skill_version": "2.1",
   "sources": {
     "openapi": {
       "origin": "vendor_published",
@@ -130,6 +140,7 @@ If no OpenAPI spec is available, omit the `openapi` field or set `origin` to `"d
 
 Populate the manifest shell (validated against `schemas/twin-manifest.schema.json`). Coverage fields will be completed as handlers are implemented:
 
+<!-- schema: twin-manifest.schema.json -->
 ```json
 {
   "twin": "{name}",
@@ -161,7 +172,7 @@ Populate the manifest shell (validated against `schemas/twin-manifest.schema.jso
   },
   "generation": {
     "method": "wondertwin_skill",
-    "skill_version": "2.0",
+    "skill_version": "2.1",
     "sources_used": {
       "deepwiki": true,
       "openapi": true,
@@ -230,6 +241,7 @@ And to the Makefile `TWINS` variable if it's a free-tier twin.
 
 **5. Fill in `twin.json`** at the twin root:
 
+<!-- schema: twin.schema.json -->
 ```json
 {
   "name": "{name}",

--- a/skills/twin-maintainer.md
+++ b/skills/twin-maintainer.md
@@ -1,3 +1,9 @@
+---
+skill: twin-maintainer
+skill_version: "1.0"
+schemas: {}
+---
+
 # SKILL: WonderTwin Twin Maintainer
 
 ## Purpose

--- a/skills/twin-researcher.md
+++ b/skills/twin-researcher.md
@@ -1,3 +1,10 @@
+---
+skill: twin-researcher
+skill_version: "1.0"
+schemas:
+  provenance.schema.json: "1.1"
+---
+
 # SKILL: WonderTwin Twin Researcher
 
 ## Purpose
@@ -445,6 +452,7 @@ Append the completion entry:
 
 This is the file that ships with the twin (in `twin-{name}/provenance.json`). It extends the existing provenance format with research lineage:
 
+<!-- schema: provenance.schema.json -->
 ```json
 {
   "twin": "twin-{name}",
@@ -455,6 +463,7 @@ This is the file that ships with the twin (in `twin-{name}/provenance.json`). It
   "category": "{category}",
   "research_archive": "wondertwin-docs/research/{platform}",
   "research_completed": "{ISO 8601}",
+  "generated_at": "{ISO 8601 timestamp}",
   "sources": [
     {
       "type": "{source_type}",

--- a/skills/twin-sidecar.md
+++ b/skills/twin-sidecar.md
@@ -1,3 +1,9 @@
+---
+skill: twin-sidecar
+skill_version: "1.0"
+schemas: {}
+---
+
 # SKILL: WonderTwin Twin Sidecar
 
 ## Purpose

--- a/twin-qbo/provenance.json
+++ b/twin-qbo/provenance.json
@@ -6,7 +6,13 @@
   "platform_url": "https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities",
   "category": "accounting",
   "research_archive": "wondertwin-docs/research/quickbooks-online",
-  "research_completed": "2026-03-17",
+  "research_completed": "2026-03-17T00:00:00Z",
+  "generated_at": "2026-03-17T00:00:00Z",
+  "sdk_target": {
+    "package": "github.com/rwestlund/quickbooks-go",
+    "language": "go",
+    "version": "v0.0.0"
+  },
   "sources": [
     {
       "type": "api_documentation",

--- a/twin-qbo/twin-manifest.json
+++ b/twin-qbo/twin-manifest.json
@@ -1,57 +1,45 @@
 {
-  "name": "twin-qbo",
+  "twin": "qbo",
   "display_name": "QuickBooks Online",
-  "version": "0.1.0",
   "category": "accounting",
   "description": "Simulates the QuickBooks Online Accounting API v3 — chart of accounts, customers, vendors, invoices, bills, payments, journal entries, and financial reports with SQL-like query language.",
-  "default_port": 4116,
-  "api_prefix": "/v3/company/{realmId}",
-  "auth_type": "bearer_oauth2",
-  "fintech_primitives": ["ledger_accounting"],
-  "sdk_targets": [],
-  "admin_endpoints": [
-    "GET /admin/health",
-    "POST /admin/reset",
-    "GET /admin/state",
-    "POST /admin/state"
-  ],
-  "api_endpoints": [
-    "POST /v3/company/{realmId}/customer",
-    "GET /v3/company/{realmId}/customer/{id}",
-    "POST /v3/company/{realmId}/vendor",
-    "GET /v3/company/{realmId}/vendor/{id}",
-    "POST /v3/company/{realmId}/account",
-    "GET /v3/company/{realmId}/account/{id}",
-    "POST /v3/company/{realmId}/item",
-    "GET /v3/company/{realmId}/item/{id}",
-    "POST /v3/company/{realmId}/invoice",
-    "GET /v3/company/{realmId}/invoice/{id}",
-    "POST /v3/company/{realmId}/bill",
-    "GET /v3/company/{realmId}/bill/{id}",
-    "POST /v3/company/{realmId}/payment",
-    "GET /v3/company/{realmId}/payment/{id}",
-    "POST /v3/company/{realmId}/billpayment",
-    "GET /v3/company/{realmId}/billpayment/{id}",
-    "POST /v3/company/{realmId}/creditmemo",
-    "GET /v3/company/{realmId}/creditmemo/{id}",
-    "POST /v3/company/{realmId}/vendorcredit",
-    "GET /v3/company/{realmId}/vendorcredit/{id}",
-    "POST /v3/company/{realmId}/salesreceipt",
-    "GET /v3/company/{realmId}/salesreceipt/{id}",
-    "POST /v3/company/{realmId}/deposit",
-    "GET /v3/company/{realmId}/deposit/{id}",
-    "POST /v3/company/{realmId}/transfer",
-    "GET /v3/company/{realmId}/transfer/{id}",
-    "POST /v3/company/{realmId}/journalentry",
-    "GET /v3/company/{realmId}/journalentry/{id}",
-    "POST /v3/company/{realmId}/estimate",
-    "GET /v3/company/{realmId}/estimate/{id}",
-    "POST /v3/company/{realmId}/purchase",
-    "GET /v3/company/{realmId}/purchase/{id}",
-    "GET /v3/company/{realmId}/companyinfo/{id}",
-    "GET /v3/company/{realmId}/query",
-    "GET /v3/company/{realmId}/reports/ProfitAndLoss",
-    "GET /v3/company/{realmId}/reports/BalanceSheet",
-    "GET /v3/company/{realmId}/reports/TrialBalance"
-  ]
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/rwestlund/quickbooks-go",
+      "language": "go",
+      "version": "v0.0.0",
+      "repo_url": "https://github.com/rwestlund/quickbooks-go"
+    }
+  },
+  "service_surface": {
+    "openapi_spec": {
+      "available": false
+    },
+    "auth_pattern": "oauth2",
+    "has_webhooks": true,
+    "resource_count": 18
+  },
+  "coverage": {
+    "resources_implemented": [
+      "Customer", "Vendor", "Account", "Item",
+      "Invoice", "Bill", "Payment", "BillPayment",
+      "CreditMemo", "VendorCredit", "SalesReceipt", "Deposit",
+      "Transfer", "JournalEntry", "Estimate", "Purchase",
+      "CompanyInfo", "Query"
+    ],
+    "resources_not_implemented": [
+      "Batch", "ChangeDataCapture", "Attachments",
+      "TaxCode", "TimeActivity", "Budget"
+    ],
+    "estimated_coverage_pct": 75
+  },
+  "generation": {
+    "method": "wondertwin_skill",
+    "skill_version": "2.1",
+    "sources_used": {
+      "deepwiki": false,
+      "openapi": false,
+      "manual_docs": true
+    }
+  }
 }

--- a/twin-qbo/twin.json
+++ b/twin-qbo/twin.json
@@ -1,0 +1,10 @@
+{
+  "name": "qbo",
+  "description": "Behavioral clone of the QuickBooks Online Accounting API",
+  "category": "accounting",
+  "sdk": {
+    "package": "github.com/rwestlund/quickbooks-go",
+    "version": "v0.0.0"
+  },
+  "default_port": 4116
+}

--- a/twin-xero/provenance.json
+++ b/twin-xero/provenance.json
@@ -5,6 +5,12 @@
   "platform": "Xero",
   "platform_url": "https://developer.xero.com/documentation/api/accounting/overview",
   "category": "accounting",
+  "generated_at": "2026-03-17T00:00:00Z",
+  "sdk_target": {
+    "package": "github.com/xero-api/xero-go",
+    "language": "go",
+    "version": "v2.0.0"
+  },
   "sources": [
     {
       "type": "api_documentation",

--- a/twin-xero/twin-manifest.json
+++ b/twin-xero/twin-manifest.json
@@ -1,47 +1,46 @@
 {
-  "name": "twin-xero",
+  "twin": "xero",
   "display_name": "Xero",
-  "version": "0.1.0",
   "category": "accounting",
   "description": "Simulates the Xero Accounting API — chart of accounts, invoices, bills, credit notes, payments, manual journals, and financial reports.",
-  "default_port": 4115,
-  "api_prefix": "/api.xro/2.0",
-  "auth_type": "bearer",
-  "fintech_primitives": ["ledger_accounting"],
-  "sdk_targets": [],
-  "admin_endpoints": [
-    "GET /admin/health",
-    "POST /admin/reset",
-    "GET /admin/state",
-    "POST /admin/state"
-  ],
-  "api_endpoints": [
-    "POST /api.xro/2.0/Contacts",
-    "GET /api.xro/2.0/Contacts",
-    "GET /api.xro/2.0/Contacts/{ContactID}",
-    "POST /api.xro/2.0/Accounts",
-    "GET /api.xro/2.0/Accounts",
-    "GET /api.xro/2.0/Accounts/{AccountID}",
-    "POST /api.xro/2.0/Invoices",
-    "GET /api.xro/2.0/Invoices",
-    "GET /api.xro/2.0/Invoices/{InvoiceID}",
-    "POST /api.xro/2.0/CreditNotes",
-    "GET /api.xro/2.0/CreditNotes",
-    "GET /api.xro/2.0/CreditNotes/{CreditNoteID}",
-    "PUT /api.xro/2.0/Payments",
-    "GET /api.xro/2.0/Payments",
-    "GET /api.xro/2.0/Payments/{PaymentID}",
-    "PUT /api.xro/2.0/BankTransactions",
-    "GET /api.xro/2.0/BankTransactions",
-    "GET /api.xro/2.0/BankTransactions/{BankTransactionID}",
-    "PUT /api.xro/2.0/ManualJournals",
-    "GET /api.xro/2.0/ManualJournals",
-    "GET /api.xro/2.0/ManualJournals/{ManualJournalID}",
-    "POST /api.xro/2.0/Items",
-    "GET /api.xro/2.0/Items",
-    "GET /api.xro/2.0/Items/{ItemID}",
-    "GET /api.xro/2.0/Reports/TrialBalance",
-    "GET /api.xro/2.0/Reports/ProfitAndLoss",
-    "GET /api.xro/2.0/Reports/BalanceSheet"
-  ]
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/xero-api/xero-go",
+      "language": "go",
+      "version": "v2.0.0",
+      "repo_url": "https://github.com/XeroAPI/xero-go"
+    }
+  },
+  "service_surface": {
+    "openapi_spec": {
+      "available": true,
+      "origin": "vendor_published",
+      "url": "https://raw.githubusercontent.com/XeroAPI/Xero-OpenAPI/master/xero_accounting.yaml"
+    },
+    "auth_pattern": "oauth2",
+    "has_webhooks": true,
+    "resource_count": 12
+  },
+  "coverage": {
+    "resources_implemented": [
+      "Contacts", "Accounts", "Invoices", "CreditNotes",
+      "Payments", "BankTransactions", "ManualJournals", "Items",
+      "TrialBalance", "ProfitAndLoss", "BalanceSheet"
+    ],
+    "resources_not_implemented": [
+      "TrackingCategories", "TaxRates", "Currencies",
+      "RepeatingInvoices", "Prepayments", "Overpayments",
+      "PurchaseOrders", "Attachments"
+    ],
+    "estimated_coverage_pct": 60
+  },
+  "generation": {
+    "method": "wondertwin_skill",
+    "skill_version": "2.1",
+    "sources_used": {
+      "deepwiki": false,
+      "openapi": true,
+      "manual_docs": true
+    }
+  }
 }

--- a/twin-xero/twin.json
+++ b/twin-xero/twin.json
@@ -1,0 +1,10 @@
+{
+  "name": "xero",
+  "description": "Behavioral clone of the Xero Accounting API",
+  "category": "accounting",
+  "sdk": {
+    "package": "github.com/xero-api/xero-go",
+    "version": "v2.0.0"
+  },
+  "default_port": 4115
+}


### PR DESCRIPTION
## Summary

- Adds `$version` fields to all 6 JSON schemas (provenance bumped to `1.1` for researcher field expansion)
- Expands `provenance.schema.json` to accept both generator format (sources as object) and researcher format (sources as array) via `oneOf`, plus optional fields: `version`, `platform`, `platform_url`, `api_version`, `category`, `research_archive`, `research_completed`, `fintech_primitives`, `twinkit_packages`, `scope`
- Adds YAML frontmatter with schema version pins to all 5 skills
- Adds `<!-- schema: X.schema.json -->` annotations before JSON template blocks in `twin-generator.md` (3 blocks) and `twin-researcher.md` (1 block)
- Two new CI validators:
  - `cmd/validate-skill-pins/` — compares skill frontmatter pins against schema `$version`; FAIL on MAJOR drift, WARN on minor drift
  - `cmd/validate-skill-templates/` — substitutes `{placeholder}` values in annotated JSON blocks and validates against declared schema
- Fixes twin-qbo and twin-xero to conform to schemas (missing `twin.json`, non-conformant manifests, invalid provenance fields)

## Motivation

Skills contain JSON templates that must conform to JSON schemas. When schemas evolve, skill templates don't get updated, causing generated twins to fail validation. This happened with twin-qbo and twin-xero — the researcher skill had a non-conformant provenance template. Nothing caught this until CI failed post-merge. This PR makes it impossible to merge a schema change without updating every skill that references it.

## Test plan

- [x] `go run ./cmd/validate-schemas/` — 27/27 twin JSON files pass (including fixed qbo/xero)
- [x] `go run ./cmd/validate-skill-pins/` — 4/4 pins match
- [x] `go run ./cmd/validate-skill-templates/` — 4/4 annotated JSON blocks pass
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] Verified pin validator catches intentional MAJOR drift (schema bumped to 2.0 → FAIL)
- [x] Verified template validator catches intentional schema violation (required field added → FAIL)

## Note for `feat/content-api` (PR #136)

This PR should merge first. Once merged, the content-api branch should rebase onto main and can drop its `85d4ab4` commit ("fix: update schemas to accept researcher-format provenance and manifests") since this PR subsumes those schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)