### PR TITLE
chore: telemetry shutdown docs and license test-seam removal

### DIFF
--- a/cmd/wt/license_test.go
+++ b/cmd/wt/license_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -13,70 +11,28 @@ import (
 	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
 )
 
-func writeLicenseFile(t *testing.T, path string, lic cimode.License, priv ed25519.PrivateKey) {
+// writeUnverifiableLicense writes a syntactically well-formed but
+// signature-invalid license file. It exercises the parse → validate
+// → reject path of the wt CLI without minting a synthetic valid
+// signature: the verifier here is the production embedded public
+// key, which has no test override anymore.
+func writeUnverifiableLicense(t *testing.T, path string, lic cimode.License) {
 	t.Helper()
-	bytes, err := lic.SigningBytes()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if priv != nil {
-		sig := ed25519.Sign(priv, bytes)
-		lic.SetSignature(sig)
-	}
+	lic.SetSignature([]byte("not-a-real-signature"))
 	data, _ := json.Marshal(lic)
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestLicenseInstallValid(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
+func TestLicenseInstallRefusesUnsignedLicense(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "input.json")
 	now := time.Now().UTC()
-	writeLicenseFile(t, src, cimode.License{
+	writeUnverifiableLicense(t, src, cimode.License{
 		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
 		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
-	}, priv)
-
-	home := t.TempDir()
-	t.Setenv(cimode.EnvHome, home)
-	t.Setenv(cimode.EnvLicenseFile, "")
-
-	out := captureStdout(t, func() {
-		if err := cmdLicenseInstall([]string{src}); err != nil {
-			t.Fatalf("install: %v", err)
-		}
 	})
-	if !strings.Contains(out, "valid") {
-		t.Errorf("expected 'valid' in output; got: %s", out)
-	}
-	dst := filepath.Join(home, cimode.DefaultLicenseFilename)
-	if _, err := os.Stat(dst); err != nil {
-		t.Errorf("expected license at %s; %v", dst, err)
-	}
-}
-
-func TestLicenseInstallRejectsTampered(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
-	dir := t.TempDir()
-	src := filepath.Join(dir, "input.json")
-	now := time.Now().UTC()
-	lic := cimode.License{
-		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
-		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
-	}
-	writeLicenseFile(t, src, lic, priv)
-	// Tamper the file: read, mutate OrgID, write back.
-	raw, _ := os.ReadFile(src)
-	tampered := strings.Replace(string(raw), `"org_id":"org"`, `"org_id":"evil"`, 1)
-	os.WriteFile(src, []byte(tampered), 0o600)
 
 	home := t.TempDir()
 	t.Setenv(cimode.EnvHome, home)
@@ -84,10 +40,10 @@ func TestLicenseInstallRejectsTampered(t *testing.T) {
 
 	err := cmdLicenseInstall([]string{src})
 	if err == nil {
-		t.Fatal("expected install to refuse tampered license")
+		t.Fatal("expected install to refuse license without valid signature")
 	}
 	if !strings.Contains(err.Error(), cimode.ReasonInvalidSig) {
-		t.Errorf("error = %v, want invalid signature", err)
+		t.Errorf("error = %v, want %q", err, cimode.ReasonInvalidSig)
 	}
 	dst := filepath.Join(home, cimode.DefaultLicenseFilename)
 	if _, err := os.Stat(dst); !os.IsNotExist(err) {
@@ -95,66 +51,67 @@ func TestLicenseInstallRejectsTampered(t *testing.T) {
 	}
 }
 
-func TestLicenseInspectDoesNotInstall(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
+func TestLicenseInstallRefusesMalformedJSON(t *testing.T) {
 	dir := t.TempDir()
-	src := filepath.Join(dir, "input.json")
-	now := time.Now().UTC()
-	writeLicenseFile(t, src, cimode.License{
-		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
-		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
-	}, priv)
-
+	src := filepath.Join(dir, "garbage.json")
+	if err := os.WriteFile(src, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	home := t.TempDir()
 	t.Setenv(cimode.EnvHome, home)
 	t.Setenv(cimode.EnvLicenseFile, "")
-
-	out := captureStdout(t, func() {
-		if err := cmdLicenseInspect([]string{src}); err != nil {
-			t.Fatalf("inspect: %v", err)
-		}
-	})
-	if !strings.Contains(out, "valid") {
-		t.Errorf("expected valid output; got: %s", out)
-	}
-	if _, err := os.Stat(filepath.Join(home, cimode.DefaultLicenseFilename)); !os.IsNotExist(err) {
-		t.Errorf("inspect should not install; stat err = %v", err)
+	if err := cmdLicenseInstall([]string{src}); err == nil {
+		t.Fatal("expected install to fail on malformed JSON")
 	}
 }
 
-func TestLicenseInstallJSON(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
+func TestLicenseInspectReportsInvalidWithoutInstall(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "input.json")
 	now := time.Now().UTC()
-	writeLicenseFile(t, src, cimode.License{
-		Key: "lic", OrgID: "org_acme", TwinScope: []string{"*"},
+	writeUnverifiableLicense(t, src, cimode.License{
+		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
 		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
-	}, priv)
+	})
 
 	home := t.TempDir()
 	t.Setenv(cimode.EnvHome, home)
 	t.Setenv(cimode.EnvLicenseFile, "")
 
 	out := captureStdout(t, func() {
-		if err := cmdLicenseInstall([]string{"--json", src}); err != nil {
-			t.Fatalf("install --json: %v", err)
-		}
+		_ = cmdLicenseInspect([]string{src})
+	})
+	if !strings.Contains(out, cimode.ReasonInvalidSig) {
+		t.Errorf("expected reason in output; got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(home, cimode.DefaultLicenseFilename)); !os.IsNotExist(err) {
+		t.Errorf("inspect must not install; stat err = %v", err)
+	}
+}
+
+func TestLicenseInstallJSONOnInvalidEmitsParseable(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "input.json")
+	now := time.Now().UTC()
+	writeUnverifiableLicense(t, src, cimode.License{
+		Key: "lic", OrgID: "org_acme", TwinScope: []string{"*"},
+		IssuedAt: now, NotAfter: now.Add(24 * time.Hour),
+	})
+	home := t.TempDir()
+	t.Setenv(cimode.EnvHome, home)
+	t.Setenv(cimode.EnvLicenseFile, "")
+
+	out := captureStdout(t, func() {
+		_ = cmdLicenseInstall([]string{"--json", src})
 	})
 	var r licenseReport
 	if err := json.Unmarshal([]byte(out), &r); err != nil {
 		t.Fatalf("not valid JSON: %v\n%s", err, out)
 	}
-	if !r.Valid || !r.Installed {
-		t.Errorf("report = %+v", r)
+	if r.Valid || r.Installed {
+		t.Errorf("expected invalid+not-installed; report = %+v", r)
 	}
-	if r.License == nil || r.License.OrgID != "org_acme" {
-		t.Errorf("license missing or wrong org: %+v", r.License)
+	if r.Reason != cimode.ReasonInvalidSig {
+		t.Errorf("Reason = %q, want %q", r.Reason, cimode.ReasonInvalidSig)
 	}
 }

--- a/twinkit/cimode/verify.go
+++ b/twinkit/cimode/verify.go
@@ -32,14 +32,6 @@ func setVerificationKey(pk ed25519.PublicKey) (restore func()) {
 	}
 }
 
-// SetVerificationKeyForTest is exposed only for use by tests in
-// dependent packages (e.g. twinkit/twincore's license-banner tests
-// that must mint a synthetic license without the production private
-// key). It MUST NOT be called by production code.
-func SetVerificationKeyForTest(pk ed25519.PublicKey) (restore func()) {
-	return setVerificationKey(pk)
-}
-
 // verifySignature returns true when lic.Signature is a valid ed25519
 // signature over lic.SigningBytes() under the active verification
 // key. Any error in deriving the signing bytes or decoding the

--- a/twinkit/telemetry/telemetry.go
+++ b/twinkit/telemetry/telemetry.go
@@ -215,7 +215,19 @@ func (r *Reporter) Flush(ctx context.Context) error {
 }
 
 // Close signals the goroutine to stop. It performs a best-effort
-// drain bounded by closeFlushDeadline. Idempotent.
+// drain bounded by closeFlushDeadline (1 second). Idempotent.
+//
+// Shutdown ordering matters for callers wiring Close into a process
+// signal path: events recorded just before SIGTERM may be in-flight
+// in the bounded channel or in a half-built batch. Close has up to
+// closeFlushDeadline to deliver them. Process supervisors that send
+// SIGTERM and then SIGKILL with no grace (or with a grace shorter
+// than closeFlushDeadline) will lose tail events.
+//
+// CI integrations should grant the twin process at least 2 seconds
+// post-SIGTERM before forcing termination so the telemetry path can
+// complete one final batch POST: closeFlushDeadline (1s) plus
+// headroom for ticker quiescence and a single HTTP round-trip.
 func (r *Reporter) Close() {
 	if r == nil {
 		return

--- a/twinkit/twincore/license_banner_test.go
+++ b/twinkit/twincore/license_banner_test.go
@@ -2,12 +2,7 @@ package twincore
 
 import (
 	"bytes"
-	"crypto/ed25519"
-	"crypto/rand"
-	"encoding/json"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -15,38 +10,20 @@ import (
 	"github.com/wondertwin-ai/wondertwin/twinkit/cimode"
 )
 
-// captureBanner installs a buffered slog handler on the Twin so tests
-// can assert against the banner output. It is invoked after New() so
-// the constructor's Logger ends up replaced; the existing banner has
-// already been emitted to the original logger. To capture the banner,
-// callers should set the buffer first via newTwinForBannerTest.
+// newTwinForBannerTest builds a Twin, swaps in a captured logger, and
+// returns both. Callers re-invoke emitLicenseBanner explicitly after
+// mutating Twin.License / Twin.LicenseStatus so the banner reflects
+// the test-controlled state rather than whatever LoadLicense found on
+// disk.
 func newTwinForBannerTest(t *testing.T, name string, env map[string]string) (*Twin, *bytes.Buffer) {
 	t.Helper()
 	for k, v := range env {
 		t.Setenv(k, v)
 	}
-	buf := &bytes.Buffer{}
-	// Hook the logger by replacing os.Stdout temporarily? Simpler:
-	// build a Twin and then re-emit the banner against a captured
-	// logger — the banner is deterministic given Twin state.
 	tw := New(&Config{Name: name})
+	buf := &bytes.Buffer{}
 	tw.Logger = slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	tw.emitLicenseBanner()
 	return tw, buf
-}
-
-func writeSignedLicense(t *testing.T, dir string, lic cimode.License, priv ed25519.PrivateKey) {
-	t.Helper()
-	bytes, err := lic.SigningBytes()
-	if err != nil {
-		t.Fatalf("SigningBytes: %v", err)
-	}
-	sig := ed25519.Sign(priv, bytes)
-	lic.SetSignature(sig)
-	data, _ := json.Marshal(lic)
-	if err := os.WriteFile(filepath.Join(dir, cimode.DefaultLicenseFilename), data, 0o600); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestBannerSilentInLocalMode(t *testing.T) {
@@ -60,21 +37,23 @@ func TestBannerSilentInLocalMode(t *testing.T) {
 	if tw.Mode != cimode.ModeLocal {
 		t.Fatalf("Mode = %v, want local", tw.Mode)
 	}
+	tw.emitLicenseBanner()
 	if buf.Len() != 0 {
 		t.Errorf("local mode should emit no banner; got: %s", buf.String())
 	}
 }
 
 func TestBannerCIWithoutLicense(t *testing.T) {
-	dir := t.TempDir()
 	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
 		"CI":             "true",
 		"GITHUB_ACTIONS": "",
-		cimode.EnvHome:   dir,
 	})
 	if tw.Mode != cimode.ModeCI {
 		t.Fatalf("Mode = %v, want ci", tw.Mode)
 	}
+	tw.License = nil
+	tw.LicenseStatus = cimode.Status{Reason: cimode.ReasonNoLicense}
+	tw.emitLicenseBanner()
 	out := buf.String()
 	if !strings.Contains(out, "without valid license") {
 		t.Errorf("expected warn banner; got: %s", out)
@@ -88,57 +67,29 @@ func TestBannerCIWithoutLicense(t *testing.T) {
 }
 
 func TestBannerCIWithExpiredLicense(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
-	dir := t.TempDir()
-	issued := time.Now().Add(-48 * time.Hour)
-	expired := time.Now().Add(-24 * time.Hour)
-	writeSignedLicense(t, dir, cimode.License{
-		Key: "lic", OrgID: "org", TwinScope: []string{"*"},
-		IssuedAt: issued, NotAfter: expired,
-	}, priv)
-
 	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
 		"CI":             "true",
 		"GITHUB_ACTIONS": "",
-		cimode.EnvHome:   dir,
 	})
 	if tw.Mode != cimode.ModeCI {
 		t.Fatalf("Mode = %v", tw.Mode)
 	}
+	tw.License = &cimode.License{Key: "lic", OrgID: "org"}
+	tw.LicenseStatus = cimode.Status{Reason: cimode.ReasonExpired, ExpiresIn: -time.Hour}
+	tw.emitLicenseBanner()
 	if !strings.Contains(buf.String(), cimode.ReasonExpired) {
 		t.Errorf("expected expired reason; got: %s", buf.String())
 	}
 }
 
 func TestBannerCIWithValidLicense(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	restore := cimode.SetVerificationKeyForTest(pub)
-	defer restore()
-
-	dir := t.TempDir()
-	now := time.Now().UTC()
-	writeSignedLicense(t, dir, cimode.License{
-		Key: "lic", OrgID: "org_acme", TwinScope: []string{"*"},
-		IssuedAt: now, NotAfter: now.Add(30 * 24 * time.Hour),
-	}, priv)
-
 	tw, buf := newTwinForBannerTest(t, "twin-test", map[string]string{
 		"CI":             "true",
 		"GITHUB_ACTIONS": "",
-		cimode.EnvHome:   dir,
 	})
-	if !tw.LicenseStatus.Valid {
-		t.Fatalf("LicenseStatus = %+v", tw.LicenseStatus)
-	}
+	tw.License = &cimode.License{Key: "lic", OrgID: "org_acme"}
+	tw.LicenseStatus = cimode.Status{Valid: true, ExpiresIn: 24 * time.Hour}
+	tw.emitLicenseBanner()
 	out := buf.String()
 	if !strings.Contains(out, "license active") {
 		t.Errorf("expected info banner; got: %s", out)

--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -351,6 +351,13 @@ func (t *Twin) UpdateConfig(updates map[string]any) error {
 }
 
 // Serve starts the HTTP server and blocks until shutdown signal.
+//
+// On SIGTERM/SIGINT, Serve drains the HTTP server (10s budget) and
+// then calls Twin.Close to flush per-twin resources — most notably
+// the telemetry reporter. Process supervisors should grant at least
+// 2 seconds post-SIGTERM before forcing termination so the
+// telemetry path can complete one final batch POST; see
+// telemetry.Reporter.Close for details.
 func (t *Twin) Serve() error {
 	if t.configErr != nil {
 		return t.configErr


### PR DESCRIPTION
Two small follow-ups from the 1B and 1C audits.

## 1. Telemetry shutdown docs

`Reporter.Close` and `Twin.Serve` doc comments now spell out the
1 second flush deadline and the ~2 second SIGTERM grace recommendation.
Process supervisors that send SIGTERM and then SIGKILL with no grace
will lose tail telemetry events; the docs make the requirement
explicit so customers wiring twins into CI workflows know the floor.

## 2. License test-seam removal

`cimode.SetVerificationKeyForTest` is removed. The verification key
is the trust anchor for license validation; it should not have a
public mutator. The cross-package test seam was unnecessary —
`twincore` banner tests now manipulate `Twin.License` and
`Twin.LicenseStatus` directly instead of round-tripping through
file loading and crypto.

The wt CLI tests previously used the seam to mint synthetic valid
licenses for the install/inspect happy path. Without the seam those
tests can no longer validate against an arbitrary key, so they have
been refactored to exercise the parse → validate → reject paths
(unsigned/malformed/invalid licenses) plus the `--json` shape on
invalid input. The crypto round-trip remains covered by
`twinkit/cimode`'s package-internal tests.

Audit: `grep -rn SetVerificationKeyForTest` → zero matches.

## Verification

- `cd twinkit && go build ./... && go test ./... -short && go vet ./...` clean
- root `go build ./... && go test ./... -short && go vet ./...` clean
- All 10 twin binaries compile
- No diff under `twin-*/`, `wondertwin-docs/`

No production behavior change. No new public API.