### PR TITLE
feat(twin-stripe): proration on subscription item changes

### DIFF
--- a/twin-stripe/BACKLOG.md
+++ b/twin-stripe/BACKLOG.md
@@ -19,11 +19,10 @@ Work items to deepen twin-stripe from "routes exist" to "behaviors work".
 
 ## Medium Value
 
-### 4. Proration on subscription changes
-- [ ] Updating a subscription's price or quantity mid-cycle generates a prorated invoice
-- [ ] Credit for unused time on old price, charge for remaining time on new price
-
-One of the most common Stripe integration bugs — important for realistic testing.
+### 4. ~~Proration on subscription changes~~ (done)
+- [x] Updating a subscription's price or quantity mid-cycle generates a prorated invoice
+- [x] Credit for unused time on old price, charge for remaining time on new price
+- [x] `proration_behavior=none` skips proration invoice
 
 ### 5. Invoice lifecycle deepening
 - [ ] `POST /v1/invoices/{id}/send` for send_invoice mode

--- a/twin-stripe/internal/api/handlers_proration_test.go
+++ b/twin-stripe/internal/api/handlers_proration_test.go
@@ -1,0 +1,219 @@
+package api_test
+
+import (
+	"testing"
+)
+
+func TestProrationOnPriceUpgrade(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	// Create product + two prices.
+	resp := stripePost(tc, "/v1/products?name=ProProd", nil)
+	resp.AssertStatus(200)
+	prodID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=1000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	cheapPrice := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=3000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	expensivePrice := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/customers?name=ProCust", nil)
+	resp.AssertStatus(200)
+	custID := resp.JSONMap()["id"].(string)
+
+	// Create subscription on cheap price.
+	resp = stripePost(tc, "/v1/subscriptions?customer="+custID+"&items[0][price]="+cheapPrice, nil)
+	resp.AssertStatus(200)
+	subID := resp.JSONMap()["id"].(string)
+	firstInvoice := resp.JSONMap()["latest_invoice"].(string)
+
+	// Advance time ~halfway through the period (15 days).
+	tc.Post("/admin/time/advance", map[string]any{"duration": "360h"})
+
+	// Upgrade to expensive price.
+	resp = stripePost(tc, "/v1/subscriptions/"+subID+"?items[0][price]="+expensivePrice, nil)
+	resp.AssertStatus(200)
+
+	// Should have a new proration invoice.
+	newInvoice := resp.JSONMap()["latest_invoice"].(string)
+	if newInvoice == firstInvoice {
+		t.Fatal("expected a new proration invoice after upgrade")
+	}
+
+	// Verify proration invoice exists and has correct structure.
+	resp = stripeGet(tc, "/v1/invoices/"+newInvoice)
+	resp.AssertStatus(200)
+	inv := resp.JSONMap()
+
+	if inv["description"] != "Proration" {
+		t.Errorf("expected description=Proration, got %v", inv["description"])
+	}
+
+	// Net should be positive (upgrading costs more).
+	total := inv["total"].(float64)
+	if total <= 0 {
+		t.Errorf("expected positive proration total for upgrade, got %v", total)
+	}
+
+	// Check line items: should have credit + charge.
+	lines := inv["lines"].(map[string]any)
+	lineData := lines["data"].([]any)
+	if len(lineData) != 2 {
+		t.Fatalf("expected 2 proration line items (credit + charge), got %d", len(lineData))
+	}
+
+	// One should be negative (credit), one positive (charge).
+	var hasCredit, hasCharge bool
+	for _, l := range lineData {
+		line := l.(map[string]any)
+		amt := line["amount"].(float64)
+		if amt < 0 {
+			hasCredit = true
+		}
+		if amt > 0 {
+			hasCharge = true
+		}
+	}
+	if !hasCredit || !hasCharge {
+		t.Error("expected one negative (credit) and one positive (charge) line item")
+	}
+
+	// Items should be updated.
+	items := resp.JSONMap()
+	_ = items // verified by checking the subscription directly
+	resp = stripeGet(tc, "/v1/subscriptions/"+subID)
+	resp.AssertStatus(200)
+	subItems := resp.JSONMap()["items"].(map[string]any)["data"].([]any)
+	if len(subItems) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(subItems))
+	}
+	price := subItems[0].(map[string]any)["price"].(map[string]any)
+	if price["id"] != expensivePrice {
+		t.Errorf("expected price=%s, got %v", expensivePrice, price["id"])
+	}
+}
+
+func TestProrationOnPriceDowngrade(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	resp := stripePost(tc, "/v1/products?name=DownProd", nil)
+	resp.AssertStatus(200)
+	prodID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=5000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	expensivePrice := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=1000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	cheapPrice := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/customers?name=DownCust", nil)
+	resp.AssertStatus(200)
+	custID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/subscriptions?customer="+custID+"&items[0][price]="+expensivePrice, nil)
+	resp.AssertStatus(200)
+	subID := resp.JSONMap()["id"].(string)
+
+	tc.Post("/admin/time/advance", map[string]any{"duration": "360h"})
+
+	resp = stripePost(tc, "/v1/subscriptions/"+subID+"?items[0][price]="+cheapPrice, nil)
+	resp.AssertStatus(200)
+
+	invID := resp.JSONMap()["latest_invoice"].(string)
+	resp = stripeGet(tc, "/v1/invoices/"+invID)
+	resp.AssertStatus(200)
+
+	// Net should be negative (downgrade = credit exceeds charge).
+	total := resp.JSONMap()["total"].(float64)
+	if total >= 0 {
+		t.Errorf("expected negative proration total for downgrade, got %v", total)
+	}
+}
+
+func TestProrationBehaviorNone(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	resp := stripePost(tc, "/v1/products?name=NoPro", nil)
+	resp.AssertStatus(200)
+	prodID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=1000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	price1 := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=2000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	price2 := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/customers?name=NoPro", nil)
+	resp.AssertStatus(200)
+	custID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/subscriptions?customer="+custID+"&items[0][price]="+price1, nil)
+	resp.AssertStatus(200)
+	subID := resp.JSONMap()["id"].(string)
+	firstInvoice := resp.JSONMap()["latest_invoice"].(string)
+
+	tc.Post("/admin/time/advance", map[string]any{"duration": "360h"})
+
+	// Update with proration_behavior=none — no invoice should be created.
+	resp = stripePost(tc, "/v1/subscriptions/"+subID+"?items[0][price]="+price2+"&proration_behavior=none", nil)
+	resp.AssertStatus(200)
+
+	// latest_invoice should be unchanged.
+	if resp.JSONMap()["latest_invoice"] != firstInvoice {
+		t.Errorf("expected latest_invoice unchanged with proration_behavior=none, got %v", resp.JSONMap()["latest_invoice"])
+	}
+
+	// Items should still be updated.
+	subItems := resp.JSONMap()["items"].(map[string]any)["data"].([]any)
+	price := subItems[0].(map[string]any)["price"].(map[string]any)
+	if price["id"] != price2 {
+		t.Errorf("expected price=%s, got %v", price2, price["id"])
+	}
+}
+
+func TestQuantityChangeProration(t *testing.T) {
+	_, tc := setupStripe(t)
+
+	resp := stripePost(tc, "/v1/products?name=QtyProd", nil)
+	resp.AssertStatus(200)
+	prodID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/prices?unit_amount=2000&currency=usd&product="+prodID+"&recurring[interval]=month", nil)
+	resp.AssertStatus(200)
+	priceID := resp.JSONMap()["id"].(string)
+
+	resp = stripePost(tc, "/v1/customers?name=QtyCust", nil)
+	resp.AssertStatus(200)
+	custID := resp.JSONMap()["id"].(string)
+
+	// Start with quantity=1.
+	resp = stripePost(tc, "/v1/subscriptions?customer="+custID+"&items[0][price]="+priceID+"&items[0][quantity]=1", nil)
+	resp.AssertStatus(200)
+	subID := resp.JSONMap()["id"].(string)
+	firstInvoice := resp.JSONMap()["latest_invoice"].(string)
+
+	tc.Post("/admin/time/advance", map[string]any{"duration": "360h"})
+
+	// Increase to quantity=3.
+	resp = stripePost(tc, "/v1/subscriptions/"+subID+"?items[0][price]="+priceID+"&items[0][quantity]=3", nil)
+	resp.AssertStatus(200)
+
+	newInvoice := resp.JSONMap()["latest_invoice"].(string)
+	if newInvoice == firstInvoice {
+		t.Fatal("expected a new proration invoice after quantity increase")
+	}
+
+	resp = stripeGet(tc, "/v1/invoices/"+newInvoice)
+	resp.AssertStatus(200)
+	// Net should be positive (more seats).
+	if resp.JSONMap()["total"].(float64) <= 0 {
+		t.Errorf("expected positive total for quantity increase, got %v", resp.JSONMap()["total"])
+	}
+}

