### PR TITLE
feat: add lifecycle fields to registry schema (v2)

### DIFF
--- a/cmd/gen-registry/lifecycle_test.go
+++ b/cmd/gen-registry/lifecycle_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmitsLifecycleFromFlags(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe",
+		"--version", "1.0.0",
+		"--checksums-file", checksumsPath,
+		"--registry-file", registryPath,
+		"--tier", "commercial",
+		"--release-type", "beta",
+		"--maintenance-status", "security_only",
+		"--maintenance-until", "2027-01-01",
+		"--bsl-expiry-date", "2030-01-01",
+		"--changelog", "initial release",
+		"--breaking-change", "removed legacy auth",
+		"--breaking-change", "renamed Charge.Source -> PaymentMethod",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatal(err)
+	}
+
+	if reg.SchemaVersion != 2 {
+		t.Errorf("schema_version = %d, want 2", reg.SchemaVersion)
+	}
+
+	v := reg.Twins["stripe"].Versions["1.0.0"]
+	if v.ReleaseType != "beta" {
+		t.Errorf("release_type = %q, want beta", v.ReleaseType)
+	}
+	if v.MaintenanceStatus != "security_only" {
+		t.Errorf("maintenance_status = %q", v.MaintenanceStatus)
+	}
+	if v.MaintenanceUntil != "2027-01-01" {
+		t.Errorf("maintenance_until = %q", v.MaintenanceUntil)
+	}
+	if v.BSLExpiryDate != "2030-01-01" {
+		t.Errorf("bsl_expiry_date = %q", v.BSLExpiryDate)
+	}
+	if v.Changelog != "initial release" {
+		t.Errorf("changelog = %q", v.Changelog)
+	}
+	if len(v.BreakingChanges) != 2 {
+		t.Errorf("breaking_changes len = %d", len(v.BreakingChanges))
+	}
+}
+
+func TestRejectsInvalidReleaseType(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+		"--release-type", "experimental",
+	})
+	if err == nil || !strings.Contains(err.Error(), "release_type") {
+		t.Fatalf("expected release_type error, got %v", err)
+	}
+}
+
+func TestRejectsInvalidDate(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+		"--maintenance-until", "next-tuesday",
+	})
+	if err == nil || !strings.Contains(err.Error(), "maintenance_until") {
+		t.Fatalf("expected maintenance_until error, got %v", err)
+	}
+}
+
+func TestRejectsBSLOnFreeTier(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+		"--tier", "community",
+		"--bsl-expiry-date", "2030-01-01",
+	})
+	if err == nil || !strings.Contains(err.Error(), "commercial") {
+		t.Fatalf("expected commercial-tier-only error, got %v", err)
+	}
+}
+
+func TestManifestLifecycleSeedsEmittedVersion(t *testing.T) {
+	dir := t.TempDir()
+	twinDir := filepath.Join(dir, "twin-stripe")
+	os.MkdirAll(twinDir, 0o755)
+	manifest := `{
+  "twin": "stripe",
+  "description": "Stripe",
+  "category": "payments",
+  "sdk_target": {"primary": {"package": "github.com/stripe/stripe-go", "version": "v80"}},
+  "lifecycle": {
+    "release_type": "rc",
+    "maintenance_status": "active",
+    "breaking_changes": ["foo"]
+  }
+}`
+	os.WriteFile(filepath.Join(twinDir, "twin-manifest.json"), []byte(manifest), 0o644)
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	if v.ReleaseType != "rc" {
+		t.Errorf("manifest release_type not seeded; got %q", v.ReleaseType)
+	}
+	if len(v.BreakingChanges) != 1 || v.BreakingChanges[0] != "foo" {
+		t.Errorf("breaking_changes = %v", v.BreakingChanges)
+	}
+}
+
+func TestFlagOverridesManifestLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	twinDir := filepath.Join(dir, "twin-stripe")
+	os.MkdirAll(twinDir, 0o755)
+	manifest := `{
+  "twin": "stripe",
+  "description": "Stripe",
+  "category": "payments",
+  "sdk_target": {"primary": {"package": "github.com/stripe/stripe-go", "version": "v80"}},
+  "lifecycle": {"release_type": "beta"}
+}`
+	os.WriteFile(filepath.Join(twinDir, "twin-manifest.json"), []byte(manifest), 0o644)
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+		"--release-type", "stable",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	if v.ReleaseType != "stable" {
+		t.Errorf("flag override failed; got %q", v.ReleaseType)
+	}
+}
+
+func TestChangelogFromFile(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	changelogPath := filepath.Join(dir, "CHANGELOG.md")
+	os.WriteFile(changelogPath, []byte("# v0.1.0\n\nFirst release.\n"), 0o644)
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+		"--changelog", "@" + changelogPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	if !strings.Contains(v.Changelog, "First release") {
+		t.Errorf("changelog file not loaded; got %q", v.Changelog)
+	}
+}

--- a/cmd/gen-registry/main.go
+++ b/cmd/gen-registry/main.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/registry"
 )
 
 // Registry mirrors internal/registry.Registry for JSON serialisation.
@@ -31,18 +33,36 @@ type TwinEntry struct {
 	Versions     map[string]Version `json:"versions"`
 }
 
