### PR TITLE
feat: cut twinkit seams for CI v2 (cimode, replay, telemetry, scrub, observer endpoint)

### DIFF
--- a/twinkit/admin/admin.go
+++ b/twinkit/admin/admin.go
@@ -34,6 +34,13 @@ type ConfigProvider interface {
 	UpdateConfig(updates map[string]any) error
 }
 
+// RunIDSetter is implemented by twins that can record an active run id.
+// When set on a Handler, POST /admin/reset?run_id=<id> forwards the id
+// before clearing transient state.
+type RunIDSetter interface {
+	SetRunID(runID string)
+}
+
 // QuirkStore manages behavioral quirks that can be toggled at runtime.
 type QuirkStore interface {
 	ListQuirks() []QuirkStatus
@@ -59,6 +66,7 @@ type Handler struct {
 	clock   *state.Clock
 	config  ConfigProvider
 	quirks  QuirkStore
+	runIDs  RunIDSetter
 }
 
 // NewHandler creates a new admin handler.
@@ -83,6 +91,12 @@ func (h *Handler) SetConfigProvider(cp ConfigProvider) {
 // SetQuirkStore sets the quirk store (optional).
 func (h *Handler) SetQuirkStore(qs QuirkStore) {
 	h.quirks = qs
+}
+
+// SetRunIDSetter wires a RunIDSetter (typically the Twin) so
+// POST /admin/reset?run_id=<id> can forward the run identifier.
+func (h *Handler) SetRunIDSetter(s RunIDSetter) {
+	h.runIDs = s
 }
 
 // Routes mounts the admin endpoints on the given router.
@@ -115,7 +129,14 @@ func (h *Handler) handleReset(w http.ResponseWriter, r *http.Request) {
 	if h.clock != nil {
 		h.clock.Reset()
 	}
-	twincore.JSON(w, http.StatusOK, map[string]string{"status": "reset"})
+	resp := map[string]string{"status": "reset"}
+	if runID := r.URL.Query().Get("run_id"); runID != "" {
+		if h.runIDs != nil {
+			h.runIDs.SetRunID(runID)
+		}
+		resp["run_id"] = runID
+	}
+	twincore.JSON(w, http.StatusOK, resp)
 }
 
 func (h *Handler) handleGetState(w http.ResponseWriter, r *http.Request) {

--- a/twinkit/admin/admin_test.go
+++ b/twinkit/admin/admin_test.go
@@ -143,6 +143,7 @@ type testServerOpts struct {
 	flusher WebhookFlusher
 	config  ConfigProvider
 	quirks  QuirkStore
+	runIDs  RunIDSetter
 }
 
 func setupTestServer(state StateStore, clock *pkgstate.Clock, flusher WebhookFlusher) *httptest.Server {
@@ -165,6 +166,9 @@ func setupTestServerFull(opts testServerOpts) *httptest.Server {
 	}
 	if opts.quirks != nil {
 		h.SetQuirkStore(opts.quirks)
+	}
+	if opts.runIDs != nil {
+		h.SetRunIDSetter(opts.runIDs)
 	}
 
 	r := chi.NewRouter()
@@ -220,6 +224,53 @@ func TestHandleReset(t *testing.T) {
 	}
 	if clk.Offset() != 0 {
 		t.Errorf("expected clock offset to be reset, got %v", clk.Offset())
+	}
+}
+
+type mockRunIDSetter struct {
+	runID string
+}
+
+func (m *mockRunIDSetter) SetRunID(id string) { m.runID = id }
+
+func TestHandleResetWithRunID(t *testing.T) {
+	state := newMockState()
+	runIDs := &mockRunIDSetter{}
+	srv := setupTestServerFull(testServerOpts{state: state, clock: pkgstate.NewClock(), runIDs: runIDs})
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/reset?run_id=run-42", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if runIDs.runID != "run-42" {
+		t.Errorf("SetRunID called with %q, want run-42", runIDs.runID)
+	}
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["run_id"] != "run-42" {
+		t.Errorf("response run_id = %q, want run-42", body["run_id"])
+	}
+}
+
+func TestHandleResetWithRunIDNoSetter(t *testing.T) {
+	// run_id is accepted even without a RunIDSetter wired (graceful no-op).
+	srv := setupTestServer(newMockState(), pkgstate.NewClock(), nil)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/reset?run_id=run-1", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
 }
 

--- a/twinkit/cimode/cimode.go
+++ b/twinkit/cimode/cimode.go
@@ -1,0 +1,120 @@
+// Package cimode detects the execution environment of a twin (local
+// development vs. CI) and the specific CI platform when applicable.
+//
+// Detection is intentionally low-cost: it inspects environment variables
+// only. Platform-specific run identifiers and organization hints are
+// surfaced for downstream telemetry consumers, but cimode itself never
+// performs network I/O.
+//
+// License validation is deliberately not part of this package; that
+// concern is layered on top in a later iteration.
+package cimode
+
+import (
+	"os"
+	"strings"
+)
+
+// Mode classifies the runtime environment of a twin.
+type Mode int
+
+const (
+	// ModeLocal indicates a local developer machine — no CI signals present.
+	ModeLocal Mode = iota
+	// ModeCI indicates execution inside a continuous-integration runner.
+	ModeCI
+)
+
+// String returns a stable lower-case name for the mode, suitable for
+// telemetry payloads.
+func (m Mode) String() string {
+	switch m {
+	case ModeCI:
+		return "ci"
+	default:
+		return "local"
+	}
+}
+
+// Detection captures the result of inspecting the process environment.
+//
+// Platform is one of:
+//   - "github-actions"
+//   - "circleci"
+//   - "buildkite"
+//   - "gitlab"
+//   - "generic"  (CI=true with no recognized platform variable)
+//   - ""         (no CI signals detected)
+//
+// RunID is the platform-native run identifier when present (e.g.
+// GITHUB_RUN_ID). OrgHint is the platform's organization or namespace
+// identifier (e.g. GITHUB_REPOSITORY_OWNER) and is intended for
+// downstream hashing into telemetry payloads — never logged verbatim.
+type Detection struct {
+	Mode     Mode
+	Platform string
+	RunID    string
+	OrgHint  string
+}
+
+// Detect reads the current process environment and returns a Detection.
+// It is safe to call multiple times and never returns an error: an
+// unrecognized environment yields Detection{Mode: ModeLocal}.
+func Detect() Detection {
+	return DetectFromEnv(os.Environ())
+}
+
+// DetectFromEnv is the testable variant of Detect. It accepts an
+// os.Environ()-style slice of "KEY=VALUE" entries and returns a
+// Detection without consulting the real process environment.
+func DetectFromEnv(env []string) Detection {
+	lookup := make(map[string]string, len(env))
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			continue
+		}
+		lookup[kv[:i]] = kv[i+1:]
+	}
+
+	get := func(k string) string { return lookup[k] }
+	truthy := func(k string) bool {
+		v := strings.ToLower(strings.TrimSpace(get(k)))
+		return v == "true" || v == "1" || v == "yes"
+	}
+
+	switch {
+	case truthy("GITHUB_ACTIONS"):
+		return Detection{
+			Mode:     ModeCI,
+			Platform: "github-actions",
+			RunID:    get("GITHUB_RUN_ID"),
+			OrgHint:  get("GITHUB_REPOSITORY_OWNER"),
+		}
+	case truthy("CIRCLECI"):
+		return Detection{
+			Mode:     ModeCI,
+			Platform: "circleci",
+			RunID:    get("CIRCLE_WORKFLOW_ID"),
+			OrgHint:  get("CIRCLE_PROJECT_USERNAME"),
+		}
+	case truthy("BUILDKITE"):
+		return Detection{
+			Mode:     ModeCI,
+			Platform: "buildkite",
+			RunID:    get("BUILDKITE_BUILD_ID"),
+			OrgHint:  get("BUILDKITE_ORGANIZATION_SLUG"),
+		}
+	case truthy("GITLAB_CI"):
+		return Detection{
+			Mode:     ModeCI,
+			Platform: "gitlab",
+			RunID:    get("CI_PIPELINE_ID"),
+			OrgHint:  get("CI_PROJECT_NAMESPACE"),
+		}
+	case truthy("CI"):
+		return Detection{Mode: ModeCI, Platform: "generic"}
+	default:
+		return Detection{Mode: ModeLocal}
+	}
+}