--- a/twin-stripe/internal/api/handlers_subscriptions.go
+++ b/twin-stripe/internal/api/handlers_subscriptions.go
@@ -184,6 +184,143 @@ func (h *Handler) UpdateSubscription(w http.ResponseWriter, r *http.Request) {
 		sub.Metadata = meta
 	}
 
+	// Handle item changes (price/quantity updates) with proration.
+	prorationBehavior := r.FormValue("proration_behavior")
+	if prorationBehavior == "" {
+		prorationBehavior = "create_prorations" // Stripe default
+	}
+
+	var newItems []store.SubscriptionItem
+	hasItemChanges := false
+	for i := 0; i < 10; i++ {
+		priceID := r.FormValue("items[" + strconv.Itoa(i) + "][price]")
+		if priceID == "" {
+			break
+		}
+		hasItemChanges = true
+		price, ok := h.store.Prices.Get(priceID)
+		if !ok {
+			twincore.StripeError(w, http.StatusBadRequest, "invalid_request_error", "resource_missing", "No such price: "+priceID)
+			return
+		}
+		qty := int64(1)
+		if v := r.FormValue("items[" + strconv.Itoa(i) + "][quantity]"); v != "" {
+			if q, err := strconv.ParseInt(v, 10, 64); err == nil {
+				qty = q
+			}
+		}
+		siID := id + "_si_" + strconv.Itoa(i)
+		newItems = append(newItems, store.SubscriptionItem{
+			ID:       siID,
+			Object:   "subscription_item",
+			Price:    price,
+			Quantity: qty,
+			Created:  store.Now(),
+		})
+	}
+
+	if hasItemChanges && sub.Items != nil && prorationBehavior == "create_prorations" {
+		now := h.store.Clock.Now().Unix()
+		periodTotal := sub.CurrentPeriodEnd - sub.CurrentPeriodStart
+		if periodTotal <= 0 {
+			periodTotal = 1
+		}
+		remaining := sub.CurrentPeriodEnd - now
+		if remaining < 0 {
+			remaining = 0
+		}
+		fraction := float64(remaining) / float64(periodTotal)
+
+		// Credit for unused time on old items.
+		var oldTotal int64
+		for _, item := range sub.Items.Data {
+			oldTotal += item.Price.UnitAmount * item.Quantity
+		}
+		credit := int64(float64(oldTotal) * fraction)
+
+		// Charge for remaining time on new items.
+		var newTotal int64
+		for _, item := range newItems {
+			newTotal += item.Price.UnitAmount * item.Quantity
+		}
+		charge := int64(float64(newTotal) * fraction)
+
+		prorationAmount := charge - credit
+
+		// Generate a proration invoice if there's a net difference.
+		if prorationAmount != 0 {
+			invID := h.store.Invoices.NextID()
+			currency := "usd"
+			if len(newItems) > 0 {
+				currency = newItems[0].Price.Currency
+			}
+
+			var lines []store.InvoiceLine
+			if credit > 0 {
+				lines = append(lines, store.InvoiceLine{
+					ID:          invID + "_il_credit",
+					Object:      "line_item",
+					Amount:      -credit,
+					Currency:    currency,
+					Description: "Unused time on previous plan",
+					Type:        "invoiceitem",
+				})
+			}
+			if charge > 0 {
+				lines = append(lines, store.InvoiceLine{
+					ID:          invID + "_il_charge",
+					Object:      "line_item",
+					Amount:      charge,
+					Currency:    currency,
+					Description: "Remaining time on new plan",
+					Type:        "invoiceitem",
+				})
+			}
+
+			inv := store.Invoice{
+				ID:               invID,
+				Object:           "invoice",
+				Customer:         sub.Customer,
+				Subscription:     sub.ID,
+				Status:           "paid",
+				Total:            prorationAmount,
+				Subtotal:         prorationAmount,
+				AmountDue:        prorationAmount,
+				AmountPaid:       prorationAmount,
+				Currency:         currency,
+				CollectionMethod: sub.CollectionMethod,
+				Paid:             true,
+				Lines:            &store.InvoiceLines{Object: "list", Data: lines, URL: "/v1/invoices/" + invID + "/lines"},
+				Number:           "INV-" + invID,
+				Description:      "Proration",
+				Livemode:         false,
+				Created:          store.Now(),
+			}
+			h.store.Invoices.Set(invID, inv)
+			sub.LatestInvoice = invID
+			h.emitEvent("invoice.created", mapFromJSON(inv))
+			if inv.Paid {
+				h.emitEvent("invoice.paid", mapFromJSON(inv))
+			}
+		}
+
+		// Update subscription items.
+		sub.Items = &store.SubscriptionItems{
+			Object:  "list",
+			Data:    newItems,
+			HasMore: false,
+			URL:     "/v1/subscription_items?subscription=" + id,
+		}
+	} else if hasItemChanges {
+		// proration_behavior=none: just swap items, no invoice.
+		sub.Items = &store.SubscriptionItems{
+			Object:  "list",
+			Data:    newItems,
+			HasMore: false,
+			URL:     "/v1/subscription_items?subscription=" + id,
+		}
+	}
+
 	h.store.Subscriptions.Set(id, sub)
 	h.emitEvent("customer.subscription.updated", mapFromJSON(sub))
 	twincore.JSON(w, http.StatusOK, sub)


### PR DESCRIPTION
## Summary
- `UpdateSubscription` now accepts `items[N][price]` and `items[N][quantity]` to change subscription items mid-cycle
- Default `proration_behavior=create_prorations`: generates a proration invoice with credit for unused time on old plan and charge for remaining time on new plan
- Supports `proration_behavior=none` to swap items without proration
- Proration invoice has two line items: negative credit + positive charge

Backlog item 4.

## Test plan
- [x] `go build ./twin-stripe/...`
- [x] `go test ./twin-stripe/...` — 4 new tests (upgrade, downgrade, none, quantity) + all existing pass
- [x] `go run ./cmd/validate-schemas/`