### PR TITLE
feat(telemetry): Phase 2A enrichment for active inference

### DIFF
--- a/cmd/wt-collector/internal/store/schema.go
+++ b/cmd/wt-collector/internal/store/schema.go
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE INDEX IF NOT EXISTS idx_events_twin ON events(twin, twin_version);
 CREATE INDEX IF NOT EXISTS idx_events_org ON events(org_id);
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type, received_at);
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events(org_id, twin, received_at);
 `
 
 // Open opens (or creates) the collector database and runs migrations.

--- a/twinkit/telemetry/emitter.go
+++ b/twinkit/telemetry/emitter.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -42,6 +43,8 @@ type Emitter struct {
 	orgID         string
 	twinName      string
 	twinVersion   string
+	instanceID    string
+	seq           atomic.Int64
 	batch         []Event
 	client        *http.Client
 	stopCh        chan struct{}
@@ -98,6 +101,7 @@ func NewEmitter(cfg Config) *Emitter {
 		orgID:         cfg.OrgID,
 		twinName:      cfg.TwinName,
 		twinVersion:   cfg.TwinVersion,
+		instanceID:    generateInstanceID(),
 		batch:         make([]Event, 0, batchSize),
 		client:        &http.Client{Timeout: 10 * time.Second},
 		flushInterval: flushInterval,
@@ -144,6 +148,8 @@ func (e *Emitter) Emit(ev Event) {
 	ev.Twin = e.twinName
 	ev.TwinVersion = e.twinVersion
 	ev.OrgID = e.orgID
+	ev.InstanceID = e.instanceID
+	ev.Seq = e.seq.Add(1)
 	if ev.Timestamp == 0 {
 		ev.Timestamp = time.Now().Unix()
 	}
@@ -166,16 +172,22 @@ func (e *Emitter) EmitHTTP(method, path string, status int, durationMS int64, re
 	if !e.enabled {
 		return
 	}
+	reqStats := ExtractBodyShapeWithStats(reqBody)
+	respStats := ExtractBodyShapeWithStats(respBody)
 	e.Emit(Event{
 		EventType: EventHTTPObservation,
 		Timestamp: time.Now().Unix(),
 		Payload: HTTPObservation{
-			Method:            method,
-			PathTemplate:      TemplatePath(path),
-			Status:            status,
-			DurationMS:        durationMS,
-			RequestBodyShape:  ExtractBodyShape(reqBody),
-			ResponseBodyShape: ExtractBodyShape(respBody),
+			Method:             method,
+			PathTemplate:       TemplatePath(path),
+			Status:             status,
+			DurationMS:         durationMS,
+			RequestBodyShape:   reqStats.Shape,
+			ResponseBodyShape:  respStats.Shape,
+			RequestBodyDepth:   reqStats.Depth,
+			ResponseBodyDepth:  respStats.Depth,
+			RequestFieldCount:  reqStats.FieldCount,
+			ResponseFieldCount: respStats.FieldCount,
 		},
 	})
 }
@@ -185,17 +197,23 @@ func (e *Emitter) EmitHTTPWithContext(correlationID, method, path string, status
 	if !e.enabled {
 		return
 	}
+	reqStats := ExtractBodyShapeWithStats(reqBody)
+	respStats := ExtractBodyShapeWithStats(respBody)
 	e.Emit(Event{
 		EventType:     EventHTTPObservation,
 		Timestamp:     time.Now().Unix(),
 		CorrelationID: correlationID,
 		Payload: HTTPObservation{
-			Method:            method,
-			PathTemplate:      TemplatePath(path),
-			Status:            status,
-			DurationMS:        durationMS,
-			RequestBodyShape:  ExtractBodyShape(reqBody),
-			ResponseBodyShape: ExtractBodyShape(respBody),
+			Method:             method,
+			PathTemplate:       TemplatePath(path),
+			Status:             status,
+			DurationMS:         durationMS,
+			RequestBodyShape:   reqStats.Shape,
+			ResponseBodyShape:  respStats.Shape,
+			RequestBodyDepth:   reqStats.Depth,
+			ResponseBodyDepth:  respStats.Depth,
+			RequestFieldCount:  reqStats.FieldCount,
+			ResponseFieldCount: respStats.FieldCount,
 		},
 	})
 }
@@ -271,6 +289,11 @@ func (e *Emitter) BatchLen() int {
 // DeliveryConfig returns the current delivery mode (for testing/diagnostics).
 func (e *Emitter) DeliveryConfig() DeliveryMode {
 	return e.delivery
+}
+
+// InstanceID returns the emitter's unique instance identifier.
+func (e *Emitter) InstanceID() string {
+	return e.instanceID
 }
 
 func (e *Emitter) flushLoop() {
@@ -434,4 +457,13 @@ func generateShortID() string {
 	b := make([]byte, 4)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// generateInstanceID produces a unique ID for this emitter lifecycle.
+func generateInstanceID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("inst_%d", time.Now().UnixNano())
+	}
+	return "inst_" + hex.EncodeToString(b)
 }

--- a/twinkit/telemetry/events.go
+++ b/twinkit/telemetry/events.go
@@ -21,19 +21,25 @@ type Event struct {
 	OrgID         string    `json:"org_id"`
 	Timestamp     int64     `json:"timestamp"`
 	CorrelationID string    `json:"correlation_id,omitempty"`
+	InstanceID    string    `json:"instance_id,omitempty"`
+	Seq           int64     `json:"seq,omitempty"`
 	Payload       any       `json:"payload"`
 }
 
 // HTTPObservation captures the shape of an HTTP request/response pair.
 type HTTPObservation struct {
-	Method            string            `json:"method"`
-	PathTemplate      string            `json:"path_template"`
-	Status            int               `json:"status"`
-	DurationMS        int64             `json:"duration_ms"`
-	RequestBodyShape  map[string]string `json:"request_body_shape,omitempty"`
-	ResponseBodyShape map[string]string `json:"response_body_shape,omitempty"`
-	ErrorCode         string            `json:"error_code,omitempty"`
-	Resource          string            `json:"resource,omitempty"`
+	Method             string         `json:"method"`
+	PathTemplate       string         `json:"path_template"`
+	Status             int            `json:"status"`
+	DurationMS         int64          `json:"duration_ms"`
+	RequestBodyShape   map[string]any `json:"request_body_shape,omitempty"`
+	ResponseBodyShape  map[string]any `json:"response_body_shape,omitempty"`
+	RequestBodyDepth   int            `json:"request_body_depth,omitempty"`
+	ResponseBodyDepth  int            `json:"response_body_depth,omitempty"`
+	RequestFieldCount  int            `json:"request_field_count,omitempty"`
+	ResponseFieldCount int            `json:"response_field_count,omitempty"`
+	ErrorCode          string         `json:"error_code,omitempty"`
+	Resource           string         `json:"resource,omitempty"`
 }
 
 // DomainEvent captures a behavioral inflection point in a domain engine.

--- a/twinkit/telemetry/sanitizer.go
+++ b/twinkit/telemetry/sanitizer.go
@@ -29,9 +29,33 @@ func TemplatePath(path string) string {
 	return strings.Join(parts, "/")
 }
 
-// ExtractBodyShape extracts the field name -> type shape from a JSON body.
+const maxShapeDepth = 4
+
+// BodyShapeStats holds pre-computed metrics about a body shape.
+type BodyShapeStats struct {
+	Shape      map[string]any
+	Depth      int
+	FieldCount int
+}
+
+// ExtractBodyShapeWithStats extracts the recursive shape and computes depth/field metrics.
+// Returns zero-value stats if body is empty or not valid JSON.
+func ExtractBodyShapeWithStats(body []byte) BodyShapeStats {
+	if len(body) == 0 {
+		return BodyShapeStats{}
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return BodyShapeStats{}
+	}
+	shape := extractShape(raw, 1)
+	depth, count := shapeMetrics(shape)
+	return BodyShapeStats{Shape: shape, Depth: depth, FieldCount: count}
+}
+
+// ExtractBodyShape extracts the recursive field name -> type shape from a JSON body.
 // Returns nil if body is empty or not valid JSON.
-func ExtractBodyShape(body []byte) map[string]string {
+func ExtractBodyShape(body []byte) map[string]any {
 	if len(body) == 0 {
 		return nil
 	}
@@ -39,22 +63,22 @@ func ExtractBodyShape(body []byte) map[string]string {
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil
 	}
-	return extractShape(raw)
+	return extractShape(raw, 1)
 }
 
-func extractShape(m map[string]any) map[string]string {
-	shape := make(map[string]string, len(m))
+func extractShape(m map[string]any, depth int) map[string]any {
+	shape := make(map[string]any, len(m))
 	for k, v := range m {
-		shape[k] = typeOf(v)
+		shape[k] = shapeOf(v, depth)
 	}
 	return shape
 }
 
-func typeOf(v any) string {
+func shapeOf(v any, depth int) any {
 	if v == nil {
 		return "null"
 	}
-	switch v.(type) {
+	switch val := v.(type) {
 	case bool:
 		return "boolean"
 	case float64:
@@ -62,10 +86,45 @@ func typeOf(v any) string {
 	case string:
 		return "string"
 	case []any:
-		return "array"
+		if depth >= maxShapeDepth || len(val) == 0 {
+			return "array"
+		}
+		elemShape := shapeOf(val[0], depth+1)
+		if nested, ok := elemShape.(map[string]any); ok {
+			return map[string]any{"_type": "array", "_element": "object", "_shape": nested}
+		}
+		return map[string]any{"_type": "array", "_element": elemShape}
 	case map[string]any:
-		return "object"
+		if depth >= maxShapeDepth {
+			return "object"
+		}
+		return map[string]any{"_type": "object", "_shape": extractShape(val, depth+1)}
 	default:
 		return fmt.Sprintf("%T", v)
 	}
+}
+
+// shapeMetrics computes max depth and total field count from a shape map.
+func shapeMetrics(shape map[string]any) (depth, count int) {
+	if shape == nil {
+		return 0, 0
+	}
+	maxD := 1
+	total := 0
+	for _, v := range shape {
+		total++
+		switch val := v.(type) {
+		case map[string]any:
+			if nested, ok := val["_shape"]; ok {
+				if nestedMap, ok := nested.(map[string]any); ok {
+					d, c := shapeMetrics(nestedMap)
+					total += c
+					if d+1 > maxD {
+						maxD = d + 1
+					}
+				}
+			}
+		}
+	}
+	return maxD, total
 }

--- a/twinkit/telemetry/smoke_test.go
+++ b/twinkit/telemetry/smoke_test.go
@@ -135,6 +135,12 @@ func TestSmoke_FullPipeline(t *testing.T) {
 	if httpObs.EventID == "" {
 		t.Error("HTTP observation should have an event ID for deduplication")
 	}
+	if httpObs.InstanceID == "" {
+		t.Error("HTTP observation should have an instance ID")
+	}
+	if httpObs.Seq < 1 {
+		t.Errorf("HTTP observation seq = %d, want >= 1", httpObs.Seq)
+	}
 
 	// Verify the HTTP observation payload.
 	payloadBytes, _ := json.Marshal(httpObs.Payload)
@@ -153,10 +159,16 @@ func TestSmoke_FullPipeline(t *testing.T) {
 		t.Error("request body shape should not be nil")
 	}
 	if obs.RequestBodyShape["email"] != "string" {
-		t.Errorf("request body shape email = %q, want string", obs.RequestBodyShape["email"])
+		t.Errorf("request body shape email = %v, want string", obs.RequestBodyShape["email"])
 	}
 	if obs.ResponseBodyShape == nil {
 		t.Error("response body shape should not be nil")
+	}
+	if obs.RequestFieldCount < 1 {
+		t.Errorf("request field count = %d, want >= 1", obs.RequestFieldCount)
+	}
+	if obs.ResponseFieldCount < 1 {
+		t.Errorf("response field count = %d, want >= 1", obs.ResponseFieldCount)
 	}
 
 	// Verify domain event.
@@ -168,6 +180,15 @@ func TestSmoke_FullPipeline(t *testing.T) {
 	}
 	if domainEvt.EventID == "" {
 		t.Error("domain event should have an event ID")
+	}
+	if domainEvt.InstanceID == "" {
+		t.Error("domain event should have an instance ID")
+	}
+	if domainEvt.InstanceID != httpObs.InstanceID {
+		t.Errorf("instance IDs should match: http=%q domain=%q", httpObs.InstanceID, domainEvt.InstanceID)
+	}
+	if domainEvt.Seq <= httpObs.Seq {
+		t.Errorf("domain event seq (%d) should be after http obs seq (%d)", domainEvt.Seq, httpObs.Seq)
 	}
 
 	// Verify the domain event payload.

--- a/twinkit/telemetry/telemetry_test.go
+++ b/twinkit/telemetry/telemetry_test.go
@@ -34,16 +34,69 @@ func TestExtractBodyShape(t *testing.T) {
 		t.Fatal("expected non-nil shape")
 	}
 	if shape["amount"] != "number" {
-		t.Errorf("amount = %q, want number", shape["amount"])
+		t.Errorf("amount = %v, want number", shape["amount"])
 	}
 	if shape["currency"] != "string" {
-		t.Errorf("currency = %q, want string", shape["currency"])
+		t.Errorf("currency = %v, want string", shape["currency"])
 	}
-	if shape["metadata"] != "object" {
-		t.Errorf("metadata = %q, want object", shape["metadata"])
+
+	// metadata should now be a nested shape, not just "object"
+	meta, ok := shape["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata should be nested shape map, got %T", shape["metadata"])
 	}
-	if shape["items"] != "array" {
-		t.Errorf("items = %q, want array", shape["items"])
+	if meta["_type"] != "object" {
+		t.Errorf("metadata._type = %v, want object", meta["_type"])
+	}
+	nested, ok := meta["_shape"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata._shape should be map, got %T", meta["_shape"])
+	}
+	if nested["key"] != "string" {
+		t.Errorf("metadata._shape.key = %v, want string", nested["key"])
+	}
+
+	// items should be a nested array shape
+	items, ok := shape["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("items should be nested shape map, got %T", shape["items"])
+	}
+	if items["_type"] != "array" {
+		t.Errorf("items._type = %v, want array", items["_type"])
+	}
+	if items["_element"] != "number" {
+		t.Errorf("items._element = %v, want number", items["_element"])
+	}
+}
+
+func TestExtractBodyShapeWithStats(t *testing.T) {
+	body := []byte(`{
+		"amount": 500,
+		"metadata": {"key": "val", "nested": {"deep": 1}},
+		"items": [{"id": "x", "qty": 2}]
+	}`)
+	stats := ExtractBodyShapeWithStats(body)
+	if stats.Shape == nil {
+		t.Fatal("expected non-nil shape")
+	}
+	if stats.Depth < 3 {
+		t.Errorf("depth = %d, want >= 3", stats.Depth)
+	}
+	if stats.FieldCount < 5 {
+		t.Errorf("field_count = %d, want >= 5", stats.FieldCount)
+	}
+}
+
+func TestExtractBodyShape_DepthLimit(t *testing.T) {
+	// 5 levels deep — should collapse at maxShapeDepth (4)
+	body := []byte(`{"a": {"b": {"c": {"d": {"e": "too deep"}}}}}`)
+	shape := ExtractBodyShape(body)
+	// Navigate to depth 3 — d should be collapsed to "object"
+	a := shape["a"].(map[string]any)["_shape"].(map[string]any)
+	b := a["b"].(map[string]any)["_shape"].(map[string]any)
+	c := b["c"].(map[string]any)["_shape"].(map[string]any)
+	if c["d"] != "object" {
+		t.Errorf("at depth 4, d should be collapsed to 'object', got %v (type %T)", c["d"], c["d"])
 	}
 }
 
@@ -104,6 +157,61 @@ func TestEmitter_SetsEnvelope(t *testing.T) {
 	}
 	if ev.EventType != EventDomainEvent {
 		t.Errorf("type = %q, want domain_event", ev.EventType)
+	}
+	if ev.InstanceID == "" {
+		t.Error("event should have an instance ID")
+	}
+	if ev.Seq != 1 {
+		t.Errorf("seq = %d, want 1", ev.Seq)
+	}
+}
+
+func TestEmitter_SequenceIncrement(t *testing.T) {
+	e := NewEmitter(Config{
+		Enabled:      true,
+		CollectorURL: "http://localhost:9999",
+		TwinName:     "test",
+		TwinVersion:  "0.1.0",
+	})
+	e.EmitHTTP("GET", "/a", 200, 1, nil, nil)
+	e.EmitHTTP("GET", "/b", 200, 1, nil, nil)
+	e.EmitHTTP("GET", "/c", 200, 1, nil, nil)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for i, ev := range e.batch {
+		want := int64(i + 1)
+		if ev.Seq != want {
+			t.Errorf("event %d: seq = %d, want %d", i, ev.Seq, want)
+		}
+		if ev.InstanceID == "" {
+			t.Errorf("event %d: missing instance ID", i)
+		}
+	}
+}
+
+func TestEmitter_InstanceIDConsistent(t *testing.T) {
+	e := NewEmitter(Config{
+		Enabled:      true,
+		CollectorURL: "http://localhost:9999",
+		TwinName:     "test",
+		TwinVersion:  "0.1.0",
+	})
+	id := e.InstanceID()
+	if id == "" {
+		t.Fatal("instance ID should not be empty")
+	}
+	e.EmitHTTP("GET", "/a", 200, 1, nil, nil)
+	e.EmitHTTP("GET", "/b", 200, 1, nil, nil)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for i, ev := range e.batch {
+		if ev.InstanceID != id {
+			t.Errorf("event %d: instance ID = %q, want %q", i, ev.InstanceID, id)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Recursive body shape extraction** (depth 4) replaces flat `map[string]string` with nested structure that distinguishes SDK-generated requests from pipeline integrations from manual calls
- **Instance ID + sequence counter** on every event enables the intelligence layer to distinguish CI/prod/dev sessions and reconstruct request sequences
- **Composite collector index** `(org_id, twin, received_at)` supports the per-agent query pattern the intelligence service will use
- **Pre-computed body depth and field count** metrics on HTTPObservation for direct use as Gaussian factor inputs

## Test plan

- [x] All 18 telemetry tests pass (5 new: recursive shapes, depth limit, stats, sequence increment, instance ID consistency)
- [x] Full pipeline smoke test verifies instance ID, seq, and field count metrics propagate end-to-end
- [x] Full repo builds clean (`go build ./...`)
- [ ] Verify collector schema migration applies cleanly on existing databases