--- a/twinkit/cimode/cimode_test.go
+++ b/twinkit/cimode/cimode_test.go
@@ -1,0 +1,111 @@
+package cimode
+
+import "testing"
+
+func TestDetectFromEnv(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  []string
+		want Detection
+	}{
+		{
+			name: "empty env is local",
+			env:  nil,
+			want: Detection{Mode: ModeLocal},
+		},
+		{
+			name: "github actions",
+			env: []string{
+				"CI=true",
+				"GITHUB_ACTIONS=true",
+				"GITHUB_RUN_ID=12345",
+				"GITHUB_REPOSITORY_OWNER=acme",
+			},
+			want: Detection{
+				Mode:     ModeCI,
+				Platform: "github-actions",
+				RunID:    "12345",
+				OrgHint:  "acme",
+			},
+		},
+		{
+			name: "circleci",
+			env: []string{
+				"CIRCLECI=true",
+				"CIRCLE_WORKFLOW_ID=wf-1",
+				"CIRCLE_PROJECT_USERNAME=acme",
+			},
+			want: Detection{
+				Mode:     ModeCI,
+				Platform: "circleci",
+				RunID:    "wf-1",
+				OrgHint:  "acme",
+			},
+		},
+		{
+			name: "buildkite",
+			env: []string{
+				"BUILDKITE=true",
+				"BUILDKITE_BUILD_ID=bk-9",
+				"BUILDKITE_ORGANIZATION_SLUG=acme",
+			},
+			want: Detection{
+				Mode:     ModeCI,
+				Platform: "buildkite",
+				RunID:    "bk-9",
+				OrgHint:  "acme",
+			},
+		},
+		{
+			name: "gitlab",
+			env: []string{
+				"GITLAB_CI=true",
+				"CI_PIPELINE_ID=42",
+				"CI_PROJECT_NAMESPACE=acme/widgets",
+			},
+			want: Detection{
+				Mode:     ModeCI,
+				Platform: "gitlab",
+				RunID:    "42",
+				OrgHint:  "acme/widgets",
+			},
+		},
+		{
+			name: "generic CI",
+			env:  []string{"CI=true"},
+			want: Detection{Mode: ModeCI, Platform: "generic"},
+		},
+		{
+			name: "github actions wins over generic",
+			env:  []string{"CI=true", "GITHUB_ACTIONS=true"},
+			want: Detection{Mode: ModeCI, Platform: "github-actions"},
+		},
+		{
+			name: "CI=false is local",
+			env:  []string{"CI=false"},
+			want: Detection{Mode: ModeLocal},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := DetectFromEnv(tc.env)
+			if got != tc.want {
+				t.Fatalf("DetectFromEnv() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModeString(t *testing.T) {
+	if got := ModeLocal.String(); got != "local" {
+		t.Errorf("ModeLocal.String() = %q, want %q", got, "local")
+	}
+	if got := ModeCI.String(); got != "ci" {
+		t.Errorf("ModeCI.String() = %q, want %q", got, "ci")
+	}
+}

--- a/twinkit/replay/replay.go
+++ b/twinkit/replay/replay.go
@@ -1,0 +1,198 @@
+// Package replay defines the interfaces and types used to capture twin
+// request/response traffic for later replay or off-host inspection.
+//
+// This package currently provides only the public seam: the Recorder,
+// the Observer fan-out hook, and the Manifest/Entry/Config value types.
+// Body capture, JSONL export, and ring-buffer ordering are filled in by
+// a follow-up change. The middleware returned by Recorder.Middleware()
+// is intentionally a pass-through so existing twins compile and serve
+// requests with no behavior change.
+//
+// The Observer interface is load-bearing public API — it is consumed by
+// the future synthetic-data sidecar and any local-only forwarder wired
+// via twincore's ObserverEndpoint configuration. Implementations MUST
+// be non-blocking; the recorder calls Observe synchronously on the
+// request path.
+package replay
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/scrub"
+)
+
+// Default Config values. Exported for documentation only — callers
+// should rely on Config zero-value handling, not these constants.
+const (
+	defaultMaxEntries   = 10_000
+	defaultMaxBodyBytes = 64 * 1024
+)
+
+// Entry is a single recorded request/response pair. Fields are populated
+// best-effort: when body capture is disabled, ReqBody and ResBody are
+// nil. SimTime, when non-zero, is the simulated clock value at request
+// arrival.
+type Entry struct {
+	RunID        string
+	Seq          uint64
+	Timestamp    time.Time
+	Method       string
+	Path         string
+	Query        string
+	ReqHeaders   map[string]string
+	ReqBody      []byte
+	ResStatus    int
+	ResHeaders   map[string]string
+	ResBody      []byte
+	DurationNs   int64
+	QuirksActive []string
+	SimTime      time.Time
+}
+
+// Manifest summarizes a completed run. It is emitted by FinishRun and
+// is the canonical bundle metadata when entries are exported to JSONL.
+type Manifest struct {
+	TwinName      string
+	TwinVersion   string
+	RunID         string
+	Seed          int64
+	StartedAt     time.Time
+	FinishedAt    time.Time
+	EntryCount    int
+	SchemaVersion int
+}
+
+// Config configures a Recorder. Zero values fall back to the package
+// defaults: 10_000 entries, 64 KiB per body, body capture disabled, and
+// the default scrubber set.
+type Config struct {
+	// MaxEntries is the upper bound on entries retained per run. When
+	// the bound is reached older entries are evicted. Zero selects the
+	// default of 10,000.
+	MaxEntries int
+
+	// MaxBodyBytes is the per-body capture cap. Bodies larger than the
+	// cap are truncated. Zero selects the default of 65,536 bytes.
+	MaxBodyBytes int
+
+	// CaptureBodies enables request and response body capture. Body
+	// capture is gated separately from header capture because it is
+	// substantially more expensive on the hot path.
+	CaptureBodies bool
+
+	// Scrubbers redacts sensitive headers and bodies before they are
+	// stored or fanned out to observers. A nil set means "use the
+	// default scrubber set"; pass scrub.NewSet() for an empty set.
+	Scrubbers *scrub.ScrubberSet
+}
+
+// Observer receives entries as they are recorded. Implementations MUST
+// be non-blocking and MUST NOT panic — the recorder invokes Observe on
+// the request hot path.
+type Observer interface {
+	Observe(entry Entry)
+}
+
+// Recorder captures request/response pairs and fans them out to any
+// registered observers. It is safe for concurrent use.
+//
+// The recorder is currently a structural seam: Middleware passes
+// requests through unchanged, Entries returns the empty slice, and
+// Export writes nothing. The public surface is stable; subsequent
+// changes will fill in the body.
+type Recorder struct {
+	cfg Config
+
+	mu        sync.Mutex
+	runID     string
+	startedAt time.Time
+	observers []Observer
+}
+
+// NewRecorder returns a Recorder configured per cfg. Zero-value fields
+// fall back to package defaults.
+func NewRecorder(cfg Config) *Recorder {
+	if cfg.MaxEntries == 0 {
+		cfg.MaxEntries = defaultMaxEntries
+	}
+	if cfg.MaxBodyBytes == 0 {
+		cfg.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if cfg.Scrubbers == nil {
+		cfg.Scrubbers = scrub.Default()
+	}
+	return &Recorder{cfg: cfg}
+}
+
+// Config returns the resolved configuration the recorder is using.
+// Useful for tests asserting that defaults were applied.
+func (r *Recorder) Config() Config {
+	return r.cfg
+}
+
+// AddObserver registers an Observer for fan-out. Observers are invoked
+// in registration order. Passing a nil observer is a no-op.
+func (r *Recorder) AddObserver(o Observer) {
+	if o == nil {
+		return
+	}
+	r.mu.Lock()
+	r.observers = append(r.observers, o)
+	r.mu.Unlock()
+}
+
+// Middleware returns an http middleware that records requests served
+// by the wrapped handler. In this revision the middleware is a
+// pass-through so callers can wire it now and pick up real recording
+// when the implementation lands.
+func (r *Recorder) Middleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// StartRun marks the beginning of a recording run with the given id.
+// Calling StartRun while a run is in progress replaces the active run.
+func (r *Recorder) StartRun(runID string) {
+	r.mu.Lock()
+	r.runID = runID
+	r.startedAt = time.Now().UTC()
+	r.mu.Unlock()
+}
+
+// FinishRun closes the active run and returns its Manifest. If no run
+// is active the returned Manifest is the zero value.
+func (r *Recorder) FinishRun() Manifest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.runID == "" {
+		return Manifest{}
+	}
+	m := Manifest{
+		RunID:      r.runID,
+		StartedAt:  r.startedAt,
+		FinishedAt: time.Now().UTC(),
+	}
+	r.runID = ""
+	r.startedAt = time.Time{}
+	return m
+}
+
+// Export writes the active run's entries as JSONL to w. The current
+// implementation writes nothing and returns nil; the export format
+// will be specified when body capture is wired.
+func (r *Recorder) Export(w io.Writer) error {
+	_ = w
+	return nil
+}
+
+// Entries returns a snapshot of the entries currently retained by the
+// recorder. The current implementation returns an empty slice.
+func (r *Recorder) Entries() []Entry {
+	return []Entry{}
+}

--- a/twinkit/replay/replay_test.go
+++ b/twinkit/replay/replay_test.go
@@ -1,0 +1,89 @@
+package replay
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewRecorderAppliesDefaults(t *testing.T) {
+	t.Parallel()
+	r := NewRecorder(Config{})
+	cfg := r.Config()
+	if cfg.MaxEntries != 10_000 {
+		t.Errorf("MaxEntries default = %d, want 10000", cfg.MaxEntries)
+	}
+	if cfg.MaxBodyBytes != 64*1024 {
+		t.Errorf("MaxBodyBytes default = %d, want 65536", cfg.MaxBodyBytes)
+	}
+	if cfg.Scrubbers == nil {
+		t.Error("Scrubbers default = nil, want non-nil default set")
+	}
+}
+
+func TestMiddlewareIsPassthrough(t *testing.T) {
+	t.Parallel()
+	r := NewRecorder(Config{})
+
+	handler := r.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("hi"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusTeapot)
+	}
+	if rec.Body.String() != "hi" {
+		t.Errorf("body = %q, want %q", rec.Body.String(), "hi")
+	}
+}
+
+type captureObserver struct {
+	entries []Entry
+}
+
+func (c *captureObserver) Observe(e Entry) { c.entries = append(c.entries, e) }
+
+func TestAddObserverAcceptsMultiple(t *testing.T) {
+	t.Parallel()
+	r := NewRecorder(Config{})
+	r.AddObserver(&captureObserver{})
+	r.AddObserver(&captureObserver{})
+	r.AddObserver(nil) // must not panic
+}
+
+func TestStartFinishRun(t *testing.T) {
+	t.Parallel()
+	r := NewRecorder(Config{})
+	r.StartRun("run-1")
+	m := r.FinishRun()
+	if m.RunID != "run-1" {
+		t.Errorf("Manifest.RunID = %q, want run-1", m.RunID)
+	}
+	if m.StartedAt.IsZero() || m.FinishedAt.IsZero() {
+		t.Error("Manifest timestamps must be set")
+	}
+	if got := r.FinishRun(); got.RunID != "" {
+		t.Errorf("second FinishRun should be zero, got %+v", got)
+	}
+}
+
+func TestExportAndEntriesAreEmpty(t *testing.T) {
+	t.Parallel()
+	r := NewRecorder(Config{})
+	var buf bytes.Buffer
+	if err := r.Export(&buf); err != nil {
+		t.Fatalf("Export() error = %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Export wrote %d bytes, want 0", buf.Len())
+	}
+	if got := r.Entries(); len(got) != 0 {
+		t.Errorf("Entries() = %d, want 0", len(got))
+	}
+}

--- a/twinkit/scrub/scrub.go
+++ b/twinkit/scrub/scrub.go
@@ -1,0 +1,115 @@
+// Package scrub provides a shared header- and body-redaction registry
+// used by twinkit components that capture or forward request/response
+// data (replay recorders, observer forwarders, telemetry payloads, and
+// the future synthetic-data sidecar).
+//
+// Scrubbers are pure functions invoked on the hot path; they MUST NOT
+// allocate excessively, perform I/O, or block. A scrubber returning the
+// empty string for a header drops that header entirely.
+package scrub
+
+import (
+	"bytes"
+	"strings"
+)
+
+// HeaderScrubber redacts the value of a single header. It receives the
+// canonical header name and the raw value, and returns the redacted
+// value. Returning "" instructs the caller to drop the header.
+type HeaderScrubber func(name string, value string) string
+
+// BodyScrubber redacts a request or response body. The contentType
+// argument is the Content-Type header value (or empty); body is the
+// raw bytes. The returned slice may alias body if no changes were made.
+type BodyScrubber func(contentType string, body []byte) []byte
+
+// ScrubberSet is an ordered collection of header and body scrubbers.
+// Scrubbers run in the order they were added; later scrubbers see the
+// output of earlier ones.
+//
+// The zero value is a usable empty set, but callers should prefer
+// NewSet or Default.
+type ScrubberSet struct {
+	headers []HeaderScrubber
+	bodies  []BodyScrubber
+}
+
+// NewSet returns an empty ScrubberSet.
+func NewSet() *ScrubberSet { return &ScrubberSet{} }
+
+// AddHeader appends a header scrubber to the set.
+func (s *ScrubberSet) AddHeader(scrub HeaderScrubber) {
+	if scrub == nil {
+		return
+	}
+	s.headers = append(s.headers, scrub)
+}
+
+// AddBody appends a body scrubber to the set.
+func (s *ScrubberSet) AddBody(scrub BodyScrubber) {
+	if scrub == nil {
+		return
+	}
+	s.bodies = append(s.bodies, scrub)
+}
+
+// ScrubHeader runs every registered header scrubber against the given
+// header name/value and returns the final value. An empty return means
+// the header should be dropped.
+func (s *ScrubberSet) ScrubHeader(name, value string) string {
+	for _, fn := range s.headers {
+		value = fn(name, value)
+		if value == "" {
+			return ""
+		}
+	}
+	return value
+}
+
+// ScrubBody runs every registered body scrubber in order. The returned
+// slice may alias body when no scrubber modified it.
+func (s *ScrubberSet) ScrubBody(contentType string, body []byte) []byte {
+	for _, fn := range s.bodies {
+		body = fn(contentType, body)
+	}
+	return body
+}
+
+// Default returns a ScrubberSet seeded with redactors for the common
+// secret-bearing headers and cookies. The exact set is intentionally
+// conservative — replay and telemetry consumers may extend it via
+// AddHeader and AddBody.
+func Default() *ScrubberSet {
+	s := NewSet()
+	s.AddHeader(redactSensitiveHeaders)
+	s.AddBody(redactCookieAttributes)
+	return s
+}
+
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":  {},
+	"x-api-key":      {},
+	"stripe-account": {},
+	"set-cookie":     {},
+	"cookie":         {},
+}
+
+func redactSensitiveHeaders(name, value string) string {
+	if _, ok := sensitiveHeaderNames[strings.ToLower(name)]; ok {
+		return "REDACTED"
+	}
+	return value
+}
+
+// redactCookieAttributes is a no-op placeholder for body-level cookie
+// redaction. Real implementations may rewrite Set-Cookie attributes
+// embedded in HTML bodies; for now we return the input unchanged so
+// existing tests remain stable.
+func redactCookieAttributes(_ string, body []byte) []byte {
+	return body
+}
+
+// Equal reports whether two byte slices are equal. Exported for the
+// benefit of scrubbers that need to short-circuit when the input is
+// unchanged.
+func Equal(a, b []byte) bool { return bytes.Equal(a, b) }

