### PR TITLE
fix: return empty list from /admin/quirks when no store is configured

### DIFF
--- a/twinkit/admin/admin.go
+++ b/twinkit/admin/admin.go
@@ -281,7 +281,7 @@ func (h *Handler) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleListQuirks(w http.ResponseWriter, r *http.Request) {
 	if h.quirks == nil {
-		twincore.Error(w, http.StatusNotFound, "quirk store not configured")
+		twincore.JSON(w, http.StatusOK, []QuirkStatus{})
 		return
 	}
 	twincore.JSON(w, http.StatusOK, h.quirks.ListQuirks())


### PR DESCRIPTION
Fixes pre-existing TestHandleListQuirksNilStore. The handler was
returning 404 when no QuirkStore was registered; the test expects
200 OK with an empty list.

The test is correct. The endpoint exists; an empty store should
yield an empty collection, not a 404 (which reads as "endpoint
undefined"). This is the right contract for community twins, which
will always have a nil quirk store, and for replay capture in
CI v2 (Entry.QuirksActive must be [] for community twins, not an
error).

handleEnableQuirk and handleDisableQuirk remain 404 on nil store —
enabling a quirk that has nowhere to live is genuinely undefined.

Surfaced as a follow-up from PR #225.