### PR TITLE
fix: security audit remediation — permissions, containers, request limits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.gitignore
+.env*
+node_modules
+*.md
+.DS_Store
+.vscode
+.claude

--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -12,12 +12,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout wondertwin
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,13 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/twin-stripe/Dockerfile
+++ b/twin-stripe/Dockerfile
@@ -9,5 +9,6 @@ FROM alpine:3.21
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /twin-stripe /usr/local/bin/twin-stripe
 EXPOSE 12111
-USER nobody
+RUN adduser -D -u 1000 twin
+USER twin
 ENTRYPOINT ["twin-stripe"]

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -193,11 +193,12 @@ func (t *Twin) Serve() error {
 	addr := fmt.Sprintf(":%d", t.Config.Port)
 
 	srv := &http.Server{
-		Addr:         addr,
-		Handler:      t.Router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:           addr,
+		Handler:        http.MaxBytesHandler(t.Router, 10<<20), // 10MB request body limit
+		ReadTimeout:    30 * time.Second,
+		WriteTimeout:   30 * time.Second,
+		IdleTimeout:    60 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1MB max header
 	}
 
 	// Graceful shutdown


### PR DESCRIPTION
## Summary

Addresses findings from the [2026-04-27 platform security audit](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/security/audit-2026-04-27.md):

- **H4**: twin-stripe container now runs as dedicated non-root user (UID 1000)
- **H5**: Added 10MB request body limit and 1MB max header size to twincore HTTP server
- **H6**: Scoped release workflow `contents: write` permission to specific jobs (was workflow-level)
- **M3**: Added `.dockerignore` to prevent `.git`, `.env`, etc. leaking into container images

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] twinkit tests pass (pre-existing `TestHandleListQuirksNilStore` failure unrelated)
- [ ] Verify twin-stripe container runs as UID 1000: `docker run --rm twin-stripe id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)