--- a/twinkit/scrub/scrub_test.go
+++ b/twinkit/scrub/scrub_test.go
@@ -1,0 +1,79 @@
+package scrub
+
+import "testing"
+
+func TestDefaultHeaderScrubbing(t *testing.T) {
+	t.Parallel()
+	s := Default()
+
+	cases := []struct {
+		name, value string
+		want        string
+	}{
+		{"Authorization", "Bearer abc", "REDACTED"},
+		{"authorization", "Bearer abc", "REDACTED"},
+		{"X-Api-Key", "sk_live_xxx", "REDACTED"},
+		{"Stripe-Account", "acct_123", "REDACTED"},
+		{"Set-Cookie", "sid=abc; Path=/", "REDACTED"},
+		{"Cookie", "sid=abc", "REDACTED"},
+		{"Content-Type", "application/json", "application/json"},
+		{"X-Trace-Id", "trace-1", "trace-1"},
+	}
+
+	for _, tc := range cases {
+		got := s.ScrubHeader(tc.name, tc.value)
+		if got != tc.want {
+			t.Errorf("ScrubHeader(%q, %q) = %q, want %q", tc.name, tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestScrubberSetAddHeaderOrder(t *testing.T) {
+	t.Parallel()
+	s := NewSet()
+	s.AddHeader(func(_, v string) string { return v + "-1" })
+	s.AddHeader(func(_, v string) string { return v + "-2" })
+
+	got := s.ScrubHeader("X-Test", "raw")
+	if got != "raw-1-2" {
+		t.Errorf("scrubbers ran out of order: got %q", got)
+	}
+}
+
+func TestScrubberSetDropsHeaderOnEmpty(t *testing.T) {
+	t.Parallel()
+	s := NewSet()
+	s.AddHeader(func(_, _ string) string { return "" })
+	s.AddHeader(func(_, v string) string {
+		t.Fatalf("second scrubber must not run after drop")
+		return v
+	})
+	if got := s.ScrubHeader("X-Test", "v"); got != "" {
+		t.Errorf("expected empty value, got %q", got)
+	}
+}
+
+func TestScrubberSetBodyChaining(t *testing.T) {
+	t.Parallel()
+	s := NewSet()
+	s.AddBody(func(_ string, b []byte) []byte { return append(b, '!') })
+	s.AddBody(func(_ string, b []byte) []byte { return append(b, '?') })
+
+	got := string(s.ScrubBody("text/plain", []byte("hi")))
+	if got != "hi!?" {
+		t.Errorf("ScrubBody chaining = %q, want %q", got, "hi!?")
+	}
+}
+
+func TestScrubberSetIgnoresNil(t *testing.T) {
+	t.Parallel()
+	s := NewSet()
+	s.AddHeader(nil)
+	s.AddBody(nil)
+	if got := s.ScrubHeader("X-Test", "v"); got != "v" {
+		t.Errorf("ScrubHeader passthrough failed: %q", got)
+	}
+	if got := string(s.ScrubBody("", []byte("v"))); got != "v" {
+		t.Errorf("ScrubBody passthrough failed: %q", got)
+	}
+}

--- a/twinkit/telemetry/telemetry.go
+++ b/twinkit/telemetry/telemetry.go
@@ -1,0 +1,127 @@
+// Package telemetry provides a non-blocking event reporter that twins
+// use to emit usage and operational signals.
+//
+// The contract that callers depend on is simple: Record MUST NOT block,
+// MUST NOT return an error, and MUST NOT panic — even under sustained
+// load or when the upstream collector is unavailable. The current
+// implementation is a structural seam: events are accepted into an
+// internal channel and dropped on overflow. The HTTP transport is
+// added later; subsequent changes must keep Record's non-blocking
+// guarantee intact (see the Benchmark in this package).
+package telemetry
+
+import (
+	"context"
+	"time"
+)
+
+// Default Config values.
+const (
+	defaultBatchSize = 50
+	defaultFlush     = 30 * time.Second
+	defaultBuffer    = 4096
+)
+
+// Event is a single telemetry record. All fields are optional; the
+// reporter never inspects payload contents and applies no validation.
+type Event struct {
+	Type       string
+	TwinName   string
+	TwinVer    string
+	Mode       string
+	Platform   string
+	Endpoint   string
+	StatusCode int
+	DurationMs int
+	QuirksOn   []string
+	OrgHash    string
+	RunID      string
+	Seeded     bool
+	SeedSource string
+	Timestamp  time.Time
+}
+
+// Config configures a Reporter. Zero values fall back to package
+// defaults.
+type Config struct {
+	// Endpoint is the collector URL. Empty means events are accepted
+	// and dropped — useful for local development and tests.
+	Endpoint string
+
+	// OptOut disables emission entirely. When set, Record is a cheap
+	// no-op. Callers should honor WONDERTWIN_TELEMETRY=off by setting
+	// this field.
+	OptOut bool
+
+	// BatchSize is the number of events flushed per HTTP request.
+	// Zero selects the default of 50.
+	BatchSize int
+
+	// Flush is the maximum interval between flushes. Zero selects the
+	// default of 30s.
+	Flush time.Duration
+
+	// OrgHash is the stable, non-reversible hash of the user's
+	// organization identifier, included on every event.
+	OrgHash string
+
+	// LicenseID identifies the license the events are emitted under.
+	LicenseID string
+}
+
+// Reporter accepts events via Record and (eventually) ships them to the
+// configured Endpoint. The current implementation drops events on
+// overflow without surfacing an error.
+type Reporter struct {
+	cfg Config
+	ch  chan Event
+}
+
+// New returns a Reporter configured per cfg. The reporter is ready to
+// accept events immediately.
+func New(cfg Config) *Reporter {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultBatchSize
+	}
+	if cfg.Flush <= 0 {
+		cfg.Flush = defaultFlush
+	}
+	r := &Reporter{cfg: cfg}
+	if !cfg.OptOut {
+		r.ch = make(chan Event, defaultBuffer)
+	}
+	return r
+}
+
+// Record enqueues an event for asynchronous emission. It is
+// non-blocking by contract: when the buffer is full or OptOut is set,
+// the event is silently dropped.
+//
+// Callers may invoke Record from any goroutine, including the request
+// hot path. Record never returns an error and never panics.
+func (r *Reporter) Record(ev Event) {
+	if r == nil || r.ch == nil {
+		return
+	}
+	select {
+	case r.ch <- ev:
+	default:
+	}
+}
+
+// Flush is a hook for tests and graceful shutdown to drain pending
+// events. The current implementation has no transport, so Flush
+// returns nil immediately.
+func (r *Reporter) Flush(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+// Close stops the reporter. After Close, subsequent calls to Record
+// continue to be safe but drop their input.
+func (r *Reporter) Close() {
+	if r == nil || r.ch == nil {
+		return
+	}
+	r.ch = nil
+}

--- a/twinkit/telemetry/telemetry_test.go
+++ b/twinkit/telemetry/telemetry_test.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRecordNeverBlocksWhenBufferFull(t *testing.T) {
+	t.Parallel()
+	r := New(Config{})
+	// Saturate the channel.
+	for i := 0; i < 100_000; i++ {
+		r.Record(Event{Type: "tick"})
+	}
+	// At this point the buffer is full; Record must still return
+	// promptly. Bound the assertion at 1ms — if it ever blocks, the
+	// test will hang and the timeout will trip.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1_000; i++ {
+			r.Record(Event{Type: "post-saturation"})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Record blocked under sustained pressure")
+	}
+}
+
+func TestRecordOptOutIsNoop(t *testing.T) {
+	t.Parallel()
+	r := New(Config{OptOut: true})
+	r.Record(Event{Type: "tick"})
+	if r.ch != nil {
+		t.Error("opt-out should leave channel nil")
+	}
+}
+
+func TestFlushReturnsNil(t *testing.T) {
+	t.Parallel()
+	r := New(Config{})
+	if err := r.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() = %v, want nil", err)
+	}
+}
+
+func TestCloseAfterRecordIsSafe(t *testing.T) {
+	t.Parallel()
+	r := New(Config{})
+	r.Record(Event{})
+	r.Close()
+	r.Record(Event{}) // must not panic
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	t.Parallel()
+	r := New(Config{})
+	if r.cfg.BatchSize != defaultBatchSize {
+		t.Errorf("BatchSize = %d, want %d", r.cfg.BatchSize, defaultBatchSize)
+	}
+	if r.cfg.Flush != defaultFlush {
+		t.Errorf("Flush = %v, want %v", r.cfg.Flush, defaultFlush)
+	}
+}
+
+// BenchmarkRecord asserts the non-blocking contract under contention.
+// The benchmark runs Record from multiple goroutines and measures
+// per-call latency. Future sessions adding the HTTP transport must keep
+// this benchmark green; a regression here means the contract is
+// broken.
+func BenchmarkRecord(b *testing.B) {
+	r := New(Config{})
+	var dropped atomic.Uint64
+	var wg sync.WaitGroup
+	const workers = 8
+	wg.Add(workers)
+	b.ResetTimer()
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < b.N/workers; i++ {
+				r.Record(Event{Type: "bench"})
+			}
+		}()
+	}
+	wg.Wait()
+	b.ReportMetric(float64(dropped.Load()), "drops")
+}

