### PR TITLE
feat: Phase 1 discovery CLI — subscribe, request, MCP tools

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -20,6 +20,12 @@
 //	wt registry remove <name>     Remove a named registry
 //	wt registry list              List configured registries
 //	wt conformance <binary>       Run conformance tests against a twin
+//	wt login --org <slug>         Authenticate with WonderTwin platform
+//	wt catalog                    Browse the full twin catalog
+//	wt scan                       Detect project dependencies, match against catalog
+//	wt subscribe <twin>           Subscribe to a twin (trial, paid, or entitled)
+//	wt request <service>          Request a twin that doesn't exist yet
+//	wt request --list             List your org's twin requests
 package main
 
 import (
@@ -121,6 +127,10 @@ func main() {
 		err = cmdCatalog(args)
 	case "scan":
 		err = cmdScan(args)
+	case "subscribe":
+		err = cmdSubscribe(args)
+	case "request":
+		err = cmdRequest(args)
 	case "auth":
 		err = cmdAuth(args)
 	case "registry":
@@ -1853,6 +1863,155 @@ func installFromLockFile(manifestDir string, m *manifest.Manifest) error {
 		if err := registry.InstallFromURL(name, locked.Version, locked.BinaryURL, locked.Checksum, binaryDir); err != nil {
 			return fmt.Errorf("twin %s: %w", name, err)
 		}
+	}
+
+	return nil
+}
+
+const signupBaseURL = "https://app.wondertwin.ai/signup"
+
+func cmdSubscribe(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: wt subscribe <twin-name>")
+	}
+
+	twinName := args[0]
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	// No-account path: surface signup URL.
+	if cfg.APIKey == "" {
+		fmt.Printf("%s requires a WonderTwin account.\n", twinName)
+		fmt.Printf("Sign up: %s?ref=cli&twin=%s\n", signupBaseURL, twinName)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	client := platform.New(platformBaseURL(), cfg.APIKey)
+	resp, err := client.Subscribe(ctx, cfg.OrgID, twinName)
+	if err != nil {
+		return fmt.Errorf("subscribe: %w", err)
+	}
+
+	switch resp.Action {
+	case "already_entitled":
+		fmt.Printf("%s is already in your catalog. Run `wt install %s` to install.\n", twinName, twinName)
+	case "subscribed":
+		fmt.Printf("Subscribed to %s. Run `wt install %s` to install.\n", twinName, twinName)
+	case "trial_started":
+		fmt.Printf("Pro trial started (expires %s). %s is now available.\n", resp.TrialEndsAt, twinName)
+		fmt.Printf("Run `wt install %s` to install.\n", twinName)
+	case "upgrade_required":
+		fmt.Printf("%s requires WonderTwin Pro.\n", twinName)
+		if resp.CheckoutURL != "" {
+			fmt.Printf("Start your subscription: %s\n", resp.CheckoutURL)
+		} else {
+			fmt.Printf("Upgrade at: %s?ref=cli&twin=%s\n", signupBaseURL, twinName)
+		}
+	case "approval_requested":
+		fmt.Printf("Subscription request submitted to your org admin.")
+		if resp.RequestID != "" {
+			fmt.Printf(" (request %s)", resp.RequestID)
+		}
+		fmt.Println()
+	case "signup_required":
+		fmt.Printf("%s requires a WonderTwin account.\n", twinName)
+		if resp.SignupURL != "" {
+			fmt.Printf("Sign up: %s\n", resp.SignupURL)
+		} else {
+			fmt.Printf("Sign up: %s?ref=cli&twin=%s\n", signupBaseURL, twinName)
+		}
+	default:
+		fmt.Printf("Response: %s\n", resp.Action)
+		if resp.Message != "" {
+			fmt.Println(resp.Message)
+		}
+	}
+
+	return nil
+}
+
+func cmdRequest(args []string) error {
+	// Parse flags.
+	var listMode bool
+	var serviceName string
+
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--list":
+			listMode = true
+		case !strings.HasPrefix(args[i], "-"):
+			serviceName = args[i]
+		}
+	}
+
+	if !listMode && serviceName == "" {
+		return fmt.Errorf("usage: wt request <service-name>  or  wt request --list")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// --list: show org's requests.
+	if listMode {
+		if cfg.APIKey == "" {
+			return fmt.Errorf("not logged in. Run `wt login --org <slug>` first")
+		}
+
+		client := platform.New(platformBaseURL(), cfg.APIKey)
+		reqs, err := client.ListTwinRequests(ctx, cfg.OrgID)
+		if err != nil {
+			return fmt.Errorf("list requests: %w", err)
+		}
+
+		if len(reqs) == 0 {
+			fmt.Println("No twin requests.")
+			return nil
+		}
+
+		fmt.Printf("%-36s  %-20s  %-12s  %s\n", "ID", "SERVICE", "STATUS", "CREATED")
+		fmt.Printf("%-36s  %-20s  %-12s  %s\n", strings.Repeat("-", 36), strings.Repeat("-", 20), strings.Repeat("-", 12), strings.Repeat("-", 19))
+		for _, r := range reqs {
+			created := r.CreatedAt
+			if len(created) > 19 {
+				created = created[:19]
+			}
+			fmt.Printf("%-36s  %-20s  %-12s  %s\n", r.ID, r.ServiceName, r.Status, created)
+		}
+		return nil
+	}
+
+	// No account: suggest GitHub issue.
+	if cfg.APIKey == "" {
+		fmt.Printf("No WonderTwin account. To request a twin for %s:\n", serviceName)
+		fmt.Printf("  Create an issue: https://github.com/wondertwin-ai/wondertwin/issues/new?title=Twin+Request:+%s&labels=twin-request\n", serviceName)
+		fmt.Printf("  Or sign up for Pro to get structured request tracking: %s?ref=cli\n", signupBaseURL)
+		return nil
+	}
+
+	// Pro path: submit structured request.
+	client := platform.New(platformBaseURL(), cfg.APIKey)
+	result, err := client.SubmitTwinRequest(ctx, cfg.OrgID, serviceName, "", "")
+	if err != nil {
+		return fmt.Errorf("submit request: %w", err)
+	}
+
+	if result.Status == "submitted" {
+		fmt.Printf("Twin request submitted for %s (request %s).\n", serviceName, result.ID)
+		fmt.Println("We'll research this and get back to you.")
+	} else {
+		// Dedup: existing request returned.
+		fmt.Printf("Existing request for %s (request %s, status: %s).\n", serviceName, result.ID, result.Status)
 	}
 
 	return nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,7 +8,9 @@ import (
 	"os"
 
 	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/config"
 	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
 )
 
 // Server is an MCP server that exposes twin management tools over JSON-RPC 2.0 on stdio.
@@ -22,10 +24,23 @@ type Server struct {
 
 // NewServer creates a new MCP server for the given manifest.
 func NewServer(m *manifest.Manifest) *Server {
+	tools := allTools()
+
+	// Add discovery tools if platform config is available.
+	cfg, err := config.Load()
+	if err == nil {
+		baseURL := platform.DefaultBaseURL
+		if u := os.Getenv("WT_PLATFORM_URL"); u != "" {
+			baseURL = u
+		}
+		pc := platform.New(baseURL, cfg.APIKey)
+		tools = append(tools, discoveryTools(pc, cfg)...)
+	}
+
 	return &Server{
 		manifest: m,
 		client:   client.New(),
-		tools:    allTools(),
+		tools:    tools,
 		stdin:    os.Stdin,
 		stdout:   os.Stdout,
 	}

--- a/internal/mcp/tools_discovery.go
+++ b/internal/mcp/tools_discovery.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+// jsonResult creates a ToolResult with structured JSON content.
+// MCP discovery tools return JSON, not formatted text.
+func jsonResult(v any) ToolResult {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return textResult(fmt.Sprintf("Error marshaling result: %v", err))
+	}
+	return ToolResult{
+		Content: []ToolContent{{Type: "text", Text: string(data)}},
+	}
+}
+
+func errorResult(msg string) ToolResult {
+	return jsonResult(map[string]string{"error": msg})
+}
+
+// discoveryTools returns MCP tool entries for catalog, scan, subscribe, and request.
+func discoveryTools(pc *platform.Client, cfg *config.Config) []toolEntry {
+	return []toolEntry{
+		{
+			Tool: Tool{
+				Name:        "wt_catalog",
+				Description: "Search the WonderTwin twin catalog. Returns structured JSON with matching twins.",
+				InputSchema: json.RawMessage(`{
+					"type": "object",
+					"properties": {
+						"query": {"type": "string", "description": "Search by name or description"},
+						"category": {"type": "string", "description": "Filter by category (e.g. payments, messaging)"},
+						"tier": {"type": "string", "description": "Filter by tier: community or commercial"},
+						"mine": {"type": "boolean", "description": "Only show org's entitled/installed twins (requires auth)"}
+					}
+				}`),
+			},
+			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+				var p struct {
+					Query    string `json:"query"`
+					Category string `json:"category"`
+					Tier     string `json:"tier"`
+					Mine     bool   `json:"mine"`
+				}
+				if len(params) > 0 {
+					json.Unmarshal(params, &p)
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				if p.Mine {
+					if cfg.APIKey == "" || cfg.OrgID == "" {
+						return errorResult("not authenticated: run wt login --org first")
+					}
+					entries, err := pc.ListOrgCatalog(ctx, cfg.OrgID, p.Category, p.Query)
+					if err != nil {
+						return errorResult(fmt.Sprintf("catalog query failed: %v", err))
+					}
+					return jsonResult(map[string]any{"twins": entries, "count": len(entries)})
+				}
+
+				entries, err := pc.ListTwins(ctx, p.Category, p.Tier, "", p.Query)
+				if err != nil {
+					return errorResult(fmt.Sprintf("catalog query failed: %v", err))
+				}
+				return jsonResult(map[string]any{"twins": entries, "count": len(entries)})
+			},
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_catalog_detail",
+				Description: "Get detailed information about a specific twin from the catalog.",
+				InputSchema: json.RawMessage(`{
+					"type": "object",
+					"properties": {
+						"twin_name": {"type": "string", "description": "Name of the twin to look up"}
+					},
+					"required": ["twin_name"]
+				}`),
+			},
+			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+				var p struct {
+					TwinName string `json:"twin_name"`
+				}
+				if len(params) > 0 {
+					json.Unmarshal(params, &p)
+				}
+				if p.TwinName == "" {
+					return errorResult("twin_name is required")
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				entries, err := pc.ListTwins(ctx, "", "", "", p.TwinName)
+				if err != nil {
+					return errorResult(fmt.Sprintf("catalog query failed: %v", err))
+				}
+
+				// Find exact match.
+				for _, e := range entries {
+					if e.Name == p.TwinName {
+						return jsonResult(e)
+					}
+				}
+				return errorResult(fmt.Sprintf("twin %q not found", p.TwinName))
+			},
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_subscribe",
+				Description: "Subscribe to a twin. The backend determines the outcome: already entitled, subscribed, trial started, or upgrade required. Returns structured JSON.",
+				InputSchema: json.RawMessage(`{
+					"type": "object",
+					"properties": {
+						"twin_name": {"type": "string", "description": "Name of the twin to subscribe to"}
+					},
+					"required": ["twin_name"]
+				}`),
+			},
+			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+				var p struct {
+					TwinName string `json:"twin_name"`
+				}
+				if len(params) > 0 {
+					json.Unmarshal(params, &p)
+				}
+				if p.TwinName == "" {
+					return errorResult("twin_name is required")
+				}
+
+				if cfg.APIKey == "" || cfg.OrgID == "" {
+					return jsonResult(map[string]any{
+						"action":     "signup_required",
+						"signup_url": fmt.Sprintf("https://app.wondertwin.ai/signup?ref=mcp&twin=%s", p.TwinName),
+						"message":    "Not authenticated. Sign up or run wt login --org.",
+					})
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+
+				resp, err := pc.Subscribe(ctx, cfg.OrgID, p.TwinName)
+				if err != nil {
+					return errorResult(fmt.Sprintf("subscribe failed: %v", err))
+				}
+				return jsonResult(resp)
+			},
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_request",
+				Description: "Request a twin that doesn't exist yet. For Pro orgs, submits a structured request. Returns structured JSON.",
+				InputSchema: json.RawMessage(`{
+					"type": "object",
+					"properties": {
+						"service_name": {"type": "string", "description": "Name of the service to request a twin for"},
+						"service_url": {"type": "string", "description": "URL of the service's developer docs (optional)"},
+						"category_hint": {"type": "string", "description": "Category hint for the service (optional)"}
+					},
+					"required": ["service_name"]
+				}`),
+			},
+			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+				var p struct {
+					ServiceName  string `json:"service_name"`
+					ServiceURL   string `json:"service_url"`
+					CategoryHint string `json:"category_hint"`
+				}
+				if len(params) > 0 {
+					json.Unmarshal(params, &p)
+				}
+				if p.ServiceName == "" {
+					return errorResult("service_name is required")
+				}
+
+				if cfg.APIKey == "" || cfg.OrgID == "" {
+					return jsonResult(map[string]any{
+						"action":    "github_issue",
+						"issue_url": fmt.Sprintf("https://github.com/wondertwin-ai/wondertwin/issues/new?title=Twin+Request:+%s&labels=twin-request", p.ServiceName),
+						"message":   "Not authenticated. Create a GitHub issue to request this twin, or sign up for Pro.",
+					})
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+
+				result, err := pc.SubmitTwinRequest(ctx, cfg.OrgID, p.ServiceName, p.ServiceURL, p.CategoryHint)
+				if err != nil {
+					return errorResult(fmt.Sprintf("submit request failed: %v", err))
+				}
+				return jsonResult(result)
+			},
+		},
+		{
+			Tool: Tool{
+				Name:        "wt_request_list",
+				Description: "List your organization's twin requests and their status.",
+				InputSchema: json.RawMessage(`{"type": "object", "properties": {}}`),
+			},
+			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, _ json.RawMessage) ToolResult {
+				if cfg.APIKey == "" || cfg.OrgID == "" {
+					return errorResult("not authenticated: run wt login --org first")
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				reqs, err := pc.ListTwinRequests(ctx, cfg.OrgID)
+				if err != nil {
+					return errorResult(fmt.Sprintf("list requests failed: %v", err))
+				}
+				return jsonResult(map[string]any{"requests": reqs, "count": len(reqs)})
+			},
+		},
+	}
+}

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -2,6 +2,7 @@
 package platform
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -235,4 +236,162 @@ func (c *Client) ListCategories(ctx context.Context) ([]Category, error) {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	return result.Categories, nil
+}
+
+// SubscribeResponse is the unified response from the subscribe endpoint.
+type SubscribeResponse struct {
+	Action      string `json:"action"`
+	TwinName    string `json:"twin_name"`
+	TrialEndsAt string `json:"trial_ends_at,omitempty"`
+	CheckoutURL string `json:"checkout_url,omitempty"`
+	SignupURL   string `json:"signup_url,omitempty"`
+	RequestID   string `json:"request_id,omitempty"`
+	Message     string `json:"message,omitempty"`
+}
+
+// Subscribe calls the unified subscribe endpoint.
+func (c *Client) Subscribe(ctx context.Context, orgID, twinName string) (*SubscribeResponse, error) {
+	body, err := json.Marshal(map[string]string{"twin_name": twinName})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		fmt.Sprintf("%s/v1/orgs/%s/subscribe", c.baseURL, orgID), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result SubscribeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("subscribe: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("subscribe: HTTP %d: %s", resp.StatusCode, result.Message)
+	}
+
+	return &result, nil
+}
+
+// TwinRequest represents a twin request in the system.
+type TwinRequest struct {
+	ID           string `json:"id"`
+	OrgID        string `json:"org_id"`
+	ServiceName  string `json:"service_name"`
+	ServiceURL   string `json:"service_url,omitempty"`
+	RequestType  string `json:"request_type"`
+	CategoryHint string `json:"category_hint,omitempty"`
+	Status       string `json:"status"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+// SubmitTwinRequest submits a structured twin request.
+func (c *Client) SubmitTwinRequest(ctx context.Context, orgID, serviceName, serviceURL, categoryHint string) (*TwinRequest, error) {
+	payload := map[string]string{"service_name": serviceName}
+	if serviceURL != "" {
+		payload["service_url"] = serviceURL
+	}
+	if categoryHint != "" {
+		payload["category_hint"] = categoryHint
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		fmt.Sprintf("%s/v1/orgs/%s/twin-requests", c.baseURL, orgID), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("submit twin request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("submit twin request: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result TwinRequest
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
+}
+
+// ListTwinRequests returns all twin requests for an org.
+func (c *Client) ListTwinRequests(ctx context.Context, orgID string) ([]TwinRequest, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/v1/orgs/%s/twin-requests", c.baseURL, orgID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list twin requests: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list twin requests: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Requests []TwinRequest `json:"requests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Requests, nil
+}
+
+// GetTwinRequest returns a single twin request.
+func (c *Client) GetTwinRequest(ctx context.Context, orgID, requestID string) (*TwinRequest, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/v1/orgs/%s/twin-requests/%s", c.baseURL, orgID, requestID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get twin request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("request not found: %s", requestID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("get twin request: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result TwinRequest
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
 }


