### PR TITLE
feat: license validation and soft-gate banner (cimode + wt license)

### DIFF
--- a/cmd/wt/license.go
+++ b/cmd/wt/license.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+)
+
+// cmdLicense dispatches `wt license <subcommand>`.
+func cmdLicense(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: wt license <install|status|inspect> [flags]")
+	}
+	switch args[0] {
+	case "install":
+		return cmdLicenseInstall(args[1:])
+	case "status":
+		return cmdLicenseStatus(args[1:])
+	case "inspect":
+		return cmdLicenseInspect(args[1:])
+	default:
+		return fmt.Errorf("unknown license subcommand %q (want: install, status, inspect)", args[0])
+	}
+}
+
+// licenseReport is the JSON shape emitted by `--json`.
+type licenseReport struct {
+	Path         string         `json:"path,omitempty"`
+	Installed    bool           `json:"installed,omitempty"`
+	License      *cimode.License `json:"license,omitempty"`
+	Valid        bool           `json:"valid"`
+	Reason       string         `json:"reason,omitempty"`
+	ExpiresInSec float64        `json:"expires_in_seconds"`
+}
+
+// scopeName is the twin name used for license validation in the wt
+// CLI. The CLI itself isn't a twin; "*" scope licenses validate
+// trivially, scoped licenses surface their scope without failing
+// validation by an arbitrary name.
+const scopeName = "*"
+
+func cmdLicenseInstall(args []string) error {
+	fs := flag.NewFlagSet("wt license install", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "Emit JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return fmt.Errorf("usage: wt license install [--json] <file>")
+	}
+	src := fs.Arg(0)
+
+	lic, err := cimode.LoadLicenseFromPath(src)
+	if err != nil {
+		return fmt.Errorf("read license: %w", err)
+	}
+	st := cimode.ValidateLicense(lic, validationScope(lic), time.Now())
+	if !st.Valid {
+		report(*asJSON, licenseReport{Path: src, License: lic, Valid: false, Reason: st.Reason, ExpiresInSec: st.ExpiresIn.Seconds()})
+		return fmt.Errorf("refusing to install invalid license: %s", st.Reason)
+	}
+
+	home, err := cimode.LicenseHome()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", home, err)
+	}
+	dst := filepath.Join(home, cimode.DefaultLicenseFilename)
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+
+	report(*asJSON, licenseReport{
+		Path:         dst,
+		Installed:    true,
+		License:      lic,
+		Valid:        true,
+		ExpiresInSec: st.ExpiresIn.Seconds(),
+	})
+	return nil
+}
+
+func cmdLicenseStatus(args []string) error {
+	fs := flag.NewFlagSet("wt license status", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "Emit JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	lic, err := cimode.LoadLicense()
+	if err != nil {
+		return fmt.Errorf("load license: %w", err)
+	}
+	st := cimode.ValidateLicense(lic, validationScope(lic), time.Now())
+	r := licenseReport{License: lic, Valid: st.Valid, Reason: st.Reason, ExpiresInSec: st.ExpiresIn.Seconds()}
+	report(*asJSON, r)
+	if !st.Valid {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func cmdLicenseInspect(args []string) error {
+	fs := flag.NewFlagSet("wt license inspect", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "Emit JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return fmt.Errorf("usage: wt license inspect [--json] <file>")
+	}
+	path := fs.Arg(0)
+
+	lic, err := cimode.LoadLicenseFromPath(path)
+	if err != nil {
+		return err
+	}
+	st := cimode.ValidateLicense(lic, validationScope(lic), time.Now())
+	report(*asJSON, licenseReport{Path: path, License: lic, Valid: st.Valid, Reason: st.Reason, ExpiresInSec: st.ExpiresIn.Seconds()})
+	if !st.Valid {
+		return fmt.Errorf("license invalid: %s", st.Reason)
+	}
+	return nil
+}
+
+// validationScope returns "*" for license validation by the CLI when
+// the license itself is wildcard-scoped, or the first scoped twin
+// name when it isn't. The CLI is not a twin, so we just need to pick
+// any name the license covers; this avoids tripping the
+// twin-not-in-scope rule.
+func validationScope(lic *cimode.License) string {
+	if lic == nil {
+		return scopeName
+	}
+	for _, s := range lic.TwinScope {
+		if s == "*" {
+			return "*"
+		}
+	}
+	if len(lic.TwinScope) > 0 {
+		return lic.TwinScope[0]
+	}
+	return scopeName
+}
+
+func report(asJSON bool, r licenseReport) {
+	if asJSON {
+		out, _ := json.MarshalIndent(r, "", "  ")
+		fmt.Println(string(out))
+		return
+	}
+	if r.License == nil {
+		fmt.Printf("No license loaded.\n")
+		fmt.Printf("Status:  %s\n", reasonOrValid(r))
+		return
+	}
+	fmt.Printf("License: %s\n", r.License.Key)
+	fmt.Printf("Org:     %s\n", r.License.OrgID)
+	fmt.Printf("Scope:   %v\n", r.License.TwinScope)
+	if !r.License.IssuedAt.IsZero() {
+		fmt.Printf("Issued:  %s\n", r.License.IssuedAt.Format(time.RFC3339))
+	}
+	if !r.License.NotAfter.IsZero() {
+		fmt.Printf("Expires: %s\n", r.License.NotAfter.Format(time.RFC3339))
+	}
+	fmt.Printf("Status:  %s\n", reasonOrValid(r))
+	if r.Installed {
+		fmt.Printf("Installed at: %s\n", r.Path)
+	}
+}
+
+func reasonOrValid(r licenseReport) string {
+	if r.Valid {
+		return fmt.Sprintf("valid (expires in %s)", time.Duration(r.ExpiresInSec*float64(time.Second)).Truncate(time.Minute))
+	}
+	if r.Reason == "" {
+		return "invalid"
+	}
+	return "invalid: " + r.Reason
+}

--- a/cmd/wt/license_test.go
+++ b/cmd/wt/license_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+)
+
+func writeLicenseFile(t *testing.T, path string, lic cimode.License, priv ed25519.PrivateKey) {
+	t.Helper()
+	bytes, err := lic.SigningBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if priv != nil {
+		sig := ed25519.Sign(priv, bytes)
+		lic.SetSignature(sig)
+	}
+	data, _ := json.Marshal(lic)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLicenseInstallValid(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "input.json")
+	now := time.Now().UTC()
+	writeLicenseFile(t, src, cimode.License{
+		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
+	}, priv)
+
+	home := t.TempDir()
+	t.Setenv(cimode.EnvHome, home)
+	t.Setenv(cimode.EnvLicenseFile, "")
+
+	out := captureStdout(t, func() {
+		if err := cmdLicenseInstall([]string{src}); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	})
+	if !strings.Contains(out, "valid") {
+		t.Errorf("expected 'valid' in output; got: %s", out)
+	}
+	dst := filepath.Join(home, cimode.DefaultLicenseFilename)
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("expected license at %s; %v", dst, err)
+	}
+}
+
+func TestLicenseInstallRejectsTampered(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "input.json")
+	now := time.Now().UTC()
+	lic := cimode.License{
+		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
+	}
+	writeLicenseFile(t, src, lic, priv)
+	// Tamper the file: read, mutate OrgID, write back.
+	raw, _ := os.ReadFile(src)
+	tampered := strings.Replace(string(raw), `"org_id":"org"`, `"org_id":"evil"`, 1)
+	os.WriteFile(src, []byte(tampered), 0o600)
+
+	home := t.TempDir()
+	t.Setenv(cimode.EnvHome, home)
+	t.Setenv(cimode.EnvLicenseFile, "")
+
+	err := cmdLicenseInstall([]string{src})
+	if err == nil {
+		t.Fatal("expected install to refuse tampered license")
+	}
+	if !strings.Contains(err.Error(), cimode.ReasonInvalidSig) {
+		t.Errorf("error = %v, want invalid signature", err)
+	}
+	dst := filepath.Join(home, cimode.DefaultLicenseFilename)
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("destination should not exist after rejection; stat err = %v", err)
+	}
+}
+
+func TestLicenseInspectDoesNotInstall(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "input.json")
+	now := time.Now().UTC()
+	writeLicenseFile(t, src, cimode.License{
+		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
+	}, priv)
+
+	home := t.TempDir()
+	t.Setenv(cimode.EnvHome, home)
+	t.Setenv(cimode.EnvLicenseFile, "")
+
+	out := captureStdout(t, func() {
+		if err := cmdLicenseInspect([]string{src}); err != nil {
+			t.Fatalf("inspect: %v", err)
+		}
+	})
+	if !strings.Contains(out, "valid") {
+		t.Errorf("expected valid output; got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(home, cimode.DefaultLicenseFilename)); !os.IsNotExist(err) {
+		t.Errorf("inspect should not install; stat err = %v", err)
+	}
+}
+
+func TestLicenseInstallJSON(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "input.json")
+	now := time.Now().UTC()
+	writeLicenseFile(t, src, cimode.License{
+		Key: "lic", OrgID: "org_acme", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
+	}, priv)
+
+	home := t.TempDir()
+	t.Setenv(cimode.EnvHome, home)
+	t.Setenv(cimode.EnvLicenseFile, "")
+
+	out := captureStdout(t, func() {
+		if err := cmdLicenseInstall([]string{"--json", src}); err != nil {
+			t.Fatalf("install --json: %v", err)
+		}
+	})
+	var r licenseReport
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !r.Valid || !r.Installed {
+		t.Errorf("report = %+v", r)
+	}
+	if r.License == nil || r.License.OrgID != "org_acme" {
+		t.Errorf("license missing or wrong org: %+v", r.License)
+	}
+}

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -141,6 +141,8 @@ func main() {
 		err = cmdConformance(args)
 	case "replay":
 		err = cmdReplay(args)
+	case "license":
+		err = cmdLicense(args)
 	default:
 		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
 		printUsage()
@@ -207,6 +209,9 @@ Commands:
   conformance <binary>       Run conformance tests against a twin binary
   replay export              Fetch /admin/replay JSONL bundle from a running twin
   replay view <path>         Pretty-print a JSONL replay bundle
+  license install <file>     Install a signed WonderTwin license file
+  license status             Show the active license's status
+  license inspect <file>     Show a license file without installing
   version                    Print the wt version
 
 Options:

--- a/twinkit/cimode/license.go
+++ b/twinkit/cimode/license.go
@@ -1,0 +1,81 @@
+package cimode
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// License is the WonderTwin license file format. It is signed by the
+// issuer's ed25519 private key over the canonical JSON of the license
+// with the Signature field omitted; verifiers re-marshal in the same
+// shape and check the signature.
+//
+// The Reason strings emitted by ValidateLicense are stable enums (see
+// the Reason* constants in this package). Telemetry payloads and the
+// `wt license status` output depend on those values.
+type License struct {
+	// Key is the opaque license identifier issued to the customer.
+	Key string `json:"key"`
+
+	// OrgID is the customer organization identifier. The issuer hashes
+	// this before insertion; verifiers treat it as opaque.
+	OrgID string `json:"org_id"`
+
+	// TwinScope lists the twin names this license covers. ["*"]
+	// authorizes all twins.
+	TwinScope []string `json:"twin_scope"`
+
+	// IssuedAt is the issuance timestamp.
+	IssuedAt time.Time `json:"issued_at"`
+
+	// NotAfter is the hard expiry timestamp.
+	NotAfter time.Time `json:"not_after"`
+
+	// Signature is the base64-standard-encoded ed25519 signature over
+	// the canonical JSON of this license with Signature omitted.
+	Signature string `json:"signature"`
+}
+
+// SigningBytes returns the deterministic JSON encoding of the license
+// with the Signature field cleared. Issuers sign these bytes; verifiers
+// re-derive them and check the signature against the License.Signature.
+func (l License) SigningBytes() ([]byte, error) {
+	clone := l
+	clone.Signature = ""
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(&clone); err != nil {
+		return nil, fmt.Errorf("encode license for signing: %w", err)
+	}
+	// json.Encoder.Encode appends a trailing newline; drop it so the
+	// signing input matches a callers-side bytes.Buffer that doesn't
+	// add one.
+	out := buf.Bytes()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
+	}
+	return out, nil
+}
+
+// SignatureBytes decodes License.Signature from base64. Returns an
+// error if the field is empty or malformed.
+func (l License) SignatureBytes() ([]byte, error) {
+	if l.Signature == "" {
+		return nil, fmt.Errorf("license signature is empty")
+	}
+	sig, err := base64.StdEncoding.DecodeString(l.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	return sig, nil
+}
+
+// SetSignature base64-encodes raw and stores it on the license. Used
+// by issuance code and tests.
+func (l *License) SetSignature(raw []byte) {
+	l.Signature = base64.StdEncoding.EncodeToString(raw)
+}

--- a/twinkit/cimode/license_test.go
+++ b/twinkit/cimode/license_test.go
@@ -1,0 +1,230 @@
+package cimode
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// signedLicense returns a License signed by priv. Tests use this
+// helper to avoid replicating signing wiring.
+func signedLicense(t *testing.T, priv ed25519.PrivateKey, lic License) License {
+	t.Helper()
+	bytes, err := lic.SigningBytes()
+	if err != nil {
+		t.Fatalf("SigningBytes: %v", err)
+	}
+	sig := ed25519.Sign(priv, bytes)
+	lic.SetSignature(sig)
+	return lic
+}
+
+func newTestKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestValidateRoundTrip(t *testing.T) {
+	pub, priv := newTestKeypair(t)
+	restore := setVerificationKey(pub)
+	defer restore()
+
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	lic := signedLicense(t, priv, License{
+		Key:       "lic_test",
+		OrgID:     "org_acme",
+		TwinScope: []string{"stripe"},
+		IssuedAt:  now,
+		NotAfter:  now.Add(90 * 24 * time.Hour),
+	})
+
+	st := ValidateLicense(&lic, "stripe", now)
+	if !st.Valid {
+		t.Fatalf("expected valid; reason=%q", st.Reason)
+	}
+	if st.ExpiresIn <= 0 {
+		t.Errorf("ExpiresIn = %v, want positive", st.ExpiresIn)
+	}
+}
+
+func TestValidateNilLicense(t *testing.T) {
+	st := ValidateLicense(nil, "stripe", time.Now())
+	if st.Valid || st.Reason != ReasonNoLicense || st.ExpiresIn != 0 {
+		t.Errorf("nil license status = %+v", st)
+	}
+}
+
+func TestValidateTamperedPayload(t *testing.T) {
+	pub, priv := newTestKeypair(t)
+	restore := setVerificationKey(pub)
+	defer restore()
+
+	now := time.Now().UTC()
+	lic := signedLicense(t, priv, License{
+		Key:       "lic_test",
+		OrgID:     "org_a",
+		TwinScope: []string{"*"},
+		IssuedAt:  now,
+		NotAfter:  now.Add(time.Hour),
+	})
+	lic.OrgID = "org_evil" // tamper after signing
+
+	st := ValidateLicense(&lic, "stripe", now)
+	if st.Valid || st.Reason != ReasonInvalidSig {
+		t.Errorf("tampered status = %+v, want invalid signature", st)
+	}
+}
+
+func TestValidateWrongKey(t *testing.T) {
+	_, priv := newTestKeypair(t)
+	otherPub, _ := newTestKeypair(t)
+	restore := setVerificationKey(otherPub)
+	defer restore()
+
+	now := time.Now().UTC()
+	lic := signedLicense(t, priv, License{
+		Key: "lic", OrgID: "o", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(time.Hour),
+	})
+	st := ValidateLicense(&lic, "stripe", now)
+	if st.Valid || st.Reason != ReasonInvalidSig {
+		t.Errorf("wrong-key status = %+v", st)
+	}
+}
+
+func TestValidateExpired(t *testing.T) {
+	pub, priv := newTestKeypair(t)
+	restore := setVerificationKey(pub)
+	defer restore()
+
+	issued := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(24 * time.Hour)
+	lic := signedLicense(t, priv, License{
+		Key: "lic", OrgID: "o", TwinScope: []string{"*"},
+		IssuedAt: issued, NotAfter: expires,
+	})
+	now := expires.Add(time.Hour)
+	st := ValidateLicense(&lic, "stripe", now)
+	if st.Valid || st.Reason != ReasonExpired {
+		t.Errorf("expired status = %+v", st)
+	}
+	if st.ExpiresIn >= 0 {
+		t.Errorf("ExpiresIn = %v, want negative", st.ExpiresIn)
+	}
+}
+
+func TestValidateTwinScope(t *testing.T) {
+	pub, priv := newTestKeypair(t)
+	restore := setVerificationKey(pub)
+	defer restore()
+
+	now := time.Now().UTC()
+	lic := signedLicense(t, priv, License{
+		Key: "lic", OrgID: "o", TwinScope: []string{"stripe"},
+		IssuedAt: now, NotAfter: now.Add(time.Hour),
+	})
+	stOK := ValidateLicense(&lic, "stripe", now)
+	if !stOK.Valid {
+		t.Errorf("stripe should validate; status=%+v", stOK)
+	}
+	stMiss := ValidateLicense(&lic, "twilio", now)
+	if stMiss.Valid || stMiss.Reason != ReasonTwinOutOfScope {
+		t.Errorf("twilio status = %+v", stMiss)
+	}
+}
+
+func TestValidateWildcardScope(t *testing.T) {
+	pub, priv := newTestKeypair(t)
+	restore := setVerificationKey(pub)
+	defer restore()
+
+	now := time.Now().UTC()
+	lic := signedLicense(t, priv, License{
+		Key: "lic", OrgID: "o", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(time.Hour),
+	})
+	for _, name := range []string{"stripe", "twilio", "anything"} {
+		st := ValidateLicense(&lic, name, now)
+		if !st.Valid {
+			t.Errorf("wildcard scope failed for %q: %+v", name, st)
+		}
+	}
+}
+
+func TestLoadLicenseFromPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "license.json")
+	want := License{Key: "k", OrgID: "o", TwinScope: []string{"*"}}
+	data, _ := json.Marshal(want)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadLicenseFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadLicenseFromPath: %v", err)
+	}
+	if got.Key != "k" {
+		t.Errorf("Key = %q", got.Key)
+	}
+}
+
+func TestLoadLicenseExplicitMissing(t *testing.T) {
+	t.Setenv(EnvLicenseFile, "/nonexistent/path/license.json")
+	if _, err := LoadLicense(); err == nil {
+		t.Error("explicit missing path should error")
+	}
+}
+
+func TestLoadLicenseDefaultMissingReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvLicenseFile, "")
+	t.Setenv(EnvHome, dir)
+	got, err := LoadLicense()
+	if err != nil {
+		t.Fatalf("expected nil error for missing default; got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil license; got %+v", got)
+	}
+}
+
+func TestLoadLicenseHomeOverride(t *testing.T) {
+	dir := t.TempDir()
+	want := License{Key: "k", OrgID: "o", TwinScope: []string{"*"}}
+	data, _ := json.Marshal(want)
+	os.WriteFile(filepath.Join(dir, DefaultLicenseFilename), data, 0o600)
+
+	t.Setenv(EnvLicenseFile, "")
+	t.Setenv(EnvHome, dir)
+	got, err := LoadLicense()
+	if err != nil {
+		t.Fatalf("LoadLicense: %v", err)
+	}
+	if got == nil || got.Key != "k" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestSigningBytesIsDeterministic(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	lic := License{Key: "k", OrgID: "o", TwinScope: []string{"a", "b"}, IssuedAt: now, NotAfter: now}
+	a, _ := lic.SigningBytes()
+	b, _ := lic.SigningBytes()
+	if string(a) != string(b) {
+		t.Errorf("SigningBytes non-deterministic:\nA: %s\nB: %s", a, b)
+	}
+	// Signature field must not appear in signing bytes.
+	lic.Signature = "spurious"
+	c, _ := lic.SigningBytes()
+	if string(a) != string(c) {
+		t.Errorf("Signature field leaked into SigningBytes:\nbase:    %s\nwithSig: %s", a, c)
+	}
+}

--- a/twinkit/cimode/loader.go
+++ b/twinkit/cimode/loader.go
@@ -1,0 +1,87 @@
+package cimode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Environment variables consulted by LoadLicense.
+const (
+	// EnvLicenseFile is an explicit license file path. When set, the
+	// path must exist and parse cleanly; LoadLicense returns an error
+	// otherwise.
+	EnvLicenseFile = "WONDERTWIN_LICENSE_FILE"
+
+	// EnvHome overrides the default $HOME/.wondertwin location used
+	// for license discovery and installation.
+	EnvHome = "WONDERTWIN_HOME"
+)
+
+// DefaultLicenseFilename is the file name LoadLicense searches for
+// inside $WONDERTWIN_HOME (or $HOME/.wondertwin).
+const DefaultLicenseFilename = "license.json"
+
+// LoadLicense reads the license file from the standard locations.
+//
+// Resolution order:
+//
+//  1. WONDERTWIN_LICENSE_FILE env var. The path must exist and parse;
+//     a missing file returns an error.
+//  2. $WONDERTWIN_HOME/license.json (or $HOME/.wondertwin/license.json
+//     when WONDERTWIN_HOME is unset). A missing file returns nil, nil
+//     — the soft-gate path.
+//
+// Malformed JSON returns nil + an error in both cases.
+func LoadLicense() (*License, error) {
+	if path := os.Getenv(EnvLicenseFile); path != "" {
+		return LoadLicenseFromPath(path)
+	}
+	home, err := licenseHome()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(home, DefaultLicenseFilename)
+	lic, err := LoadLicenseFromPath(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return lic, nil
+}
+
+// LoadLicenseFromPath reads and parses a license file at path. The
+// returned License is structurally well-formed; callers must invoke
+// ValidateLicense to check the signature and expiry.
+func LoadLicenseFromPath(path string) (*License, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read license %s: %w", path, err)
+	}
+	var lic License
+	if err := json.Unmarshal(data, &lic); err != nil {
+		return nil, fmt.Errorf("parse license %s: %w", path, err)
+	}
+	return &lic, nil
+}
+
+// LicenseHome returns the resolved license home directory. Exported
+// for the wt CLI; honors WONDERTWIN_HOME, then $HOME/.wondertwin.
+func LicenseHome() (string, error) {
+	return licenseHome()
+}
+
+func licenseHome() (string, error) {
+	if h := os.Getenv(EnvHome); h != "" {
+		return h, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".wondertwin"), nil
+}

--- a/twinkit/cimode/pubkey.go
+++ b/twinkit/cimode/pubkey.go
@@ -1,0 +1,19 @@
+package cimode
+
+import "crypto/ed25519"
+
+// embeddedPubKey is the WonderTwin license verification key, embedded
+// at build time. The matching private key lives in wondertwin-app and
+// is used by the license issuer service.
+//
+// To rotate: generate a new ed25519 keypair, replace the bytes below,
+// and distribute the new private key to the issuer service. Existing
+// licenses signed with the old key will fail verification once this
+// file is replaced — plan rotation alongside a re-issuance window so
+// customers' NotAfter horizons cover the swap.
+var embeddedPubKey = ed25519.PublicKey{
+	0x1b, 0xef, 0x64, 0xad, 0xc1, 0x0e, 0x26, 0xe3,
+	0x61, 0xc1, 0x2d, 0xfa, 0x59, 0xa5, 0x11, 0x5d,
+	0xc0, 0x00, 0x20, 0x9b, 0xf6, 0x24, 0x03, 0x0d,
+	0x04, 0x33, 0xfe, 0x7a, 0x3a, 0x4f, 0x77, 0xcd,
+}

--- a/twinkit/cimode/validate.go
+++ b/twinkit/cimode/validate.go
@@ -1,0 +1,61 @@
+package cimode
+
+import "time"
+
+// Stable Reason strings emitted by ValidateLicense. These values are
+// part of the public contract: they appear in `wt license status`
+// output and (in a follow-up) in telemetry payloads.
+const (
+	ReasonNoLicense       = "no license"
+	ReasonInvalidSig      = "invalid signature"
+	ReasonExpired         = "license expired"
+	ReasonTwinOutOfScope  = "twin not in scope"
+)
+
+// Status is the result of ValidateLicense.
+type Status struct {
+	// Valid is true when the license is structurally sound, signed by
+	// the active verification key, not expired, and covers the
+	// requested twin.
+	Valid bool
+
+	// Reason is one of the Reason* constants above when Valid is
+	// false; "" when Valid is true.
+	Reason string
+
+	// ExpiresIn is positive when the license is still valid (time
+	// remaining until NotAfter), negative when expired, and zero when
+	// no license is present.
+	ExpiresIn time.Duration
+}
+
+// ValidateLicense reports whether lic authorizes twinName at the given
+// clock. A nil license is the soft-gate path: Valid=false,
+// Reason=ReasonNoLicense.
+//
+// The check order is signature → expiry → scope. The first failing
+// check determines the reported Reason.
+func ValidateLicense(lic *License, twinName string, now time.Time) Status {
+	if lic == nil {
+		return Status{Reason: ReasonNoLicense}
+	}
+	if !verifySignature(*lic) {
+		return Status{Reason: ReasonInvalidSig}
+	}
+	if now.After(lic.NotAfter) {
+		return Status{Reason: ReasonExpired, ExpiresIn: lic.NotAfter.Sub(now)}
+	}
+	if !scopeIncludes(lic.TwinScope, twinName) {
+		return Status{Reason: ReasonTwinOutOfScope, ExpiresIn: lic.NotAfter.Sub(now)}
+	}
+	return Status{Valid: true, ExpiresIn: lic.NotAfter.Sub(now)}
+}
+
+func scopeIncludes(scope []string, twinName string) bool {
+	for _, s := range scope {
+		if s == "*" || s == twinName {
+			return true
+		}
+	}
+	return false
+}

--- a/twinkit/cimode/verify.go
+++ b/twinkit/cimode/verify.go
@@ -1,0 +1,51 @@
+package cimode
+
+import (
+	"crypto/ed25519"
+	"sync"
+)
+
+var (
+	verifyMu     sync.RWMutex
+	activeVerify = embeddedPubKey
+)
+
+// verifyKey returns the active verification key. Tests use
+// setVerificationKey to swap it out.
+func verifyKey() ed25519.PublicKey {
+	verifyMu.RLock()
+	defer verifyMu.RUnlock()
+	return activeVerify
+}
+
+// setVerificationKey replaces the active verification key with pk and
+// returns a closure that restores the previous value. It is exported
+// only to tests in this package; callers outside cimode use the
+// embedded key.
+func setVerificationKey(pk ed25519.PublicKey) (restore func()) {
+	verifyMu.Lock()
+	prev := activeVerify
+	activeVerify = pk
+	verifyMu.Unlock()
+	return func() {
+		verifyMu.Lock()
+		activeVerify = prev
+		verifyMu.Unlock()
+	}
+}
+
+// verifySignature returns true when lic.Signature is a valid ed25519
+// signature over lic.SigningBytes() under the active verification
+// key. Any error in deriving the signing bytes or decoding the
+// signature is treated as an invalid signature (returns false).
+func verifySignature(lic License) bool {
+	msg, err := lic.SigningBytes()
+	if err != nil {
+		return false
+	}
+	sig, err := lic.SignatureBytes()
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(verifyKey(), msg, sig)
+}

--- a/twinkit/cimode/verify.go
+++ b/twinkit/cimode/verify.go
@@ -19,9 +19,7 @@ func verifyKey() ed25519.PublicKey {
 }
 
 // setVerificationKey replaces the active verification key with pk and
-// returns a closure that restores the previous value. It is exported
-// only to tests in this package; callers outside cimode use the
-// embedded key.
+// returns a closure that restores the previous value.
 func setVerificationKey(pk ed25519.PublicKey) (restore func()) {
 	verifyMu.Lock()
 	prev := activeVerify
@@ -32,6 +30,14 @@ func setVerificationKey(pk ed25519.PublicKey) (restore func()) {
 		activeVerify = prev
 		verifyMu.Unlock()
 	}
+}
+
+// SetVerificationKeyForTest is exposed only for use by tests in
+// dependent packages (e.g. twinkit/twincore's license-banner tests
+// that must mint a synthetic license without the production private
+// key). It MUST NOT be called by production code.
+func SetVerificationKeyForTest(pk ed25519.PublicKey) (restore func()) {
+	return setVerificationKey(pk)
 }
 
 // verifySignature returns true when lic.Signature is a valid ed25519

--- a/twinkit/twincore/license.go
+++ b/twinkit/twincore/license.go
@@ -1,0 +1,52 @@
+package twincore
+
+import (
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+)
+
+// licenseLink is the URL surfaced in the soft-gate warn banner so
+// operators tailing CI logs know where to acquire a license.
+const licenseLink = "https://wondertwin.dev/license"
+
+// loadLicense populates Twin.License and Twin.LicenseStatus. License
+// loading errors (malformed file, etc.) are logged but never abort
+// startup — license absence is a normal state.
+func (t *Twin) loadLicense() {
+	lic, err := cimode.LoadLicense()
+	if err != nil {
+		t.Logger.Warn("failed to load WonderTwin license; continuing unlicensed", "err", err)
+		t.LicenseStatus = cimode.Status{Reason: cimode.ReasonNoLicense}
+		return
+	}
+	t.License = lic
+	t.LicenseStatus = cimode.ValidateLicense(lic, t.Config.Name, time.Now())
+}
+
+// emitLicenseBanner writes a single startup log line in CI mode
+// describing license state. Local mode is silent. The soft-gate
+// design forbids refusing traffic on license absence — this banner
+// is the only signal.
+func (t *Twin) emitLicenseBanner() {
+	if t.Mode != cimode.ModeCI {
+		return
+	}
+	if t.LicenseStatus.Valid {
+		org := ""
+		if t.License != nil {
+			org = t.License.OrgID
+		}
+		t.Logger.Info("WonderTwin license active",
+			"twin", t.Config.Name,
+			"org", org,
+			"expires_in", t.LicenseStatus.ExpiresIn.String(),
+		)
+		return
+	}
+	t.Logger.Warn("WonderTwin running in CI without valid license",
+		"twin", t.Config.Name,
+		"reason", t.LicenseStatus.Reason,
+		"link", licenseLink,
+	)
+}

--- a/twinkit/twincore/license_banner_test.go
+++ b/twinkit/twincore/license_banner_test.go
@@ -1,0 +1,149 @@
+package twincore
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
+)
+
+// captureBanner installs a buffered slog handler on the Twin so tests
+// can assert against the banner output. It is invoked after New() so
+// the constructor's Logger ends up replaced; the existing banner has
+// already been emitted to the original logger. To capture the banner,
+// callers should set the buffer first via newTwinForBannerTest.
+func newTwinForBannerTest(t *testing.T, name string, env map[string]string) (*Twin, *bytes.Buffer) {
+	t.Helper()
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+	buf := &bytes.Buffer{}
+	// Hook the logger by replacing os.Stdout temporarily? Simpler:
+	// build a Twin and then re-emit the banner against a captured
+	// logger — the banner is deterministic given Twin state.
+	tw := New(&Config{Name: name})
+	tw.Logger = slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	tw.emitLicenseBanner()
+	return tw, buf
+}
+
+func writeSignedLicense(t *testing.T, dir string, lic cimode.License, priv ed25519.PrivateKey) {
+	t.Helper()
+	bytes, err := lic.SigningBytes()
+	if err != nil {
+		t.Fatalf("SigningBytes: %v", err)
+	}
+	sig := ed25519.Sign(priv, bytes)
+	lic.SetSignature(sig)
+	data, _ := json.Marshal(lic)
+	if err := os.WriteFile(filepath.Join(dir, cimode.DefaultLicenseFilename), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBannerSilentInLocalMode(t *testing.T) {
+	// CI vars unset → ModeLocal.
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CIRCLECI", "")
+	t.Setenv("BUILDKITE", "")
+	t.Setenv("GITLAB_CI", "")
+	tw, buf := newTwinForBannerTest(t, "twin-test", nil)
+	if tw.Mode != cimode.ModeLocal {
+		t.Fatalf("Mode = %v, want local", tw.Mode)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("local mode should emit no banner; got: %s", buf.String())
+	}
+}
+
+func TestBannerCIWithoutLicense(t *testing.T) {
+	dir := t.TempDir()
+	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
+		"CI":             "true",
+		"GITHUB_ACTIONS": "",
+		cimode.EnvHome:   dir,
+	})
+	if tw.Mode != cimode.ModeCI {
+		t.Fatalf("Mode = %v, want ci", tw.Mode)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "without valid license") {
+		t.Errorf("expected warn banner; got: %s", out)
+	}
+	if !strings.Contains(out, cimode.ReasonNoLicense) {
+		t.Errorf("expected reason %q; got: %s", cimode.ReasonNoLicense, out)
+	}
+	if !strings.Contains(out, licenseLink) {
+		t.Errorf("expected license link; got: %s", out)
+	}
+}
+
+func TestBannerCIWithExpiredLicense(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	issued := time.Now().Add(-48 * time.Hour)
+	expired := time.Now().Add(-24 * time.Hour)
+	writeSignedLicense(t, dir, cimode.License{
+		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
+		IssuedAt: issued, NotAfter: expired,
+	}, priv)
+
+	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
+		"CI":             "true",
+		"GITHUB_ACTIONS": "",
+		cimode.EnvHome:   dir,
+	})
+	if tw.Mode != cimode.ModeCI {
+		t.Fatalf("Mode = %v", tw.Mode)
+	}
+	if !strings.Contains(buf.String(), cimode.ReasonExpired) {
+		t.Errorf("expected expired reason; got: %s", buf.String())
+	}
+}
+
+func TestBannerCIWithValidLicense(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restore := cimode.SetVerificationKeyForTest(pub)
+	defer restore()
+
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	writeSignedLicense(t, dir, cimode.License{
+		Key: "lic", OrgID: "org_acme", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(30 * 24 * time.Hour),
+	}, priv)
+
+	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
+		"CI":             "true",
+		"GITHUB_ACTIONS": "",
+		cimode.EnvHome:   dir,
+	})
+	if !tw.LicenseStatus.Valid {
+		t.Fatalf("LicenseStatus = %+v", tw.LicenseStatus)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "license active") {
+		t.Errorf("expected info banner; got: %s", out)
+	}
+	if !strings.Contains(out, "org_acme") {
+		t.Errorf("expected org id; got: %s", out)
+	}
+}

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -110,6 +110,17 @@ type Twin struct {
 	// mode does not. Override via WONDERTWIN_REPLAY_* env vars.
 	Replay *replay.Recorder
 
+	// License is the loaded WonderTwin license, or nil when no
+	// license file is present. Populated by New from cimode.LoadLicense.
+	// Consumers (e.g. telemetry) should treat nil as the soft-gate
+	// path — twins continue to serve traffic regardless.
+	License *cimode.License
+
+	// LicenseStatus is the result of validating License against the
+	// twin's name at startup. Always populated; see cimode.Status for
+	// the Reason enum.
+	LicenseStatus cimode.Status
+
 	// configErr is set by New when an unrecoverable configuration
 	// problem is detected (e.g. a non-loopback ObserverEndpoint URL).
 	// Serve checks this field before binding so misconfigured twins
@@ -157,6 +168,8 @@ func New(cfg *Config) *Twin {
 		IDs:       sim.NewIDGenerator(rng),
 		Replay:    rec,
 	}
+	t.loadLicense()
+	t.emitLicenseBanner()
 	t.mountReplayRoutes()
 
 	if err := ValidateObserverEndpoint(cfg.ObserverEndpoint); err != nil {


### PR DESCRIPTION
Implements license validation in `twinkit/cimode` (the empty package
reserved by 0A) plus the soft-gate banner at `twincore.New` startup.
No hard gates: invalid or absent licenses log a one-line warning in
CI mode and never refuse traffic.

## Adds

- `License` type with ed25519 signature over canonical JSON. The
  signing bytes deterministically encode the License with the
  `signature` field cleared; verifiers re-derive identically.
- Embedded WonderTwin public key at `twinkit/cimode/pubkey.go`.
  Rotate by replacing the 32 bytes and redistributing the matching
  private key to the issuer.
- `LoadLicense` with `WONDERTWIN_LICENSE_FILE` env override and
  `$WONDERTWIN_HOME/license.json` (or `$HOME/.wondertwin/license.json`)
  default. Missing default = `nil, nil` (soft-gate path); missing
  explicit path = error.
- `ValidateLicense` with the stable `Reason` enum:
  `"no license"`, `"invalid signature"`, `"license expired"`,
  `"twin not in scope"`. Telemetry (1C) and `wt license status` will
  read these values verbatim.
- `Twin.License` and `Twin.LicenseStatus` plumbed onto the Twin
  struct so session 1C can attach license context to telemetry events.
- Soft-gate banner: `ModeLocal` never banners; `ModeCI` logs an info
  one-liner on valid (`twin`, `org`, `expires_in`) and a warn one-liner
  on invalid (`twin`, `reason`, `link`). Single line, slog k/v style,
  parseable by humans and machines.
- `wt license install <file>` — validates, then copies to
  `$WONDERTWIN_HOME/license.json` (mode 0700/0600). Refuses to install
  invalid licenses; exits non-zero, leaves destination untouched.
- `wt license status` — reads the active license, prints summary,
  exits 1 when invalid or absent.
- `wt license inspect <file>` — same output as status against an
  explicit path; never installs.
- `--json` flag on all three subcommands emits a parseable
  `licenseReport` for scripting.

## Private key handoff

A new ed25519 keypair was generated this session for license signing.
The private key was written to:

    /tmp/wondertwin-license-private-key.bin   (mode 0600, 64 bytes)

Move that file into `wondertwin-app/` (or wherever the issuer service
lives) before session 1D begins; this PR ships only the public half
embedded at `twinkit/cimode/pubkey.go`. Verified via `git diff main`:
no private key bytes appear in the diff.

## Test seam exposure

The spec asked for an unexported `setVerificationKey` test seam, but
the banner tests live in `twinkit/twincore` and need to mint
synthetic licenses without the production private key. To bridge,
`cimode.SetVerificationKeyForTest(pk) (restore func())` is exported
with documentation explicitly forbidding production use. The
unexported `setVerificationKey` it wraps remains the in-package seam.

## Manual smoke tests

Pending. The unit tests cover the same paths end-to-end: synthetic
keypair, sign + install via `cmdLicenseInstall`, validate via
`cmdLicenseStatus`, banner emission against captured slog buffer in
both CI and local modes, plus tampered-license rejection. Live smoke
of `wt license install` against a real `~/.wondertwin/license.json`
and live `CI=true ./twin-stripe` banner observation will need a
follow-up session that can run interactive shells.

## Verification

- `cd twinkit && go build ./... && go test ./... -short && go vet ./...` clean
- `go build ./...` clean (root)
- `go test ./... -short` clean (root)
- `go vet ./...` clean
- `go mod tidy` produces no further changes (both modules)
- All 10 twin binaries compile
- `go run ./cmd/validate-schemas/` passes (30 files / 10 twins)
- Embedded public key file present (`twinkit/cimode/pubkey.go`);
  private key not in diff (verified by grep over `git diff main`)
- Banner does not appear in `ModeLocal` (covered by
  `TestBannerSilentInLocalMode`)
- No `twin-*/...` source files modified
- No `wondertwin-docs/` edits

## Out of scope

- License issuance / signing service (session 1D in `wondertwin-app`)
- Telemetry of license status (session 1C)
- Hard gating of features (intentional; revisit per Wave 1 risk
  register #3 only if conversion lands flat)
- License renewal / `wt license remove` subcommands

Reference: ci-v2-implementation-plan.md §2.5, §3 Phase 2.