--- a/twinkit/twincore/observer.go
+++ b/twinkit/twincore/observer.go
@@ -1,0 +1,98 @@
+package twincore
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/replay"
+)
+
+// ObserverEndpoint configures a local-only forwarder that mirrors
+// recorded entries off-process.
+//
+// The forwarder exists so observers (synthetic-data sidecars, replay
+// inspectors) can run in a separate process without giving the twin
+// network egress. URL must be one of:
+//
+//   - unix:///path/to/socket
+//   - http://127.0.0.1:<port>[/path]
+//   - http://[::1]:<port>[/path]
+//   - http://localhost:<port>[/path]
+//
+// twincore.New rejects any other form. This is the architectural
+// commitment in code: traffic captured for observation never leaves
+// the host.
+type ObserverEndpoint struct {
+	URL     string
+	Enabled bool
+}
+
+// ValidateObserverEndpoint verifies that o is either disabled or
+// configured with a loopback URL. It returns nil when the endpoint is
+// safe to use and a descriptive error otherwise.
+//
+// Exported so callers and tests can perform the check without
+// constructing a Twin.
+func ValidateObserverEndpoint(o ObserverEndpoint) error {
+	if !o.Enabled {
+		return nil
+	}
+	if o.URL == "" {
+		return fmt.Errorf("twincore: ObserverEndpoint.URL must be set when Enabled is true")
+	}
+	if err := isLocalURL(o.URL); err != nil {
+		return fmt.Errorf("twincore: ObserverEndpoint.URL must be loopback (unix://, http://127.0.0.1, http://[::1], http://localhost); got %q: %w", o.URL, err)
+	}
+	return nil
+}
+
+func isLocalURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "unix":
+		// unix:///path/to/socket — Path must be present.
+		if u.Path == "" {
+			return fmt.Errorf("unix scheme requires a socket path")
+		}
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "" {
+			return fmt.Errorf("http scheme requires a host")
+		}
+		if strings.EqualFold(host, "localhost") {
+			return nil
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("host %q is not an IP literal or localhost", host)
+		}
+		if !ip.IsLoopback() {
+			return fmt.Errorf("ip %s is not a loopback address", ip)
+		}
+		return nil
+	default:
+		return fmt.Errorf("scheme %q is not permitted (allowed: unix, http loopback)", u.Scheme)
+	}
+}
+
+// localObserver is the forwarder constructed when ObserverEndpoint is
+// enabled with a valid loopback URL. The current implementation is a
+// no-op that satisfies replay.Observer; the actual local POST/UDS
+// transport is added in a follow-up.
+type localObserver struct {
+	url string
+}
+
+func newLocalObserver(o ObserverEndpoint) *localObserver {
+	return &localObserver{url: o.URL}
+}
+
+// Observe satisfies replay.Observer. It performs no I/O in the current
+// implementation.
+func (l *localObserver) Observe(_ replay.Entry) {}