-// Version mirrors internal/registry.Version.
+// Version mirrors internal/registry.Version, including schema-v2
+// lifecycle fields. All lifecycle fields are omitempty so emitted
+// entries remain compatible with v1 consumers.
 type Version struct {
-	Released   string            `json:"released"`
-	SDKPackage string            `json:"sdk_package"`
-	SDKVersion string            `json:"sdk_version"`
-	APIVersion string            `json:"api_version,omitempty"`
-	Tier       string            `json:"tier"`
-	Checksums  map[string]string `json:"checksums"`
-	BinaryURLs map[string]string `json:"binary_urls"`
+	Released          string            `json:"released"`
+	SDKPackage        string            `json:"sdk_package"`
+	SDKVersion        string            `json:"sdk_version"`
+	APIVersion        string            `json:"api_version,omitempty"`
+	Tier              string            `json:"tier"`
+	Checksums         map[string]string `json:"checksums"`
+	BinaryURLs        map[string]string `json:"binary_urls"`
+	ReleaseType       string            `json:"release_type,omitempty"`
+	MaintenanceStatus string            `json:"maintenance_status,omitempty"`
+	MaintenanceUntil  string            `json:"maintenance_until,omitempty"`
+	BSLExpiryDate     string            `json:"bsl_expiry_date,omitempty"`
+	Changelog         string            `json:"changelog,omitempty"`
+	BreakingChanges   []string          `json:"breaking_changes,omitempty"`
 }
 
+// stringSliceFlag accumulates repeated --breaking-change values.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string     { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error { *s = append(*s, v); return nil }
+
 // TwinManifest represents the relevant fields from twin-manifest.json.
+//
+// The Lifecycle block is optional; when present its values seed the
+// emitted Version's lifecycle metadata. CLI flags override anything
+// supplied here.
 type TwinManifest struct {
 	Twin        string `json:"twin"`
 	Description string `json:"description"`
@@ -54,6 +74,25 @@ type TwinManifest struct {
 			APIVersion string `json:"api_version"`
 		} `json:"primary"`
 	} `json:"sdk_target"`
+	Lifecycle *struct {
+		ReleaseType       string   `json:"release_type"`
+		MaintenanceStatus string   `json:"maintenance_status"`
+		MaintenanceUntil  string   `json:"maintenance_until"`
+		BSLExpiryDate     string   `json:"bsl_expiry_date"`
+		Changelog         string   `json:"changelog"`
+		BreakingChanges   []string `json:"breaking_changes"`
+	} `json:"lifecycle,omitempty"`
+}
+
+// lifecycleInputs aggregates resolved lifecycle metadata from manifest
+// + CLI flags after validation.
+type lifecycleInputs struct {
+	releaseType       string
+	maintenanceStatus string
+	maintenanceUntil  string
+	bslExpiryDate     string
+	changelog         string
+	breakingChanges   []string
 }
 
 // nowFunc is overridden in tests to produce deterministic dates.
