### PR TITLE
add: --tier and --manifest-file flags to gen-registry

### DIFF
--- a/cmd/gen-registry/main.go
+++ b/cmd/gen-registry/main.go
@@ -21,12 +21,14 @@ type Registry struct {
 
 // TwinEntry mirrors internal/registry.TwinEntry.
 type TwinEntry struct {
-	Description string             `json:"description"`
-	Repo        string             `json:"repo"`
-	Category    string             `json:"category"`
-	Author      string             `json:"author"`
-	Latest      string             `json:"latest"`
-	Versions    map[string]Version `json:"versions"`
+	Description  string             `json:"description"`
+	Repo         string             `json:"repo"`
+	Category     string             `json:"category"`
+	Author       string             `json:"author"`
+	Tier         string             `json:"tier"`
+	DownloadAuth string             `json:"download_auth,omitempty"`
+	Latest       string             `json:"latest"`
+	Versions     map[string]Version `json:"versions"`
 }
 
 // Version mirrors internal/registry.Version.
@@ -72,6 +74,8 @@ func run(args []string) error {
 	registryFile := fs.String("registry-file", "", "path to registry.json")
 	repo := fs.String("repo", "wondertwin-ai/registry", "GitHub repo for download URLs")
 	prerelease := fs.Bool("prerelease", false, "add version without updating latest")
+	tier := fs.String("tier", "community", "twin tier: community or commercial")
+	manifestFile := fs.String("manifest-file", "", "explicit path to twin-manifest.json (default: twin-<name>/twin-manifest.json)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -81,8 +85,12 @@ func run(args []string) error {
 		return fmt.Errorf("--twin, --version, --checksums-file, and --registry-file are all required")
 	}
 
+	if *tier != "community" && *tier != "commercial" {
+		return fmt.Errorf("--tier must be 'community' or 'commercial', got %q", *tier)
+	}
+
 	// 1. Read twin manifest
-	manifest, err := readManifest(*twin)
+	manifest, err := readManifestFrom(*twin, *manifestFile)
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
 	}
@@ -100,10 +108,10 @@ func run(args []string) error {
 	}
 
 	// 4. Build version entry
-	ver := buildVersion(*twin, *version, *repo, manifest, checksums)
+	ver := buildVersion(*twin, *version, *repo, *tier, manifest, checksums)
 
 	// 5. Upsert into registry
-	upsert(reg, *twin, *version, manifest, ver, *prerelease)
+	upsert(reg, *twin, *version, *tier, manifest, ver, *prerelease)
 
 	// 6. Write back
 	if err := writeRegistry(*registryFile, reg); err != nil {
@@ -114,8 +122,11 @@ func run(args []string) error {
 	return nil
 }
 
-func readManifest(twin string) (*TwinManifest, error) {
-	path := filepath.Join(fmt.Sprintf("twin-%s", twin), "twin-manifest.json")
+func readManifestFrom(twin, manifestFile string) (*TwinManifest, error) {
+	path := manifestFile
+	if path == "" {
+		path = filepath.Join(fmt.Sprintf("twin-%s", twin), "twin-manifest.json")
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -187,7 +198,7 @@ func loadRegistry(path string) (*Registry, error) {
 	return &reg, nil
 }
 
-func buildVersion(twin, version, repo string, manifest *TwinManifest, checksums map[string]string) Version {
+func buildVersion(twin, version, repo, tier string, manifest *TwinManifest, checksums map[string]string) Version {
 	platforms := []string{"darwin-amd64", "darwin-arm64", "linux-amd64", "linux-arm64"}
 	binaryURLs := make(map[string]string, len(platforms))
 	for _, p := range platforms {
@@ -202,23 +213,33 @@ func buildVersion(twin, version, repo string, manifest *TwinManifest, checksums 
 		SDKPackage: manifest.SDKTarget.Primary.Package,
 		SDKVersion: manifest.SDKTarget.Primary.Version,
 		APIVersion: manifest.SDKTarget.Primary.APIVersion,
-		Tier:       "free",
+		Tier:       tier,
 		Checksums:  checksums,
 		BinaryURLs: binaryURLs,
 	}
 }
 
-func upsert(reg *Registry, twin, version string, manifest *TwinManifest, ver Version, prerelease bool) {
+func upsert(reg *Registry, twin, version, tier string, manifest *TwinManifest, ver Version, prerelease bool) {
 	entry, exists := reg.Twins[twin]
 	if !exists {
+		repo := "https://github.com/wondertwin-ai/wondertwin"
+		if tier == "commercial" {
+			repo = "https://github.com/wondertwin-ai/wondertwin-pro"
+		}
 		entry = TwinEntry{
 			Description: manifest.Description,
-			Repo:        "https://github.com/wondertwin-ai/wondertwin",
+			Repo:        repo,
 			Category:    manifest.Category,
 			Author:      "WonderTwin",
 			Versions:    make(map[string]Version),
 		}
 	}
+
+	entry.Tier = tier
+	if tier == "commercial" {
+		entry.DownloadAuth = "required"
+	}
+
 	// Update latest unless --prerelease is set.
 	// Exception: if there's no previous latest (first release), set it even for prereleases.
 	if !prerelease || entry.Latest == "" {

--- a/cmd/gen-registry/main_test.go
+++ b/cmd/gen-registry/main_test.go
@@ -125,8 +125,11 @@ func TestCreateRegistryFromScratch(t *testing.T) {
 	if ver.SDKVersion != "v81" {
 		t.Errorf("sdk_version = %q", ver.SDKVersion)
 	}
-	if ver.Tier != "free" {
-		t.Errorf("tier = %q", ver.Tier)
+	if ver.Tier != "community" {
+		t.Errorf("tier = %q, want %q", ver.Tier, "community")
+	}
+	if entry.Tier != "community" {
+		t.Errorf("entry.tier = %q, want %q", entry.Tier, "community")
 	}
 }
 
@@ -574,6 +577,142 @@ func TestBackwardCompatibilityWithoutAPIVersion(t *testing.T) {
 		t.Errorf("api_version should be empty for old registry, got %q", ver.APIVersion)
 	}
 	if ver.SDKPackage != "github.com/stripe/stripe-go" {
+		t.Errorf("sdk_package = %q", ver.SDKPackage)
+	}
+}
+
+func TestCommercialTier(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe",
+		"--version", "0.1.0",
+		"--checksums-file", checksumsPath,
+		"--registry-file", registryPath,
+		"--tier", "commercial",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	entry := reg.Twins["stripe"]
+	if entry.Tier != "commercial" {
+		t.Errorf("entry.tier = %q, want %q", entry.Tier, "commercial")
+	}
+	if entry.DownloadAuth != "required" {
+		t.Errorf("download_auth = %q, want %q", entry.DownloadAuth, "required")
+	}
+	if entry.Repo != "https://github.com/wondertwin-ai/wondertwin-pro" {
+		t.Errorf("repo = %q, want wondertwin-pro URL", entry.Repo)
+	}
+
+	ver := entry.Versions["0.1.0"]
+	if ver.Tier != "commercial" {
+		t.Errorf("version tier = %q, want %q", ver.Tier, "commercial")
+	}
+}
+
+func TestInvalidTierRejected(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe",
+		"--version", "0.1.0",
+		"--checksums-file", checksumsPath,
+		"--registry-file", registryPath,
+		"--tier", "pro",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid tier 'pro', got nil")
+	}
+}
+
+func TestManifestFileFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	// Place manifest in a non-standard location (simulating cross-repo)
+	manifestPath := filepath.Join(dir, "external-manifest.json")
+	manifest := `{
+  "twin": "plaid",
+  "display_name": "Plaid",
+  "category": "fintech",
+  "description": "Plaid twin for testing",
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/plaid/plaid-go",
+      "language": "go",
+      "version": "v14"
+    }
+  }
+}`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	// Write checksums for plaid
+	content := `abc123def456  twin-plaid-darwin-amd64
+789ghi012jkl  twin-plaid-darwin-arm64
+mno345pqr678  twin-plaid-linux-amd64
+stu901vwx234  twin-plaid-linux-arm64
+`
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	os.WriteFile(checksumsPath, []byte(content), 0o644)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	// No twin-plaid/ directory exists — rely entirely on --manifest-file
+	err := run([]string{
+		"--twin", "plaid",
+		"--version", "0.1.0",
+		"--checksums-file", checksumsPath,
+		"--registry-file", registryPath,
+		"--manifest-file", manifestPath,
+		"--tier", "commercial",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+
+	entry := reg.Twins["plaid"]
+	if entry.Description != "Plaid twin for testing" {
+		t.Errorf("description = %q", entry.Description)
+	}
+	if entry.Category != "fintech" {
+		t.Errorf("category = %q", entry.Category)
+	}
+	if entry.Tier != "commercial" {
+		t.Errorf("tier = %q, want %q", entry.Tier, "commercial")
+	}
+
+	ver := entry.Versions["0.1.0"]
+	if ver.SDKPackage != "github.com/plaid/plaid-go" {
 		t.Errorf("sdk_package = %q", ver.SDKPackage)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--tier community|commercial` flag to gen-registry (default: `community`)
- Adds `--manifest-file` flag to read twin-manifest.json from an explicit path instead of the monorepo convention (`twin-<name>/twin-manifest.json`)
- Sets entry-level `tier` and `download_auth: "required"` for commercial twins
- Sets repo URL to `wondertwin-pro` for commercial entries
- Validates tier input — rejects values like "pro" or "paid"

These flags are required by the commercial twin release workflow in wondertwin-pro, which runs gen-registry from the public repo checkout but reads manifests from the pro repo checkout on the same CI runner.

## Test plan

- [x] Existing tests updated (community tier replaces hardcoded "free")
- [x] `TestCommercialTier` — verifies entry tier, download_auth, repo URL, version tier
- [x] `TestInvalidTierRejected` — ensures invalid tier values are rejected
- [x] `TestManifestFileFlag` — verifies reading manifest from non-standard path without twin directory present
- [x] All 14 tests passing, build and vet clean