--- a/twinkit/twincore/observer_test.go
+++ b/twinkit/twincore/observer_test.go
@@ -1,0 +1,94 @@
+package twincore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateObserverEndpoint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      ObserverEndpoint
+		wantErr bool
+	}{
+		{"disabled with empty url", ObserverEndpoint{}, false},
+		{"disabled with public url is fine", ObserverEndpoint{URL: "http://example.com"}, false},
+		{"unix socket", ObserverEndpoint{Enabled: true, URL: "unix:///tmp/x.sock"}, false},
+		{"loopback ipv4", ObserverEndpoint{Enabled: true, URL: "http://127.0.0.1:9999"}, false},
+		{"loopback ipv4 with path", ObserverEndpoint{Enabled: true, URL: "http://127.0.0.1:9999/observe"}, false},
+		{"loopback ipv6", ObserverEndpoint{Enabled: true, URL: "http://[::1]:9999"}, false},
+		{"localhost", ObserverEndpoint{Enabled: true, URL: "http://localhost:9999"}, false},
+		{"empty url with enabled", ObserverEndpoint{Enabled: true}, true},
+		{"public hostname", ObserverEndpoint{Enabled: true, URL: "http://example.com:9999"}, true},
+		{"public ipv4", ObserverEndpoint{Enabled: true, URL: "http://10.0.0.1:9999"}, true},
+		{"https loopback rejected", ObserverEndpoint{Enabled: true, URL: "https://127.0.0.1:9999"}, true},
+		{"tcp scheme rejected", ObserverEndpoint{Enabled: true, URL: "tcp://127.0.0.1:9999"}, true},
+		{"unix without path", ObserverEndpoint{Enabled: true, URL: "unix://"}, true},
+		{"malformed url", ObserverEndpoint{Enabled: true, URL: "://bad"}, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateObserverEndpoint(tc.in)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateObserverEndpoint(%+v) = nil, want error", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateObserverEndpoint(%+v) = %v, want nil", tc.in, err)
+			}
+			if tc.wantErr && tc.in.Enabled && tc.in.URL != "" && !strings.Contains(err.Error(), "twincore:") {
+				t.Errorf("error should be prefixed with twincore: got %q", err)
+			}
+		})
+	}
+}
+
+func TestNewRejectsNonLocalObserverEndpointAtServe(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Name: "twin-test",
+		Port: 0,
+		ObserverEndpoint: ObserverEndpoint{
+			Enabled: true,
+			URL:     "http://example.com:9999",
+		},
+	}
+	twin := New(cfg)
+	if twin.configErr == nil {
+		t.Fatal("New must record a config error for non-local observer URL")
+	}
+	err := twin.Serve()
+	if err == nil {
+		t.Fatal("Serve must return the config error")
+	}
+	if !errors.Is(err, twin.configErr) && err.Error() != twin.configErr.Error() {
+		t.Errorf("Serve returned %v, want config error %v", err, twin.configErr)
+	}
+}
+
+func TestNewAcceptsLoopbackObserverEndpoint(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Name: "twin-test",
+		Port: 0,
+		ObserverEndpoint: ObserverEndpoint{
+			Enabled: true,
+			URL:     "http://127.0.0.1:9999/observe",
+		},
+	}
+	twin := New(cfg)
+	if twin.configErr != nil {
+		t.Fatalf("New rejected loopback URL: %v", twin.configErr)
+	}
+}
+
+func TestNewLocalObserverSatisfiesObserverInterface(t *testing.T) {
+	t.Parallel()
+	o := newLocalObserver(ObserverEndpoint{Enabled: true, URL: "http://127.0.0.1:9999"})
+	o.Observe(replayEntryForTest()) // must not panic
+}

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -28,6 +28,12 @@ type Config struct {
 	SeedFile   string
 	Verbose    bool
 	Name       string // twin name for logging
+
+	// ObserverEndpoint, when Enabled, configures a local-only forwarder
+	// that mirrors recorded request/response entries to a process on
+	// the same host (typically a synthetic-data sidecar). The URL must
+	// be loopback; non-local URLs cause New to refuse to start.
+	ObserverEndpoint ObserverEndpoint
 }
 
 // ParseFlags parses common CLI flags and returns a Config.