@@ -76,6 +115,14 @@ func run(args []string) error {
 	prerelease := fs.Bool("prerelease", false, "add version without updating latest")
 	tier := fs.String("tier", "community", "twin tier: community or commercial")
 	manifestFile := fs.String("manifest-file", "", "explicit path to twin-manifest.json (default: twin-<name>/twin-manifest.json)")
+
+	releaseType := fs.String("release-type", "", "release stream: stable, beta, or rc (overrides manifest)")
+	maintenanceStatus := fs.String("maintenance-status", "", "maintenance status: active, security_only, or eol (overrides manifest)")
+	maintenanceUntil := fs.String("maintenance-until", "", "maintenance end date in ISO 8601 (YYYY-MM-DD) (overrides manifest)")
+	bslExpiryDate := fs.String("bsl-expiry-date", "", "BSL expiry date in ISO 8601 (commercial tier only) (overrides manifest)")
+	changelogFlag := fs.String("changelog", "", "changelog text or @path/to/file (overrides manifest)")
+	var breakingChanges stringSliceFlag
+	fs.Var(&breakingChanges, "breaking-change", "breaking change description; may be repeated (overrides manifest)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -107,10 +154,23 @@ func run(args []string) error {
 		return fmt.Errorf("loading registry: %w", err)
 	}
 
-	// 4. Build version entry
-	ver := buildVersion(*twin, *version, *repo, *tier, manifest, checksums)
+	// 4. Resolve lifecycle metadata from manifest + flag overrides.
+	lc, err := resolveLifecycle(manifest, *tier, lifecycleFlags{
+		releaseType:       *releaseType,
+		maintenanceStatus: *maintenanceStatus,
+		maintenanceUntil:  *maintenanceUntil,
+		bslExpiryDate:     *bslExpiryDate,
+		changelog:         *changelogFlag,
+		breakingChanges:   []string(breakingChanges),
+	})
+	if err != nil {
+		return fmt.Errorf("invalid lifecycle metadata: %w", err)
+	}
 
-	// 5. Upsert into registry
+	// 5. Build version entry
+	ver := buildVersion(*twin, *version, *repo, *tier, manifest, checksums, lc)
+
+	// 6. Upsert into registry
 	upsert(reg, *twin, *version, *tier, manifest, ver, *prerelease)
 
 	// 6. Write back
@@ -198,7 +258,7 @@ func loadRegistry(path string) (*Registry, error) {
 	return &reg, nil
 }
 
-func buildVersion(twin, version, repo, tier string, manifest *TwinManifest, checksums map[string]string) Version {
+func buildVersion(twin, version, repo, tier string, manifest *TwinManifest, checksums map[string]string, lc lifecycleInputs) Version {
 	platforms := []string{"darwin-amd64", "darwin-arm64", "linux-amd64", "linux-arm64"}
 	binaryURLs := make(map[string]string, len(platforms))
 	for _, p := range platforms {
@@ -209,14 +269,120 @@ func buildVersion(twin, version, repo, tier string, manifest *TwinManifest, chec
 	}
 
 	return Version{
-		Released:   nowFunc().UTC().Format("2006-01-02"),
-		SDKPackage: manifest.SDKTarget.Primary.Package,
-		SDKVersion: manifest.SDKTarget.Primary.Version,
-		APIVersion: manifest.SDKTarget.Primary.APIVersion,
-		Tier:       tier,
-		Checksums:  checksums,
-		BinaryURLs: binaryURLs,
+		Released:          nowFunc().UTC().Format("2006-01-02"),
+		SDKPackage:        manifest.SDKTarget.Primary.Package,
+		SDKVersion:        manifest.SDKTarget.Primary.Version,
+		APIVersion:        manifest.SDKTarget.Primary.APIVersion,
+		Tier:              tier,
+		Checksums:         checksums,
+		BinaryURLs:        binaryURLs,
+		ReleaseType:       lc.releaseType,
+		MaintenanceStatus: lc.maintenanceStatus,
+		MaintenanceUntil:  lc.maintenanceUntil,
+		BSLExpiryDate:     lc.bslExpiryDate,
+		Changelog:         lc.changelog,
+		BreakingChanges:   lc.breakingChanges,
 	}
+}
+
+// lifecycleFlags carries CLI-supplied lifecycle overrides into
+// resolveLifecycle.
+type lifecycleFlags struct {
+	releaseType       string
+	maintenanceStatus string
+	maintenanceUntil  string
+	bslExpiryDate     string
+	changelog         string
+	breakingChanges   []string
+}
+
+// resolveLifecycle reconciles manifest-supplied lifecycle metadata with
+// CLI overrides and validates the result. Manifest values are used
+// where flags are absent; flag values override manifest values when
+// non-empty.
+func resolveLifecycle(manifest *TwinManifest, tier string, flags lifecycleFlags) (lifecycleInputs, error) {
+	var lc lifecycleInputs
+	if manifest != nil && manifest.Lifecycle != nil {
+		lc.releaseType = manifest.Lifecycle.ReleaseType
+		lc.maintenanceStatus = manifest.Lifecycle.MaintenanceStatus
+		lc.maintenanceUntil = manifest.Lifecycle.MaintenanceUntil
+		lc.bslExpiryDate = manifest.Lifecycle.BSLExpiryDate
+		lc.changelog = manifest.Lifecycle.Changelog
+		lc.breakingChanges = append([]string(nil), manifest.Lifecycle.BreakingChanges...)
+	}
+	if flags.releaseType != "" {
+		lc.releaseType = flags.releaseType
+	}
+	if flags.maintenanceStatus != "" {
+		lc.maintenanceStatus = flags.maintenanceStatus
+	}
+	if flags.maintenanceUntil != "" {
+		lc.maintenanceUntil = flags.maintenanceUntil
+	}
+	if flags.bslExpiryDate != "" {
+		lc.bslExpiryDate = flags.bslExpiryDate
+	}
+	if flags.changelog != "" {
+		resolved, err := loadChangelog(flags.changelog)
+		if err != nil {
+			return lifecycleInputs{}, err
+		}
+		lc.changelog = resolved
+	}
+	if len(flags.breakingChanges) > 0 {
+		lc.breakingChanges = append([]string(nil), flags.breakingChanges...)
+	}
+
+	if err := validateLifecycle(lc, tier); err != nil {
+		return lifecycleInputs{}, err
+	}
+	return lc, nil
+}
+
+func validateLifecycle(lc lifecycleInputs, tier string) error {
+	switch lc.releaseType {
+	case "", registry.ReleaseTypeStable, registry.ReleaseTypeBeta, registry.ReleaseTypeRC:
+	default:
+		return fmt.Errorf("release_type %q must be one of stable, beta, rc", lc.releaseType)
+	}
+	switch lc.maintenanceStatus {
+	case "", registry.MaintenanceActive, registry.MaintenanceSecurityOnly, registry.MaintenanceEOL:
+	default:
+		return fmt.Errorf("maintenance_status %q must be one of active, security_only, eol", lc.maintenanceStatus)
+	}
+	if lc.maintenanceUntil != "" {
+		if _, err := time.Parse("2006-01-02", lc.maintenanceUntil); err != nil {
+			return fmt.Errorf("maintenance_until %q is not ISO 8601 (YYYY-MM-DD)", lc.maintenanceUntil)
+		}
+	}
+	if lc.bslExpiryDate != "" {
+		if _, err := time.Parse("2006-01-02", lc.bslExpiryDate); err != nil {
+			return fmt.Errorf("bsl_expiry_date %q is not ISO 8601 (YYYY-MM-DD)", lc.bslExpiryDate)
+		}
+		if tier != "commercial" {
+			return fmt.Errorf("bsl_expiry_date is only meaningful for commercial-tier twins (got tier=%q)", tier)
+		}
+	}
+	for i, bc := range lc.breakingChanges {
+		if strings.TrimSpace(bc) == "" {
+			return fmt.Errorf("breaking_changes[%d] is empty", i)
+		}
+	}
+	return nil
+}
+
+// loadChangelog reads a changelog string. A leading "@" treats the rest
+// of the value as a path to read from.
+func loadChangelog(s string) (string, error) {
+	if !strings.HasPrefix(s, "@") {
+		return s, nil
+	}
+	path := strings.TrimPrefix(s, "@")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading changelog file: %w", err)
+	}
+	return string(data), nil
 }
 
 func upsert(reg *Registry, twin, version, tier string, manifest *TwinManifest, ver Version, prerelease bool) {
@@ -250,6 +416,7 @@ func upsert(reg *Registry, twin, version, tier string, manifest *TwinManifest, v
 }
 
 func writeRegistry(path string, reg *Registry) error {
+	reg.SchemaVersion = registry.CurrentSchemaVersion
 	data, err := json.MarshalIndent(reg, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/gen-registry/main_test.go
+++ b/cmd/gen-registry/main_test.go
@@ -92,8 +92,8 @@ func TestCreateRegistryFromScratch(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
-	if reg.SchemaVersion != 1 {
-		t.Errorf("schema_version = %d, want 1", reg.SchemaVersion)
+	if reg.SchemaVersion != 2 {
+		t.Errorf("schema_version = %d, want 2", reg.SchemaVersion)
 	}
 	entry, ok := reg.Twins["stripe"]
 	if !ok {

--- a/cmd/verify-registry/lifecycle_test.go
+++ b/cmd/verify-registry/lifecycle_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func registryWith(v versionDef) registrySchema {
+	r := validRegistry()
+	cur := r.Twins["stripe"].Versions["0.1.0"]
+	v.Released = cur.Released
+	v.SDKPackage = cur.SDKPackage
+	v.SDKVersion = cur.SDKVersion
+	v.Tier = cur.Tier
+	v.Checksums = cur.Checksums
+	v.BinaryURLs = cur.BinaryURLs
+	r.Twins["stripe"].Versions["0.1.0"] = v
+	return r
+}
+
+func runRegistry(t *testing.T, reg registrySchema) []checkResult {
+	t.Helper()
+	binaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(binaryServer.Close)
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	for _, p := range requiredPlatforms {
+		v.BinaryURLs[p] = binaryServer.URL + "/" + p
+	}
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+
+	data, _ := json.Marshal(reg)
+	regServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(data)
+	}))
+	t.Cleanup(regServer.Close)
+	return run(regServer.URL)
+}
+
+func failedCheck(results []checkResult, name string) *checkResult {
+	for i := range results {
+		if results[i].Name == name && !results[i].Passed {
+			return &results[i]
+		}
+	}
+	return nil
+}
+
+func TestVerifyAcceptsV1WithoutLifecycle(t *testing.T) {
+	results := runRegistry(t, validRegistry())
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("v1 fixture should pass cleanly; %s failed: %s", r.Name, r.Detail)
+		}
+	}
+}
+
+func TestVerifyAcceptsValidV2(t *testing.T) {
+	reg := registryWith(versionDef{
+		ReleaseType:       "beta",
+		MaintenanceStatus: "security_only",
+		MaintenanceUntil:  "2027-01-01",
+		BreakingChanges:   []string{"removed legacy auth"},
+	})
+	reg.SchemaVersion = 2
+	results := runRegistry(t, reg)
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("valid v2 fixture should pass cleanly; %s failed: %s", r.Name, r.Detail)
+		}
+	}
+}
+
+func TestVerifyRejectsInvalidReleaseType(t *testing.T) {
+	reg := registryWith(versionDef{ReleaseType: "experimental"})
+	results := runRegistry(t, reg)
+	if failedCheck(results, "[stripe@0.1.0] release_type") == nil {
+		t.Error("expected release_type check to fail")
+	}
+}
+
+func TestVerifyRejectsInvalidMaintenanceStatus(t *testing.T) {
+	reg := registryWith(versionDef{MaintenanceStatus: "yolo"})
+	results := runRegistry(t, reg)
+	if failedCheck(results, "[stripe@0.1.0] maintenance_status") == nil {
+		t.Error("expected maintenance_status check to fail")
+	}
+}
+
+func TestVerifyRejectsInvalidDate(t *testing.T) {
+	reg := registryWith(versionDef{MaintenanceUntil: "next-week"})
+	results := runRegistry(t, reg)
+	if failedCheck(results, "[stripe@0.1.0] maintenance_until") == nil {
+		t.Error("expected maintenance_until check to fail")
+	}
+}
+
+func TestVerifyRejectsBSLOnFreeTier(t *testing.T) {
+	reg := registryWith(versionDef{BSLExpiryDate: "2030-01-01"})
+	v := reg.Twins["stripe"].Versions["0.1.0"]
+	v.Tier = "community"
+	reg.Twins["stripe"].Versions["0.1.0"] = v
+	results := runRegistry(t, reg)
+	if failedCheck(results, "[stripe@0.1.0] bsl_expiry_date") == nil {
+		t.Error("expected bsl_expiry_date check to fail on community tier")
+	}
+}
+
+func TestVerifyRejectsEmptyBreakingChange(t *testing.T) {
+	reg := registryWith(versionDef{BreakingChanges: []string{"   "}})
+	results := runRegistry(t, reg)
+	if failedCheck(results, "[stripe@0.1.0] breaking_changes[0]") == nil {
+		t.Error("expected breaking_changes[0] check to fail on whitespace")
+	}
+}
+
+func TestVerifyRejectsSchemaV3(t *testing.T) {
+	reg := validRegistry()
+	reg.SchemaVersion = 3
+	results := runRegistry(t, reg)
+	if failedCheck(results, "Schema version") == nil {
+		t.Error("expected schema version check to fail for v3")
+	}
+}

--- a/cmd/verify-registry/main.go
+++ b/cmd/verify-registry/main.go
@@ -49,13 +49,28 @@ type twinEntry struct {
 }
 
 type versionDef struct {
-	Released   string            `json:"released"`
-	SDKPackage string            `json:"sdk_package"`
-	SDKVersion string            `json:"sdk_version"`
-	Tier       string            `json:"tier"`
-	Checksums  map[string]string `json:"checksums"`
-	BinaryURLs map[string]string `json:"binary_urls"`
+	Released          string            `json:"released"`
+	SDKPackage        string            `json:"sdk_package"`
+	SDKVersion        string            `json:"sdk_version"`
+	Tier              string            `json:"tier"`
+	Checksums         map[string]string `json:"checksums"`
+	BinaryURLs        map[string]string `json:"binary_urls"`
+	ReleaseType       string            `json:"release_type,omitempty"`
+	MaintenanceStatus string            `json:"maintenance_status,omitempty"`
+	MaintenanceUntil  string            `json:"maintenance_until,omitempty"`
+	BSLExpiryDate     string            `json:"bsl_expiry_date,omitempty"`
+	Changelog         string            `json:"changelog,omitempty"`
+	BreakingChanges   []string          `json:"breaking_changes,omitempty"`
 }
+
+var (
+	validReleaseTypes = map[string]struct{}{
+		"stable": {}, "beta": {}, "rc": {},
+	}
+	validMaintenanceStatuses = map[string]struct{}{
+		"active": {}, "security_only": {}, "eol": {},
+	}
+)
 
 // checkResult stores the outcome of a single check.
 type checkResult struct {
@@ -99,6 +114,8 @@ func run(registryURL string) []checkResult {
 	// 3. Schema version
 	if reg.SchemaVersion < 1 {
 		results = append(results, checkResult{"Schema version", false, fmt.Sprintf("got %d, expected >= 1", reg.SchemaVersion)})
+	} else if reg.SchemaVersion > 2 {
+		results = append(results, checkResult{"Schema version", false, fmt.Sprintf("got %d, max supported 2", reg.SchemaVersion)})
 	} else {
 		results = append(results, checkResult{"Schema version", true, fmt.Sprintf("%d", reg.SchemaVersion)})
 	}
@@ -156,6 +173,56 @@ func validateVersion(name, ver string, vd versionDef) []checkResult {
 	for platform, url := range vd.BinaryURLs {
 		ok, detail := headCheck(url)
 		results = append(results, checkResult{fmt.Sprintf("%s reachable %s", prefix, platform), ok, detail})
+	}
+
+	// Lifecycle metadata (schema v2). Absent fields are valid; only
+	// malformed values are flagged.
+	results = append(results, validateLifecycle(prefix, vd)...)
+
+	return results
+}
+
+func validateLifecycle(prefix string, vd versionDef) []checkResult {
+	var results []checkResult
+
+	if vd.ReleaseType != "" {
+		if _, ok := validReleaseTypes[vd.ReleaseType]; !ok {
+			results = append(results, checkResult{prefix + " release_type", false, fmt.Sprintf("invalid value %q (want stable, beta, or rc)", vd.ReleaseType)})
+		} else {
+			results = append(results, checkResult{prefix + " release_type", true, vd.ReleaseType})
+		}
+	}
+
+	if vd.MaintenanceStatus != "" {
+		if _, ok := validMaintenanceStatuses[vd.MaintenanceStatus]; !ok {
+			results = append(results, checkResult{prefix + " maintenance_status", false, fmt.Sprintf("invalid value %q (want active, security_only, or eol)", vd.MaintenanceStatus)})
+		} else {
+			results = append(results, checkResult{prefix + " maintenance_status", true, vd.MaintenanceStatus})
+		}
+	}
+
+	if vd.MaintenanceUntil != "" {
+		if _, err := time.Parse("2006-01-02", vd.MaintenanceUntil); err != nil {
+			results = append(results, checkResult{prefix + " maintenance_until", false, fmt.Sprintf("not ISO 8601 date: %q", vd.MaintenanceUntil)})
+		} else {
+			results = append(results, checkResult{prefix + " maintenance_until", true, vd.MaintenanceUntil})
+		}
+	}
+
+	if vd.BSLExpiryDate != "" {
+		if _, err := time.Parse("2006-01-02", vd.BSLExpiryDate); err != nil {
+			results = append(results, checkResult{prefix + " bsl_expiry_date", false, fmt.Sprintf("not ISO 8601 date: %q", vd.BSLExpiryDate)})
+		} else if vd.Tier == "free" || vd.Tier == "community" {
+			results = append(results, checkResult{prefix + " bsl_expiry_date", false, fmt.Sprintf("set on free-tier version (tier=%q)", vd.Tier)})
+		} else {
+			results = append(results, checkResult{prefix + " bsl_expiry_date", true, vd.BSLExpiryDate})
+		}
+	}
+
+	for i, bc := range vd.BreakingChanges {
+		if strings.TrimSpace(bc) == "" {
+			results = append(results, checkResult{fmt.Sprintf("%s breaking_changes[%d]", prefix, i), false, "empty entry"})
+		}
 	}
 
 	return results

--- a/internal/registry/lifecycle_test.go
+++ b/internal/registry/lifecycle_test.go
@@ -1,0 +1,158 @@
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseSchemaV1Cleanly(t *testing.T) {
+	body := `{
+  "schema_version": 1,
+  "twins": {
+    "stripe": {
+      "description": "Stripe twin",
+      "latest": "0.4.0",
+      "versions": {
+        "0.4.0": {
+          "released": "2025-01-15",
+          "sdk_package": "github.com/stripe/stripe-go",
+          "sdk_version": "v76",
+          "tier": "community",
+          "checksums": {},
+          "binary_urls": {}
+        }
+      }
+    }
+  }
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	reg, err := FetchRegistry(srv.URL+"/registry.json", "")
+	if err != nil {
+		t.Fatalf("FetchRegistry returned error on v1 fixture: %v", err)
+	}
+	v := reg.Twins["stripe"].Versions["0.4.0"]
+	if v.EffectiveReleaseType() != ReleaseTypeStable {
+		t.Errorf("EffectiveReleaseType = %q, want stable", v.EffectiveReleaseType())
+	}
+	if v.EffectiveMaintenanceStatus() != MaintenanceActive {
+		t.Errorf("EffectiveMaintenanceStatus = %q, want active", v.EffectiveMaintenanceStatus())
+	}
+	if !v.IsActive() {
+		t.Error("v1 entry should be IsActive")
+	}
+	if v.IsEOL() {
+		t.Error("v1 entry should not be IsEOL")
+	}
+	if _, ok := v.MaintenanceUntilTime(); ok {
+		t.Error("MaintenanceUntilTime should be ok=false for unset field")
+	}
+}
+
+func TestParseSchemaV2Round(t *testing.T) {
+	src := Registry{
+		SchemaVersion: 2,
+		Twins: map[string]TwinEntry{
+			"stripe": {
+				Description: "Stripe",
+				Latest:      "1.0.0",
+				Versions: map[string]Version{
+					"1.0.0": {
+						Released:          "2026-04-01",
+						SDKPackage:        "github.com/stripe/stripe-go",
+						SDKVersion:        "v80",
+						Tier:              "commercial",
+						Checksums:         map[string]string{},
+						BinaryURLs:        map[string]string{},
+						ReleaseType:       ReleaseTypeBeta,
+						MaintenanceStatus: MaintenanceSecurityOnly,
+						MaintenanceUntil:  "2027-01-01",
+						BSLExpiryDate:     "2030-01-01",
+						Changelog:         "initial release",
+						BreakingChanges:   []string{"removed legacy auth"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(src)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	reg, err := FetchRegistry(srv.URL+"/registry.json", "")
+	if err != nil {
+		t.Fatalf("FetchRegistry returned error on v2 fixture: %v", err)
+	}
+	v := reg.Twins["stripe"].Versions["1.0.0"]
+	if v.EffectiveReleaseType() != ReleaseTypeBeta {
+		t.Errorf("ReleaseType = %q, want beta", v.EffectiveReleaseType())
+	}
+	if v.EffectiveMaintenanceStatus() != MaintenanceSecurityOnly {
+		t.Errorf("MaintenanceStatus = %q, want security_only", v.EffectiveMaintenanceStatus())
+	}
+	if !v.IsActive() {
+		t.Error("security_only must count as active")
+	}
+	if _, ok := v.MaintenanceUntilTime(); !ok {
+		t.Error("MaintenanceUntilTime should parse 2027-01-01")
+	}
+	if _, ok := v.BSLExpiryTime(); !ok {
+		t.Error("BSLExpiryTime should parse 2030-01-01")
+	}
+	if got := len(v.BreakingChanges); got != 1 {
+		t.Errorf("BreakingChanges len = %d, want 1", got)
+	}
+}
+
+func TestParseSchemaV3Rejected(t *testing.T) {
+	body := `{"schema_version": 3, "twins": {"x": {"latest": "1.0.0", "versions": {"1.0.0": {}}}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	_, err := FetchRegistry(srv.URL+"/registry.json", "")
+	if err == nil {
+		t.Fatal("expected error for schema_version=3")
+	}
+	if !strings.Contains(err.Error(), "schema version 3") {
+		t.Errorf("error %q should mention schema version 3", err)
+	}
+}
+
+func TestEOLAndIsActive(t *testing.T) {
+	cases := []struct {
+		status string
+		active bool
+		eol    bool
+	}{
+		{"", true, false},
+		{MaintenanceActive, true, false},
+		{MaintenanceSecurityOnly, true, false},
+		{MaintenanceEOL, false, true},
+	}
+	for _, tc := range cases {
+		v := Version{MaintenanceStatus: tc.status}
+		if v.IsActive() != tc.active {
+			t.Errorf("IsActive(%q) = %v, want %v", tc.status, v.IsActive(), tc.active)
+		}
+		if v.IsEOL() != tc.eol {
+			t.Errorf("IsEOL(%q) = %v, want %v", tc.status, v.IsEOL(), tc.eol)
+		}
+	}
+}
+
+func TestParseISODateInvalid(t *testing.T) {
+	v := Version{MaintenanceUntil: "not-a-date"}
+	if _, ok := v.MaintenanceUntilTime(); ok {
+		t.Error("MaintenanceUntilTime should be ok=false for unparseable input")
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -17,6 +17,12 @@ import (
 // FetchRegistry will try the JSON variant first and fall back to YAML.
 const DefaultRegistryURL = "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.yaml"
 
+// CurrentSchemaVersion is the schema version emitted by gen-registry
+// going forward. Parsers accept any schema_version <= CurrentSchemaVersion.
+// Schema v1 entries continue to parse cleanly because all v2 fields are
+// declared with `omitempty`.
+const CurrentSchemaVersion = 2
+
 // Registry represents the top-level registry manifest.
 type Registry struct {
 	SchemaVersion int                  `yaml:"schema_version" json:"schema_version"`
@@ -240,6 +246,10 @@ func fetchAndParse(url, token string) (*Registry, error) {
 		if err := yaml.Unmarshal(body, &reg); err != nil {
 			return nil, fmt.Errorf("parsing registry YAML: %w", err)
 		}
+	}
+
+	if reg.SchemaVersion > CurrentSchemaVersion {
+		return nil, fmt.Errorf("registry schema version %d not supported (max %d)", reg.SchemaVersion, CurrentSchemaVersion)
 	}
 
 	if reg.Twins == nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -33,7 +33,32 @@ type TwinEntry struct {
 	Versions    map[string]Version `yaml:"versions" json:"versions"`
 }
 
+// Release-type constants. ReleaseType on a Version is one of these or
+// empty; consumers should prefer Version.EffectiveReleaseType, which
+// treats an empty value as ReleaseTypeStable.
+const (
+	ReleaseTypeStable = "stable"
+	ReleaseTypeBeta   = "beta"
+	ReleaseTypeRC     = "rc"
+)
+
+// Maintenance-status constants. MaintenanceStatus on a Version is one
+// of these or empty; consumers should prefer
+// Version.EffectiveMaintenanceStatus, which treats an empty value as
+// MaintenanceActive.
+const (
+	MaintenanceActive       = "active"
+	MaintenanceSecurityOnly = "security_only"
+	MaintenanceEOL          = "eol"
+)
+
 // Version describes a specific release of a twin.
+//
+// The lifecycle fields (ReleaseType, MaintenanceStatus, MaintenanceUntil,
+// BSLExpiryDate, Changelog, BreakingChanges) are optional schema-v2
+// additions. Use the EffectiveX accessors to read them: a v1 entry with
+// no lifecycle fields is interpreted as an active stable release with
+// no expiry.
 type Version struct {
 	Released   string            `yaml:"released" json:"released"`
 	SDKPackage string            `yaml:"sdk_package" json:"sdk_package"`
@@ -42,6 +67,90 @@ type Version struct {
 	Tier       string            `yaml:"tier" json:"tier"`
 	Checksums  map[string]string `yaml:"checksums" json:"checksums"`
 	BinaryURLs map[string]string `yaml:"binary_urls" json:"binary_urls"`
+
+	// ReleaseType identifies the release stream: stable, beta, or rc.
+	// Empty values default to stable via EffectiveReleaseType.
+	ReleaseType string `yaml:"release_type,omitempty" json:"release_type,omitempty"`
+
+	// MaintenanceStatus is the current maintenance commitment: active,
+	// security_only, or eol. Empty values default to active via
+	// EffectiveMaintenanceStatus.
+	MaintenanceStatus string `yaml:"maintenance_status,omitempty" json:"maintenance_status,omitempty"`
+
+	// MaintenanceUntil is an ISO 8601 date marking when maintenance
+	// ends. Parse via MaintenanceUntilTime.
+	MaintenanceUntil string `yaml:"maintenance_until,omitempty" json:"maintenance_until,omitempty"`
+
+	// BSLExpiryDate is the ISO 8601 date a BSL-licensed pro twin
+	// converts to MIT. Only meaningful for commercial-tier versions.
+	// Parse via BSLExpiryTime.
+	BSLExpiryDate string `yaml:"bsl_expiry_date,omitempty" json:"bsl_expiry_date,omitempty"`
+
+	// Changelog is human-readable release notes for this version,
+	// typically markdown. Optional.
+	Changelog string `yaml:"changelog,omitempty" json:"changelog,omitempty"`
+
+	// BreakingChanges enumerates breaking changes introduced in this
+	// version. Each entry should be a complete, non-empty sentence.
+	BreakingChanges []string `yaml:"breaking_changes,omitempty" json:"breaking_changes,omitempty"`
+}
+
+// EffectiveReleaseType returns ReleaseType when set, else
+// ReleaseTypeStable. Use this in consumer code so v1 entries (which
+// lack the field) are treated as stable releases.
+func (v Version) EffectiveReleaseType() string {
+	if v.ReleaseType == "" {
+		return ReleaseTypeStable
+	}
+	return v.ReleaseType
+}
+
+// EffectiveMaintenanceStatus returns MaintenanceStatus when set, else
+// MaintenanceActive. A v1 registry entry with no lifecycle fields is
+// treated as an active release.
+func (v Version) EffectiveMaintenanceStatus() string {
+	if v.MaintenanceStatus == "" {
+		return MaintenanceActive
+	}
+	return v.MaintenanceStatus
+}
+
+// IsActive reports whether the version is currently maintained — that
+// is, its EffectiveMaintenanceStatus is active or security_only.
+func (v Version) IsActive() bool {
+	switch v.EffectiveMaintenanceStatus() {
+	case MaintenanceActive, MaintenanceSecurityOnly:
+		return true
+	}
+	return false
+}
+
+// IsEOL reports whether the version has reached end-of-life.
+func (v Version) IsEOL() bool {
+	return v.EffectiveMaintenanceStatus() == MaintenanceEOL
+}
+
+// MaintenanceUntilTime parses MaintenanceUntil into a time.Time.
+// Returns ok=false when the field is empty or unparseable.
+func (v Version) MaintenanceUntilTime() (time.Time, bool) {
+	return parseISODate(v.MaintenanceUntil)
+}
+
+// BSLExpiryTime parses BSLExpiryDate into a time.Time. Returns
+// ok=false when the field is empty or unparseable.
+func (v Version) BSLExpiryTime() (time.Time, bool) {
+	return parseISODate(v.BSLExpiryDate)
+}
+
+func parseISODate(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // FetchRegistry downloads and parses the registry from the given URL.


### PR DESCRIPTION
Extends the registry Version schema with lifecycle metadata:
release_type, maintenance_status, maintenance_until, bsl_expiry_date,
changelog, breaking_changes. All fields are optional (omitempty), so
the existing registry data (schema v1) continues to parse cleanly.

## Adds

- `registry.Version` lifecycle fields with `EffectiveReleaseType` /
  `EffectiveMaintenanceStatus` / `IsActive` / `IsEOL` /
  `MaintenanceUntilTime` / `BSLExpiryTime` helpers so consumer code
  doesn't have to special-case empty values.
- `registry.CurrentSchemaVersion = 2`. The parser accepts schema
  versions <= 2 and rejects anything higher with the error
  `registry schema version N not supported (max 2)`.
- `gen-registry`:
  - Emits `schema_version: 2`.
  - New flags: `--release-type`, `--maintenance-status`,
    `--maintenance-until`, `--bsl-expiry-date`, `--changelog` (accepts
    `@/path/to/file`), and repeatable `--breaking-change`.
  - Reads `lifecycle` from `twin-manifest.json` when present; CLI flags
    override per-field.
  - Validates enum membership, ISO 8601 date format, and rejects
    `bsl_expiry_date` on non-commercial tier.
- `verify-registry`:
  - Adds lifecycle validation (enum values, ISO dates, non-empty
    breaking_changes, BSL only on commercial tier).
  - Caps schema_version at 2; v1 fixtures continue to validate cleanly.

## Why

Customers pinning to specific twin versions need to see maintenance
status, EOL timelines, and BSL→MIT expiry. Unblocks `wt drift`,
`wt pin`, and the BSL archive policy decision. CI v2 telemetry will
also surface this metadata once session 1C/1D ingestion lands.

## Tier mapping note

The spec called out "non-pro twin (i.e. tier != 'pro' and tier !=
'enterprise')". The repo's actual tier values are `community` and
`commercial` (see existing gen-registry validation). I treated
`bsl_expiry_date` as commercial-tier-only, since BSL→MIT only applies
to commercial pro twins. Verify-registry rejects it on either
`free` or `community` tiers (covers both legacy and current names).

## Out of scope

The actual registry data file lives in `wondertwin-ai/registry`; it
will pick up v2 fields on the next gen-registry release run. This PR
makes the fields possible, not populated.

Reference: ci-v2-implementation-plan.md §4 coordination map; earlier
versioning audit recommendation #1.

## Verification

- `go build ./...` clean
- `go test ./... -short` clean
- `go vet ./...` clean
- `go mod tidy` produces no further changes
- All 10 twin binaries compile
- `go run ./cmd/validate-schemas/` passes
- Tests cover: v1 fixture parses cleanly; v2 fixture round-trips;
  schema_version=3 rejected with clear error; gen-registry CLI flags +
  manifest fields + flag overrides + changelog file load; verify-registry
  rejects each malformed lifecycle value path; BSL on free-tier rejected
  by both tools.