### PR TITLE
feat: Agent Twin Discovery CLI — catalog, scan, login

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -117,6 +117,10 @@ func main() {
 		err = cmdCI(manifestPath)
 	case "login":
 		err = cmdLogin(args)
+	case "catalog":
+		err = cmdCatalog(args)
+	case "scan":
+		err = cmdScan(args)
 	case "auth":
 		err = cmdAuth(args)
 	case "registry":
@@ -1032,6 +1036,158 @@ func cmdLogin(args []string) error {
 
 	fmt.Printf("Authenticated as org %q (ID: %s).\n", result.OrgSlug, result.OrgID[:8]+"...")
 	return nil
+}
+
+func cmdCatalog(args []string) error {
+	// Parse flags.
+	var category, tier, search string
+	var mine bool
+	var twinName string
+
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--category" && i+1 < len(args):
+			category = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--category="):
+			category = strings.TrimPrefix(args[i], "--category=")
+		case args[i] == "--tier" && i+1 < len(args):
+			tier = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--tier="):
+			tier = strings.TrimPrefix(args[i], "--tier=")
+		case args[i] == "--search" && i+1 < len(args):
+			search = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--search="):
+			search = strings.TrimPrefix(args[i], "--search=")
+		case args[i] == "--mine":
+			mine = true
+		case !strings.HasPrefix(args[i], "-"):
+			twinName = args[i]
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := platform.New(platformBaseURL(), "")
+
+	// Detail view: wt catalog <name>
+	if twinName != "" {
+		return catalogDetail(ctx, client, twinName)
+	}
+
+	// --mine: org-scoped catalog.
+	if mine {
+		return catalogMine(ctx, category, search)
+	}
+
+	// Public catalog.
+	twins, err := client.ListTwins(ctx, category, tier, "", search)
+	if err != nil {
+		return fmt.Errorf("fetching catalog: %w", err)
+	}
+
+	if len(twins) == 0 {
+		fmt.Println("No twins found.")
+		return nil
+	}
+
+	printCatalogTable(twins)
+	return nil
+}
+
+func catalogDetail(ctx context.Context, client *platform.Client, name string) error {
+	twins, err := client.ListTwins(ctx, "", "", "", name)
+	if err != nil {
+		return fmt.Errorf("fetching twin detail: %w", err)
+	}
+
+	// Filter to exact match.
+	var matches []platform.CatalogEntry
+	for _, t := range twins {
+		if t.Name == name {
+			matches = append(matches, t)
+		}
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("twin %q not found", name)
+	}
+
+	for i, t := range matches {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("Name:       %s\n", t.DisplayName)
+		fmt.Printf("Tier:       %s\n", t.Tier)
+		fmt.Printf("Category:   %s\n", t.Category)
+		fmt.Printf("Status:     %s\n", t.Status)
+		fmt.Printf("Coverage:   %d%%\n", t.Coverage.EstimatedPct)
+		fmt.Printf("Resources:  %d\n", t.Coverage.ResourceCount)
+		fmt.Printf("Auth:       %s\n", t.Coverage.AuthPattern)
+		fmt.Printf("Webhooks:   %v\n", t.Coverage.WebhookSupport)
+		if t.SDKTargets.Primary.Package != "" {
+			fmt.Printf("SDK:        %s (%s)\n", t.SDKTargets.Primary.Package, t.SDKTargets.Primary.Language)
+		}
+		if t.Description != "" {
+			fmt.Printf("Desc:       %s\n", t.Description)
+		}
+	}
+	return nil
+}
+
+func catalogMine(ctx context.Context, category, search string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if !cfg.HasOrgContext() {
+		fmt.Println("Not logged in. Run `wt login --org <slug>` or sign up at https://app.wondertwin.ai/signup")
+		return nil
+	}
+
+	client := platform.New(platformBaseURL(), cfg.APIKey)
+	twins, err := client.ListOrgCatalog(ctx, cfg.OrgID, category, search)
+	if err != nil {
+		return fmt.Errorf("fetching org catalog: %w", err)
+	}
+
+	if len(twins) == 0 {
+		fmt.Println("No twins found.")
+		return nil
+	}
+
+	printOrgCatalogTable(twins)
+	return nil
+}
+
+func printCatalogTable(twins []platform.CatalogEntry) {
+	fmt.Printf("%-20s %-16s %-12s %-8s\n", "NAME", "CATEGORY", "TIER", "STATUS")
+	for _, t := range twins {
+		cat := t.Category
+		if cat == "" {
+			cat = "—"
+		}
+		fmt.Printf("%-20s %-16s %-12s %-8s\n", t.Name, cat, t.Tier, t.Status)
+	}
+}
+
+func printOrgCatalogTable(twins []platform.OrgCatalogEntry) {
+	fmt.Printf("%-20s %-16s %-12s %-12s %-16s\n", "NAME", "CATEGORY", "TIER", "STATE", "ACTION")
+	for _, t := range twins {
+		cat := t.Category
+		if cat == "" {
+			cat = "—"
+		}
+		fmt.Printf("%-20s %-16s %-12s %-12s %-16s\n", t.Name, cat, t.Tier, t.EntitlementState, t.AvailableAction)
+	}
+}
+
+func cmdScan(args []string) error {
+	// Placeholder — implemented in issue #207.
+	return fmt.Errorf("wt scan: not yet implemented")
 }
 
 func cmdAuth(args []string) error {

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -1186,8 +1186,179 @@ func printOrgCatalogTable(twins []platform.OrgCatalogEntry) {
 }
 
 func cmdScan(args []string) error {
-	// Placeholder — implemented in issue #207.
-	return fmt.Errorf("wt scan: not yet implemented")
+	var projectPath string
+	var recommend bool
+
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--path" && i+1 < len(args):
+			projectPath = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--path="):
+			projectPath = strings.TrimPrefix(args[i], "--path=")
+		case args[i] == "--recommend":
+			recommend = true
+		}
+	}
+
+	if projectPath == "" {
+		projectPath = "."
+	}
+
+	if recommend {
+		fmt.Println("Recommendations coming soon (Phase 2).")
+	}
+
+	// Detect SDKs from project files.
+	detected := detectSDKs(projectPath)
+	if len(detected) == 0 {
+		fmt.Println("No SDK dependencies detected.")
+		return nil
+	}
+
+	// Fetch catalog to match against.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := platform.New(platformBaseURL(), "")
+	catalog, err := client.ListTwins(ctx, "", "", "", "")
+	if err != nil {
+		return fmt.Errorf("fetching catalog: %w", err)
+	}
+
+	// Build SDK → twin lookup from catalog.
+	type twinMatch struct {
+		Name string
+		Tier string
+	}
+	sdkIndex := make(map[string]twinMatch)
+	for _, entry := range catalog {
+		if pkg := entry.SDKTargets.Primary.Package; pkg != "" {
+			sdkIndex[pkg] = twinMatch{Name: entry.Name, Tier: entry.Tier}
+		}
+		for _, a := range entry.SDKTargets.Additional {
+			if a.Package != "" {
+				sdkIndex[a.Package] = twinMatch{Name: entry.Name, Tier: entry.Tier}
+			}
+		}
+	}
+
+	// Match detected SDKs against catalog.
+	fmt.Printf("%-45s %-14s %-12s %-16s\n", "DETECTED SDK", "TWIN", "TIER", "ACTION")
+	for _, sdk := range detected {
+		match, found := sdkIndex[sdk.Package]
+		if !found {
+			// Check for prefix match (Go module versioning: github.com/stripe/stripe-go/v81).
+			for catalogPkg, m := range sdkIndex {
+				if strings.HasPrefix(sdk.Package, catalogPkg) || strings.HasPrefix(catalogPkg, sdk.Package) {
+					match = m
+					found = true
+					break
+				}
+			}
+		}
+
+		label := sdk.Package
+		if sdk.Version != "" {
+			label += " " + sdk.Version
+		}
+
+		if found {
+			action := "subscribe"
+			if match.Tier == "community" {
+				action = "install"
+			}
+			fmt.Printf("%-45s %-14s %-12s %-16s\n", label, match.Name, match.Tier, action)
+		} else {
+			fmt.Printf("%-45s %-14s %-12s %-16s\n", label, "—", "—", "no twin available")
+		}
+	}
+
+	return nil
+}
+
+type detectedSDK struct {
+	Package  string
+	Version  string
+	Language string
+}
+
+func detectSDKs(projectPath string) []detectedSDK {
+	var results []detectedSDK
+	results = append(results, detectGoSDKs(projectPath)...)
+	results = append(results, detectNodeSDKs(projectPath)...)
+	return results
+}
+
+func detectGoSDKs(projectPath string) []detectedSDK {
+	goModPath := filepath.Join(projectPath, "go.mod")
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return nil
+	}
+
+	var results []detectedSDK
+	inRequire := false
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "require (" {
+			inRequire = true
+			continue
+		}
+		if line == ")" {
+			inRequire = false
+			continue
+		}
+		if !inRequire {
+			continue
+		}
+		// Skip indirect deps.
+		if strings.Contains(line, "// indirect") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			results = append(results, detectedSDK{
+				Package:  parts[0],
+				Version:  parts[1],
+				Language: "go",
+			})
+		}
+	}
+	return results
+}
+
+func detectNodeSDKs(projectPath string) []detectedSDK {
+	pkgPath := filepath.Join(projectPath, "package.json")
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return nil
+	}
+
+	var pkg struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+
+	var results []detectedSDK
+	for name, version := range pkg.Dependencies {
+		results = append(results, detectedSDK{
+			Package:  name,
+			Version:  version,
+			Language: "typescript",
+		})
+	}
+	for name, version := range pkg.DevDependencies {
+		results = append(results, detectedSDK{
+			Package:  name,
+			Version:  version,
+			Language: "typescript",
+		})
+	}
+	return results
 }
 
 func cmdAuth(args []string) error {

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -36,6 +36,8 @@ import (
 	"syscall"
 	"time"
 
+	"context"
+
 	"github.com/wondertwin-ai/wondertwin/internal/auth"
 	"github.com/wondertwin-ai/wondertwin/internal/cache"
 	"github.com/wondertwin-ai/wondertwin/internal/client"
@@ -45,6 +47,7 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/lockfile"
 	"github.com/wondertwin-ai/wondertwin/internal/manifest"
 	"github.com/wondertwin-ai/wondertwin/internal/mcp"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
 	"github.com/wondertwin-ai/wondertwin/internal/procmgr"
 	"github.com/wondertwin-ai/wondertwin/internal/registry"
 	"github.com/wondertwin-ai/wondertwin/internal/scenario/v2"
@@ -112,6 +115,8 @@ func main() {
 		err = cmdInstall(manifestPath, args)
 	case "ci":
 		err = cmdCI(manifestPath)
+	case "login":
+		err = cmdLogin(args)
 	case "auth":
 		err = cmdAuth(args)
 	case "registry":
@@ -963,6 +968,72 @@ func cmdRegistryList() error {
 // wt auth login|status|logout
 // ---------------------------------------------------------------------------
 
+// platformBaseURL returns the wondertwin-app API URL, using the WT_PLATFORM_URL
+// env var if set, otherwise the default.
+func platformBaseURL() string {
+	if u := os.Getenv("WT_PLATFORM_URL"); u != "" {
+		return u
+	}
+	return platform.DefaultBaseURL
+}
+
+func cmdLogin(args []string) error {
+	// Parse --org flag.
+	var orgSlug string
+	for i, a := range args {
+		if a == "--org" && i+1 < len(args) {
+			orgSlug = args[i+1]
+			break
+		}
+		if strings.HasPrefix(a, "--org=") {
+			orgSlug = strings.TrimPrefix(a, "--org=")
+			break
+		}
+	}
+
+	if orgSlug == "" {
+		return fmt.Errorf("usage: wt login --org <org-slug>")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Logging into org %q.\n", orgSlug)
+	fmt.Print("Enter API key: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return fmt.Errorf("no input received")
+	}
+
+	apiKey := strings.TrimSpace(scanner.Text())
+	if apiKey == "" {
+		return fmt.Errorf("no API key provided")
+	}
+
+	// Validate the key against the platform.
+	client := platform.New(platformBaseURL(), "")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := client.ValidateKey(ctx, apiKey)
+	if err != nil {
+		return fmt.Errorf("API key validation failed: %w", err)
+	}
+
+	cfg.OrgSlug = result.OrgSlug
+	cfg.OrgID = result.OrgID
+	cfg.APIKey = apiKey
+
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	fmt.Printf("Authenticated as org %q (ID: %s).\n", result.OrgSlug, result.OrgID[:8]+"...")
+	return nil
+}
+
 func cmdAuth(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("usage: wt auth <login|status|logout>")
@@ -1023,8 +1094,18 @@ func cmdAuthStatus() error {
 		return err
 	}
 
+	// Show org context if present.
+	if cfg.HasOrgContext() {
+		fmt.Printf("Org:     %s\n", cfg.OrgSlug)
+		fmt.Printf("Org ID:  %s\n", cfg.OrgID)
+		maskedKey := cfg.APIKey[:8] + "..." + cfg.APIKey[len(cfg.APIKey)-4:]
+		fmt.Printf("API Key: %s\n", maskedKey)
+		return nil
+	}
+
+	// Fall back to legacy license key display.
 	if cfg.LicenseKey == "" {
-		fmt.Println("Tier: free (no license key)")
+		fmt.Println("Not authenticated. Run `wt login --org <slug>` to connect.")
 		return nil
 	}
 
@@ -1050,17 +1131,22 @@ func cmdAuthLogout() error {
 		return err
 	}
 
-	if cfg.LicenseKey == "" {
-		fmt.Println("No license key configured.")
+	hadOrg := cfg.HasOrgContext()
+	hadLicense := cfg.LicenseKey != ""
+
+	if !hadOrg && !hadLicense {
+		fmt.Println("Not authenticated.")
 		return nil
 	}
 
+	cfg.ClearOrgContext()
 	cfg.LicenseKey = ""
+
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
-	fmt.Println("License key removed.")
+	fmt.Println("Logged out.")
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,11 @@ type RegistryEntry struct {
 type Config struct {
 	LicenseKey string                   `yaml:"license_key" json:"license_key"`
 	Registries map[string]RegistryEntry `yaml:"registries" json:"registries"`
+
+	// Org context for authenticated API access.
+	OrgSlug string `yaml:"org_slug,omitempty" json:"org_slug,omitempty"`
+	OrgID   string `yaml:"org_id,omitempty" json:"org_id,omitempty"`
+	APIKey  string `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 }
 
 // LicenseInfo holds parsed fields from a license key.
@@ -195,6 +200,18 @@ func ParseLicenseKey(key string) *LicenseInfo {
 // HasValidLicense returns true if the config has a parseable license key.
 func (c *Config) HasValidLicense() bool {
 	return ParseLicenseKey(c.LicenseKey) != nil
+}
+
+// HasOrgContext returns true if the config has stored org credentials.
+func (c *Config) HasOrgContext() bool {
+	return c.APIKey != "" && c.OrgID != ""
+}
+
+// ClearOrgContext removes all org-scoped credentials.
+func (c *Config) ClearOrgContext() {
+	c.OrgSlug = ""
+	c.OrgID = ""
+	c.APIKey = ""
 }
 
 // TierName returns a human-readable tier name from a license key tier code.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,56 @@ func TestSaveWritesJSON(t *testing.T) {
 	_ = data // used above
 }
 
+func TestOrgContext(t *testing.T) {
+	cfg := &Config{}
+	if cfg.HasOrgContext() {
+		t.Error("empty config should not have org context")
+	}
+
+	cfg.OrgSlug = "acme"
+	cfg.OrgID = "org-123"
+	cfg.APIKey = "wt_live_abc123"
+	if !cfg.HasOrgContext() {
+		t.Error("expected org context after setting fields")
+	}
+
+	cfg.ClearOrgContext()
+	if cfg.HasOrgContext() {
+		t.Error("expected no org context after clear")
+	}
+	if cfg.OrgSlug != "" || cfg.OrgID != "" || cfg.APIKey != "" {
+		t.Error("expected all org fields cleared")
+	}
+}
+
+func TestOrgContextRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "license_key": "",
+  "org_slug": "acme",
+  "org_id": "org-123",
+  "api_key": "wt_live_abc123"
+}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path, true)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.OrgSlug != "acme" {
+		t.Errorf("org_slug: got %q, want acme", cfg.OrgSlug)
+	}
+	if cfg.OrgID != "org-123" {
+		t.Errorf("org_id: got %q, want org-123", cfg.OrgID)
+	}
+	if cfg.APIKey != "wt_live_abc123" {
+		t.Errorf("api_key: got %q, want wt_live_abc123", cfg.APIKey)
+	}
+}
+
 func TestParseLicenseKey(t *testing.T) {
 	// Compute a valid checksum for the key "wt_com_acme_abcdef"
 	// payload bytes sum = 1842, 1842 % 256 = 50 = 0x32

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -52,7 +52,7 @@ func (c *Client) ValidateKey(ctx context.Context, apiKey string) (*ValidateKeyRe
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", apiKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -188,7 +188,7 @@ func (c *Client) ListOrgCatalog(ctx context.Context, orgID, category, search str
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Authorization", c.apiKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -1,0 +1,238 @@
+// Package platform provides an HTTP client for the wondertwin-app API.
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the production wondertwin-app API.
+	DefaultBaseURL = "https://api.wondertwin.ai"
+
+	requestTimeout = 10 * time.Second
+)
+
+// Client communicates with the wondertwin-app platform API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// New creates a platform client. If baseURL is empty, DefaultBaseURL is used.
+func New(baseURL, apiKey string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+}
+
+// ValidateKeyResponse is the result of validating an API key.
+type ValidateKeyResponse struct {
+	OrgID   string `json:"org_id"`
+	OrgSlug string `json:"org_slug"`
+	KeyID   string `json:"key_id"`
+}
+
+// ValidateKey checks an API key against the platform and returns org context.
+func (c *Client) ValidateKey(ctx context.Context, apiKey string) (*ValidateKeyResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/v1/auth/validate", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("validate key: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("invalid API key")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("validate key: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result ValidateKeyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
+}
+
+// CatalogEntry matches the TwinCatalogEntry from the catalog API.
+type CatalogEntry struct {
+	Name        string     `json:"name"`
+	DisplayName string     `json:"display_name"`
+	Description string     `json:"description"`
+	Category    string     `json:"category"`
+	Tier        string     `json:"tier"`
+	SDKTargets  SDKTargets `json:"sdk_targets"`
+	Coverage    Coverage   `json:"coverage"`
+	Status      string     `json:"status"`
+}
+
+// SDKTargets groups primary and additional SDK targets.
+type SDKTargets struct {
+	Primary    SDKTarget   `json:"primary"`
+	Additional []SDKTarget `json:"additional,omitempty"`
+}
+
+// SDKTarget identifies a language SDK package.
+type SDKTarget struct {
+	Package  string `json:"package"`
+	Language string `json:"language"`
+	Version  string `json:"version,omitempty"`
+}
+
+// Coverage describes twin API coverage.
+type Coverage struct {
+	EstimatedPct   int    `json:"estimated_pct"`
+	ResourceCount  int    `json:"resource_count"`
+	WebhookSupport bool   `json:"webhook_support"`
+	AuthPattern    string `json:"auth_pattern"`
+}
+
+// OrgCatalogEntry extends CatalogEntry with org-specific state.
+type OrgCatalogEntry struct {
+	CatalogEntry
+	EntitlementState string `json:"entitlement_state"`
+	AvailableAction  string `json:"available_action"`
+}
+
+// Category represents a catalog category with twin count.
+type Category struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// ListTwins fetches the public catalog with optional filters.
+func (c *Client) ListTwins(ctx context.Context, category, tier, sdkLanguage, search string) ([]CatalogEntry, error) {
+	u, err := url.Parse(c.baseURL + "/v1/catalog/twins")
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+
+	q := u.Query()
+	if category != "" {
+		q.Set("category", category)
+	}
+	if tier != "" {
+		q.Set("tier", tier)
+	}
+	if sdkLanguage != "" {
+		q.Set("sdk_language", sdkLanguage)
+	}
+	if search != "" {
+		q.Set("search", search)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list twins: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list twins: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Twins []CatalogEntry `json:"twins"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Twins, nil
+}
+
+// ListOrgCatalog fetches the org-scoped catalog with entitlement enrichment.
+func (c *Client) ListOrgCatalog(ctx context.Context, orgID, category, search string) ([]OrgCatalogEntry, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/catalog", c.baseURL, orgID))
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+
+	q := u.Query()
+	if category != "" {
+		q.Set("category", category)
+	}
+	if search != "" {
+		q.Set("search", search)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list org catalog: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list org catalog: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Twins []OrgCatalogEntry `json:"twins"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Twins, nil
+}
+
+// ListCategories fetches the catalog categories.
+func (c *Client) ListCategories(ctx context.Context) ([]Category, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/v1/catalog/categories", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list categories: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list categories: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Categories []Category `json:"categories"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Categories, nil
+}


### PR DESCRIPTION
## Summary

Phase 0 CLI implementation for Agent Twin Discovery. Adds three new commands and the platform API client.

- **`wt login --org <slug>`** — prompts for API key, validates against wondertwin-app, stores org context (slug, ID, key) in config.
- **`wt catalog`** — browse the full twin catalog. Supports `--category`, `--tier`, `--search` filters. `--mine` shows org's entitled twins (requires auth). `wt catalog <name>` shows detail.
- **`wt scan`** — detects project dependencies (go.mod, package.json) and matches against catalog. Shows table of detected SDKs with matching twin, tier, and available action.
- **`internal/platform/`** — new HTTP client for wondertwin-app API.

Includes a fix for the Authorization header format — API keys are sent as raw `wt_live_...` tokens, not with a `Bearer` prefix (which would misroute to the Clerk JWT auth path).

## Planning docs

- [agent-twin-discovery-roadmap.md — CLI Command Taxonomy](https://github.com/wondertwin-ai/wondertwin-docs/blob/main/product/agent-twin-discovery-roadmap.md)
- [platform-roadmap.md](https://github.com/wondertwin-ai/wondertwin-docs/blob/main/plans/platform-roadmap.md)

## Issues closed

- Closes #211 (CLI API key auth wiring)
- Closes #206 (wt catalog command)
- Closes #207 (wt scan command)

## Test plan

- [ ] `go build ./...` compiles
- [ ] `go test ./... -short` passes
- [ ] `go vet ./...` clean
- [ ] `wt catalog` returns twin list from public API (no auth)
- [ ] `wt catalog --mine` requires auth and shows entitlement state
- [ ] `wt catalog stripe` shows detail view
- [ ] `wt scan` in a Go project detects SDK imports and matches against catalog
- [ ] `wt login --org <slug>` prompts for key, validates, stores context
- [ ] `wt auth status` shows org context after login

## Note

Agent vote telemetry (logging zero-result searches) and MCP tool registration are Phase 1 scope (issues #210, wondertwin-app#20). The command structure supports adding these without changes.