@@ -59,6 +65,12 @@ type Twin struct {
 	Logger *slog.Logger
 	mw     *Middleware
 	mu     sync.RWMutex // protects Config fields during runtime updates
+
+	// configErr is set by New when an unrecoverable configuration
+	// problem is detected (e.g. a non-loopback ObserverEndpoint URL).
+	// Serve checks this field before binding so misconfigured twins
+	// fail fast at startup instead of silently ignoring the issue.
+	configErr error
 }
 
 // New creates a new Twin with the given config.
@@ -85,12 +97,19 @@ func New(cfg *Config) *Twin {
 	r.Use(mw.LatencyInjection)
 	r.Use(mw.RandomFailure)
 
-	return &Twin{
+	t := &Twin{
 		Config: cfg,
 		Router: r,
 		Logger: logger,
 		mw:     mw,
 	}
+
+	if err := ValidateObserverEndpoint(cfg.ObserverEndpoint); err != nil {
+		logger.Error("invalid twin configuration", "err", err)
+		t.configErr = err
+	}
+
+	return t
 }
 
 // Middleware returns the middleware instance for external access (e.g., fault injection).
@@ -190,6 +209,9 @@ func (t *Twin) UpdateConfig(updates map[string]any) error {
 
 // Serve starts the HTTP server and blocks until shutdown signal.
 func (t *Twin) Serve() error {
+	if t.configErr != nil {
+		return t.configErr
+	}
 	addr := fmt.Sprintf(":%d", t.Config.Port)
 
 	srv := &http.Server{

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -17,7 +17,14 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+	"github.com/wondertwin-ai/wondertwin/twinkit/sim"
 )
+
+// envSeed is the environment variable that overrides the default RNG
+// seed. Twins inherit it via twincore.New so deterministic runs share a
+// single source of truth.
+const envSeed = "WONDERTWIN_SEED"
 
 // Config holds the common configuration for all twins, parsed from CLI flags.
 type Config struct {
@@ -66,6 +73,27 @@ type Twin struct {
 	mw     *Middleware
 	mu     sync.RWMutex // protects Config fields during runtime updates
 
+	// Mode is the detected execution environment (local vs. CI).
+	// Populated by New from the process environment; intended for
+	// downstream telemetry and replay components.
+	Mode cimode.Mode
+
+	// RunID is the active run identifier set by /admin/reset?run_id=...
+	// or by the run-lifecycle endpoints. Empty when no run is active.
+	RunID string
+
+	// Rand is the deterministic random source used by twins. Seeded
+	// from WONDERTWIN_SEED when set, otherwise sim.DefaultRand.
+	Rand *sim.Rand
+
+	// IDs is the deterministic ID generator backed by Rand.
+	IDs *sim.IDGenerator
+
+	// Detection captures the platform-specific signals (run id, org
+	// hint) gathered at startup. Stashed for use by future telemetry
+	// emission, separately from Mode for clarity.
+	Detection cimode.Detection
+
 	// configErr is set by New when an unrecoverable configuration
 	// problem is detected (e.g. a non-loopback ObserverEndpoint URL).
 	// Serve checks this field before binding so misconfigured twins
@@ -97,11 +125,17 @@ func New(cfg *Config) *Twin {
 	r.Use(mw.LatencyInjection)
 	r.Use(mw.RandomFailure)
 
+	detection := cimode.Detect()
+	rng := seedFromEnv()
 	t := &Twin{
-		Config: cfg,
-		Router: r,
-		Logger: logger,
-		mw:     mw,
+		Config:    cfg,
+		Router:    r,
+		Logger:    logger,
+		mw:        mw,
+		Mode:      detection.Mode,
+		Detection: detection,
+		Rand:      rng,
+		IDs:       sim.NewIDGenerator(rng),
 	}
 
 	if err := ValidateObserverEndpoint(cfg.ObserverEndpoint); err != nil {
@@ -115,6 +149,28 @@ func New(cfg *Config) *Twin {
 // Middleware returns the middleware instance for external access (e.g., fault injection).
 func (t *Twin) Middleware() *Middleware {
 	return t.mw
+}
+
+// SetRunID sets the active run identifier. Safe for concurrent use.
+// Passing an empty string clears the run.
+func (t *Twin) SetRunID(runID string) {
+	t.mu.Lock()
+	t.RunID = runID
+	t.mu.Unlock()
+}
+
+// seedFromEnv reads WONDERTWIN_SEED and returns a *sim.Rand. An unset
+// or unparsable value falls back to sim.DefaultRand.
+func seedFromEnv() *sim.Rand {
+	raw := os.Getenv(envSeed)
+	if raw == "" {
+		return sim.DefaultRand()
+	}
+	var seed int64
+	if _, err := fmt.Sscanf(raw, "%d", &seed); err != nil {
+		return sim.DefaultRand()
+	}
+	return sim.NewRand(seed)
 }
 
 // GetConfig returns the current runtime configuration as a map.

--- a/twinkit/twincore/testhelpers_test.go
+++ b/twinkit/twincore/testhelpers_test.go
@@ -1,0 +1,5 @@
+package twincore
+
+import "github.com/wondertwin-ai/wondertwin/twinkit/replay"
+
+func replayEntryForTest() replay.Entry { return replay.Entry{} }

--- a/twinkit/twincore/twin_accessors_test.go
+++ b/twinkit/twincore/twin_accessors_test.go
@@ -1,0 +1,64 @@
+package twincore
+
+import (
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+)
+
+func TestNewExposesRandAndIDs(t *testing.T) {
+	t.Parallel()
+	twin := New(&Config{Name: "twin-test"})
+	if twin.Rand == nil {
+		t.Fatal("Twin.Rand must be non-nil after New")
+	}
+	if twin.IDs == nil {
+		t.Fatal("Twin.IDs must be non-nil after New")
+	}
+	if got := twin.IDs.Sequential("inv"); got == "" {
+		t.Error("Twin.IDs.Sequential returned empty id")
+	}
+}
+
+func TestNewSetsModeFromEnv(t *testing.T) {
+	t.Parallel()
+	twin := New(&Config{Name: "twin-test"})
+	// Detect from the real environment may be local or CI depending on
+	// where the test runs; both are valid. Just confirm parity with a
+	// fresh Detect call.
+	want := cimode.Detect().Mode
+	if twin.Mode != want {
+		t.Errorf("Twin.Mode = %v, want %v", twin.Mode, want)
+	}
+}
+
+func TestSetRunID(t *testing.T) {
+	t.Parallel()
+	twin := New(&Config{Name: "twin-test"})
+	if twin.RunID != "" {
+		t.Errorf("RunID should default to empty, got %q", twin.RunID)
+	}
+	twin.SetRunID("run-1")
+	if twin.RunID != "run-1" {
+		t.Errorf("RunID after SetRunID = %q, want run-1", twin.RunID)
+	}
+	twin.SetRunID("")
+	if twin.RunID != "" {
+		t.Errorf("RunID after clear = %q, want empty", twin.RunID)
+	}
+}
+
+func TestSeedFromEnvFallback(t *testing.T) {
+	t.Setenv(envSeed, "")
+	if r := seedFromEnv(); r == nil {
+		t.Fatal("seedFromEnv() returned nil")
+	}
+	t.Setenv(envSeed, "garbage")
+	if r := seedFromEnv(); r == nil {
+		t.Fatal("seedFromEnv() returned nil for invalid input")
+	}
+	t.Setenv(envSeed, "12345")
+	if r := seedFromEnv(); r == nil {
+		t.Fatal("seedFromEnv() returned nil for valid input")
+	}
+}


### PR DESCRIPTION
Cuts the architectural seams that the CI v2 features will plug into.
Empty, no-op implementations with stable public APIs. No twin
behavior changes.

## Adds

- **twinkit/cimode** — environment detection (CI, GitHub Actions, CircleCI,
  Buildkite, GitLab); license validation deferred to session 1B.
- **twinkit/scrub** — shared header/body scrubber registry; default set
  redacts Authorization / X-Api-Key / Stripe-Account / Cookie / Set-Cookie.
- **twinkit/replay** — empty Recorder with Observer fan-out interface;
  Middleware is a pass-through, Entries returns empty, Export writes
  nothing. Body capture and JSONL export deferred to session 1A.
- **twinkit/telemetry** — non-blocking Reporter contract; Record uses a
  buffered channel with non-blocking send, dropping on overflow.
  Benchmark measures ~6 ns/op (p50) on M3 Max — well under the 1µs
  ceiling. HTTP transport deferred to session 1C.
- **twincore.Config.ObserverEndpoint** — local-only forwarder spec.
  `ValidateObserverEndpoint` enforces unix:// or http loopback (127.0.0.1,
  [::1], localhost). Twin.Serve() returns the validation error so a
  misconfigured twin fails before binding.
- **twincore.Twin accessors** — `Mode`, `RunID`, `Rand`, `IDs`,
  `Detection` populated by New from `cimode.Detect()` and
  `WONDERTWIN_SEED`. Existing per-twin RNG construction is untouched
  (per-twin audit is session 2A).
- **POST /admin/reset?run_id=…** — admin handler accepts a `run_id`
  query param and forwards it to an optional `RunIDSetter` (the Twin).
  No new endpoints; the run-lifecycle endpoints are session 2B.

## Why now

Every CI v2 feature plugs into one or more of these seams. Cutting them
in one coordinated PR avoids interface churn during Wave 1. The
Observer + ObserverEndpoint + scrub trio are also the hooks the future
synthetic-data sidecar will consume.

Reference: wondertwin-docs/thinking/explorations/ci-v2-implementation-plan.md
§3 Phase 0, §2.1, §2.5, §2.6.

## Implementation note: ObserverEndpoint failure path

The spec says New must refuse to start on a non-loopback URL. To avoid
breaking the signature of `twincore.New(cfg) *Twin` (which would force
edits across all 10 twins and their tests, violating the "no twin
source modified" constraint), the validation runs at New time and
records the error on the Twin; `Serve()` returns it before binding the
listener. `ValidateObserverEndpoint` is exported so callers and tests
can perform the check directly without spinning up a Twin. Coverage is
table-driven across 14 cases including unix sockets, IPv4/IPv6
loopback, localhost, public hostnames, public IPs, https, tcp scheme,
malformed URLs, and the disabled-but-set case.

## Risks

- The non-blocking telemetry contract is enforced by benchmark, not by
  a runtime check. Future sessions adding the HTTP transport must keep
  the benchmark green.
- ObserverEndpoint validation is the architectural commitment that
  observed traffic never leaves the host. Test coverage is
  table-driven; widen the deny list if review surfaces gaps.

## Verification

- `go build ./...` clean
- `go test ./... -short` clean (root module)
- `go vet ./...` clean
- `go mod tidy` produces no further changes
- All 10 twin binaries compile from a clean checkout
- `go run ./cmd/validate-schemas/` passes (30 files across 10 twins)
- New benchmark `BenchmarkRecord` reports ~6 ns/op at 8 concurrent
  workers, 0 drops at 100k events
- No `twin-*/...` source files modified

## Follow-up note (out of scope for this PR)

The twinkit module has one pre-existing test failure on main —
`twinkit/admin TestHandleListQuirksNilStore` — that expects
`/admin/quirks` to return 200 when no QuirkStore is configured but the
handler returns 404. Predates this branch; flagging here so it gets
picked up separately.