### PR TITLE
fix: standardize manifest tier taxonomy to community/commercial

### DIFF
--- a/schemas/twin-manifest.schema.json
+++ b/schemas/twin-manifest.schema.json
@@ -9,9 +9,8 @@
   "properties": {
     "tier": {
       "type": "string",
-      "description": "Distribution tier for the twin.",
-      "enum": ["free", "paid"],
-      "default": "free"
+      "description": "Distribution tier for the twin. Describes provenance and licensing, not pricing. 'community' = MIT licensed, public repo, no account needed. 'commercial' = BSL licensed, pro repo, account required. Pricing (included in Pro, add-on cost, enterprise-only) is a backend concern managed by the catalog service.",
+      "enum": ["community", "commercial"]
     },
     "twin": {
       "type": "string",

--- a/twin-github/twin-manifest.json
+++ b/twin-github/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "github",
   "display_name": "GitHub",
-  "tier": "free",
+  "tier": "community",
   "category": "workspace",
   "description": "Simulates the GitHub REST API: repos, issues, PRs, reviews, checks, labels, milestones, contents, deployments, orgs, teams, reactions, search, webhooks, Actions, and Git data.",
   "sdk_target": {

--- a/twin-hubspot/twin-manifest.json
+++ b/twin-hubspot/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "hubspot",
   "display_name": "HubSpot",
-  "tier": "free",
+  "tier": "community",
   "category": "workspace",
   "description": "Simulates the HubSpot CRM v3 API: generic CRM objects (contacts, companies, deals, tickets, engagements), batch operations, search, associations v4, properties, pipelines, owners, lists, webhooks, forms, and OAuth.",
   "sdk_target": {

--- a/twin-linear/twin-manifest.json
+++ b/twin-linear/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "linear",
   "display_name": "Linear",
-  "tier": "free",
+  "tier": "community",
   "category": "workspace",
   "description": "Simulates the Linear GraphQL API: issues, teams, projects, cycles, workflow states, labels, comments, attachments, relations, documents, project updates, webhooks, reactions, notifications, and favorites.",
   "sdk_target": {

--- a/twin-logodev/twin-manifest.json
+++ b/twin-logodev/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "logodev",
   "display_name": "Logo.dev",
-  "tier": "free",
+  "tier": "community",
   "category": "media",
   "description": "Simulates the full Logo.dev API surface: logo retrieval by domain/name/ticker/crypto/ISIN, brand search, and describe.",
   "sdk_target": {

--- a/twin-posthog/twin-manifest.json
+++ b/twin-posthog/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "posthog",
   "display_name": "PostHog",
-  "tier": "free",
+  "tier": "community",
   "category": "analytics",
   "description": "Simulates the PostHog event capture, feature flag evaluation, identify, alias, group identify, exception tracking, and local evaluation API surfaces for the PostHog Go SDK.",
   "sdk_target": {

--- a/twin-resend/twin-manifest.json
+++ b/twin-resend/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "resend",
   "display_name": "Resend",
-  "tier": "free",
+  "tier": "community",
   "category": "email",
   "description": "Simulates the Resend email sending API, including single and batch email dispatch with delivery tracking.",
   "sdk_target": {

--- a/twin-shopify/twin-manifest.json
+++ b/twin-shopify/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "shopify",
   "display_name": "Shopify",
-  "tier": "free",
+  "tier": "community",
   "category": "workspace",
   "description": "Simulates the Shopify Admin REST API: products, variants, images, orders, transactions, refunds, customers, addresses, inventory, fulfillments, collections, webhooks, metafields, themes, assets, pages, blogs, articles, price rules, discount codes, gift cards, draft orders, script tags, and redirects.",
   "sdk_target": {

--- a/twin-slack/twin-manifest.json
+++ b/twin-slack/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "slack",
   "display_name": "Slack",
-  "tier": "free",
+  "tier": "community",
   "category": "workspace",
   "description": "Simulates the Slack Web API including chat, conversations, users, reactions, pins, files, and more.",
   "sdk_target": {

--- a/twin-stripe/twin-manifest.json
+++ b/twin-stripe/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "stripe",
   "display_name": "Stripe",
-  "tier": "free",
+  "tier": "community",
   "category": "payments",
   "description": "Simulates the Stripe API — Customers, Products, Prices, PaymentIntents, PaymentMethods, Charges, Refunds, Subscriptions, Invoices, Coupons, SetupIntents, TaxRates, Disputes, Connect accounts, transfers, balance, payouts, events, checkout sessions, payment links, credit notes, promotion codes, subscription items, quotes, billing portal sessions, tokens, sources, mandates, confirmation tokens, application fees, application fee refunds, transfer reversals, account links, persons, topups, webhook endpoints, files, file links, shipping rates, reviews, and tax IDs with webhook delivery.",
   "sdk_target": {

--- a/twin-twilio/twin-manifest.json
+++ b/twin-twilio/twin-manifest.json
@@ -1,7 +1,7 @@
 {
   "twin": "twilio",
   "display_name": "Twilio",
-  "tier": "free",
+  "tier": "community",
   "category": "communications",
   "description": "Simulates the Twilio Messaging and Verify API surfaces, including SMS message send/retrieve and phone number verification workflows.",
   "sdk_target": {


### PR DESCRIPTION
## Summary

- Replace the ambiguous `free`/`paid` tier enum in `twin-manifest.schema.json` with `community`/`commercial`
- Update all 10 community twin manifests from `"tier": "free"` to `"tier": "community"`
- Schema validation passes for all 30 files across 10 twins

The tier field describes **provenance and licensing**, not pricing:
- `community` — MIT licensed, public repo, no account required
- `commercial` — BSL licensed, pro repo, account required

Pricing (included in Pro, add-on cost, enterprise-only) is a backend concern managed by the catalog service.

## Test plan

- [ ] `go run ./cmd/validate-schemas/` passes (verified locally)
- [ ] `go test ./... -short` passes (verified locally)
- [ ] Companion PR for wondertwin-pro to update all pro twins to `"tier": "commercial"`