### PR DESCRIPTION
## Summary

Phase 1 CLI and MCP implementation for Agent Twin Discovery.

- **`wt subscribe <twin>`** — unified acquisition command. Calls `POST /v1/orgs/{orgID}/subscribe`, handles all response actions: already_entitled, subscribed, trial_started, upgrade_required, approval_requested. Without auth, surfaces signup URL with twin context.
- **`wt request <service>`** — twin request for services without twins. Pro orgs get structured request tracking via API. Community/unauthenticated users get a GitHub issue link. `wt request --list` shows request status table.
- **MCP discovery tools** — 6 tools returning structured JSON (not formatted tables): `wt_catalog`, `wt_catalog_detail`, `wt_subscribe`, `wt_request`, `wt_request_list`. Platform client auto-configured from stored credentials.

Platform client extended with Subscribe, SubmitTwinRequest, ListTwinRequests, GetTwinRequest methods.

## Planning docs

- [agent-twin-discovery-roadmap.md — CLI Taxonomy](https://github.com/wondertwin-ai/wondertwin-docs/blob/main/product/agent-twin-discovery-roadmap.md)
- [platform-roadmap.md](https://github.com/wondertwin-ai/wondertwin-docs/blob/main/plans/platform-roadmap.md)

## Issues closed

- Closes #208 (wt subscribe command)
- Closes #209 (wt request command)
- Closes #210 (MCP discovery tools)

## Test plan

- [ ] `go build ./...` compiles
- [ ] `go test ./... -short` passes
- [ ] `go vet ./...` clean
- [ ] `wt subscribe` without auth shows signup URL
- [ ] `wt request` without auth shows GitHub issue link
- [ ] MCP tools return structured JSON, not table text
- [ ] All 6 MCP tools appear in `tools/list` response