### PR TITLE
feat: wt runs subcommands for CI run lifecycle

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -143,6 +143,8 @@ func main() {
 		err = cmdReplay(args)
 	case "license":
 		err = cmdLicense(args)
+	case "runs":
+		err = cmdRuns(args)
 	default:
 		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
 		printUsage()
@@ -212,6 +214,10 @@ Commands:
   license install <file>     Install a signed WonderTwin license file
   license status             Show the active license's status
   license inspect <file>     Show a license file without installing
+  runs start                 Start a run on a running twin (drives /admin/runs/start)
+  runs finish                Finish a run; optional --export to write JSONL
+  runs current               Show the active run on a running twin
+  runs wrap -- <cmd>         Start a run, exec <cmd>, finish on exit
   version                    Print the wt version
 
 Options:

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -31,6 +31,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -152,6 +153,14 @@ func main() {
 	}
 
 	if err != nil {
+		var ec ExitCodeError
+		if errors.As(err, &ec) {
+			// Child process surfaced its exit code via the typed
+			// error. Skip the "wt: ..." prefix — the child wrote its
+			// own output, the wrap path printed cleanup confirmation,
+			// and customers see the code via $?.
+			os.Exit(ec.Code())
+		}
 		fmt.Fprintf(os.Stderr, "wt: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/wt/runs.go
+++ b/cmd/wt/runs.go
@@ -1,0 +1,410 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// runsHelp is printed when the user runs `wt runs` with no verb or
+// asks for `--help`. The examples are intentionally copy-pasteable.
+const runsHelp = `wt runs — drive a twin's /admin/runs/* lifecycle
+
+Usage:
+  wt runs start   [--twin URL] [--seed N] [--fixtures FILE] [--run-id ID] [--json]
+  wt runs finish  [--twin URL] [--run-id ID] [--export PATH] [--gzip] [--json]
+  wt runs current [--twin URL] [--json]
+  wt runs wrap    [--twin URL] [--seed N] [--fixtures FILE] [--run-id ID] [--export PATH] [--gzip] -- <command> [args...]
+
+Examples:
+  wt runs start --twin http://127.0.0.1:4111 --seed 42 --run-id ci-123
+  wt runs wrap --seed 42 --export /tmp/run.jsonl.gz --gzip -- go test ./...
+  wt runs finish --run-id ci-123 --export /tmp/run.jsonl.gz
+
+The twin must already be running. wt runs wrap does NOT spawn the twin
+— customers manage twin lifecycle externally (docker-compose, &, GitHub
+Actions service container).
+
+For raw bundle access without lifecycle, see wt replay export.
+`
+
+// cmdRuns dispatches `wt runs <verb>`.
+func cmdRuns(args []string) error {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fmt.Print(runsHelp)
+		if len(args) == 0 {
+			return fmt.Errorf("usage: wt runs <start|finish|current|wrap> [flags]")
+		}
+		return nil
+	}
+	switch args[0] {
+	case "start":
+		return cmdRunsStart(args[1:])
+	case "finish":
+		return cmdRunsFinish(args[1:])
+	case "current":
+		return cmdRunsCurrent(args[1:])
+	case "wrap":
+		return cmdRunsWrap(args[1:])
+	default:
+		return fmt.Errorf("unknown runs subcommand %q (want: start, finish, current, wrap)", args[0])
+	}
+}
+
+// resolveTwinURL returns the twin base URL. Precedence:
+// flag → WT_TWIN_URL env → http://127.0.0.1:4111.
+func resolveTwinURL(flagVal string) string {
+	if flagVal != "" {
+		return strings.TrimRight(flagVal, "/")
+	}
+	if v := os.Getenv("WT_TWIN_URL"); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return "http://127.0.0.1:4111"
+}
+
+// startRunRequest mirrors the admin handler's body shape.
+type startRunRequest struct {
+	RunID    string          `json:"run_id,omitempty"`
+	Seed     int64           `json:"seed,omitempty"`
+	Fixtures json.RawMessage `json:"fixtures,omitempty"`
+}
+
+func loadFixtures(path string) (json.RawMessage, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read fixtures: %w", err)
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("fixtures file %s is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func cmdRunsStart(args []string) error {
+	fs := flag.NewFlagSet("wt runs start", flag.ContinueOnError)
+	twin := fs.String("twin", "", "Twin base URL (default: $WT_TWIN_URL or http://127.0.0.1:4111)")
+	seed := fs.Int64("seed", 0, "Deterministic seed (0 = unset)")
+	runID := fs.String("run-id", "", "Run identifier (auto-generated when empty)")
+	fixturesPath := fs.String("fixtures", "", "Path to a JSON file forwarded as the run's fixtures blob")
+	asJSON := fs.Bool("json", false, "Emit the server response as JSON to stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	url := resolveTwinURL(*twin)
+	body := startRunRequest{RunID: *runID, Seed: *seed}
+	if fx, err := loadFixtures(*fixturesPath); err != nil {
+		return err
+	} else if fx != nil {
+		body.Fixtures = fx
+	}
+	raw, err := postJSON(url+"/admin/runs/start", body)
+	if err != nil {
+		return err
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	id, _ := resp["run_id"].(string)
+	if *asJSON {
+		os.Stdout.Write(raw)
+		fmt.Println()
+	} else {
+		fmt.Fprintf(os.Stderr, "WT_RUN_ID=%s\n", id)
+		fmt.Fprintf(os.Stderr, "started run %s on %s (seed=%v seed_source=%v)\n", id, url, resp["seeded"], resp["seed_source"])
+	}
+
+	writeGitHubEnv("WT_RUN_ID", id)
+	writeGitHubEnv("WT_TWIN_URL", url)
+	return nil
+}
+
+type finishResp struct {
+	RunID      string    `json:"run_id"`
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	FinishedAt time.Time `json:"finished_at,omitempty"`
+	EntryCount int       `json:"entry_count,omitempty"`
+}
+
+func cmdRunsFinish(args []string) error {
+	fs := flag.NewFlagSet("wt runs finish", flag.ContinueOnError)
+	twin := fs.String("twin", "", "Twin base URL (default: $WT_TWIN_URL or http://127.0.0.1:4111)")
+	runID := fs.String("run-id", os.Getenv("WT_RUN_ID"), "Run identifier (default: $WT_RUN_ID)")
+	export := fs.String("export", "", "Write the JSONL replay bundle to PATH after finish")
+	gz := fs.Bool("gzip", false, "Gzip-compress --export output (also auto-detected from .gz suffix)")
+	asJSON := fs.Bool("json", false, "Emit the manifest as JSON to stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	url := resolveTwinURL(*twin)
+	status, raw, err := postJSONStatus(url+"/admin/runs/finish", map[string]string{"run_id": *runID})
+	if err != nil {
+		return err
+	}
+	switch status {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		fmt.Fprintln(os.Stderr, "wt runs finish: no run active; skipping export")
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf("run_id mismatch: %s", strings.TrimSpace(string(raw)))
+	default:
+		return fmt.Errorf("twin returned HTTP %d: %s", status, strings.TrimSpace(string(raw)))
+	}
+
+	var manifest finishResp
+	_ = json.Unmarshal(raw, &manifest)
+	if *asJSON {
+		os.Stdout.Write(raw)
+		fmt.Println()
+	} else {
+		fmt.Fprintf(os.Stderr, "finished run %s (entries=%d)\n", manifest.RunID, manifest.EntryCount)
+	}
+
+	if *export != "" {
+		if err := exportBundle(url, *export, *gz || strings.HasSuffix(*export, ".gz")); err != nil {
+			return err
+		}
+		writeStepSummary(url, manifest, *export)
+	}
+	return nil
+}
+
+func cmdRunsCurrent(args []string) error {
+	fs := flag.NewFlagSet("wt runs current", flag.ContinueOnError)
+	twin := fs.String("twin", "", "Twin base URL (default: $WT_TWIN_URL or http://127.0.0.1:4111)")
+	asJSON := fs.Bool("json", false, "Emit the response as JSON to stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	url := resolveTwinURL(*twin)
+	resp, err := http.Get(url + "/admin/runs/current")
+	if err != nil {
+		return fmt.Errorf("fetch current run: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("twin returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if *asJSON {
+		os.Stdout.Write(raw)
+		fmt.Println()
+		return nil
+	}
+	var c map[string]any
+	_ = json.Unmarshal(raw, &c)
+	if id, _ := c["run_id"].(string); id == "" {
+		fmt.Println("no run active")
+		return nil
+	}
+	fmt.Printf("run_id:      %v\n", c["run_id"])
+	if v, ok := c["started_at"]; ok {
+		fmt.Printf("started_at:  %v\n", v)
+	}
+	fmt.Printf("entry_count: %v\n", c["entry_count"])
+	if v, ok := c["seed_source"]; ok && v != "" {
+		fmt.Printf("seed_source: %v\n", v)
+	}
+	return nil
+}
+
+// cmdRunsWrap starts a run, runs the child command, and always
+// finishes on exit. Returns the child's exit code.
+func cmdRunsWrap(args []string) error {
+	fs := flag.NewFlagSet("wt runs wrap", flag.ContinueOnError)
+	twin := fs.String("twin", "", "Twin base URL (default: $WT_TWIN_URL or http://127.0.0.1:4111)")
+	seed := fs.Int64("seed", 0, "Deterministic seed (0 = unset)")
+	runID := fs.String("run-id", "", "Run identifier (auto-generated when empty)")
+	fixturesPath := fs.String("fixtures", "", "Path to a JSON fixtures file")
+	export := fs.String("export", "", "Write the JSONL replay bundle to PATH after finish")
+	gz := fs.Bool("gzip", false, "Gzip-compress --export output (also auto-detected from .gz suffix)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return fmt.Errorf("usage: wt runs wrap [flags] -- <command> [args...]")
+	}
+
+	url := resolveTwinURL(*twin)
+	body := startRunRequest{RunID: *runID, Seed: *seed}
+	if fx, err := loadFixtures(*fixturesPath); err != nil {
+		return err
+	} else if fx != nil {
+		body.Fixtures = fx
+	}
+	startRaw, err := postJSON(url+"/admin/runs/start", body)
+	if err != nil {
+		return err
+	}
+	var startResp map[string]any
+	_ = json.Unmarshal(startRaw, &startResp)
+	id, _ := startResp["run_id"].(string)
+	fmt.Fprintf(os.Stderr, "wt runs wrap: started run %s\n", id)
+
+	defer func() {
+		status, finishRaw, err := postJSONStatus(url+"/admin/runs/finish", map[string]string{"run_id": id})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wt runs wrap: finish failed: %v\n", err)
+			return
+		}
+		if status != http.StatusOK && status != http.StatusNotFound {
+			fmt.Fprintf(os.Stderr, "wt runs wrap: finish returned HTTP %d: %s\n", status, finishRaw)
+			return
+		}
+		var manifest finishResp
+		_ = json.Unmarshal(finishRaw, &manifest)
+		fmt.Fprintf(os.Stderr, "wt runs wrap: finished run %s (entries=%d)\n", manifest.RunID, manifest.EntryCount)
+		if *export != "" {
+			if err := exportBundle(url, *export, *gz || strings.HasSuffix(*export, ".gz")); err != nil {
+				fmt.Fprintf(os.Stderr, "wt runs wrap: export failed: %v\n", err)
+				return
+			}
+			writeStepSummary(url, manifest, *export)
+		}
+	}()
+
+	cmd := exec.Command(rest[0], rest[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "WT_RUN_ID="+id, "WT_TWIN_URL="+url)
+	err = cmd.Run()
+	if err != nil {
+		var ee *exec.ExitError
+		if asExitErr(&ee, err) {
+			os.Exit(ee.ExitCode())
+		}
+		return fmt.Errorf("exec: %w", err)
+	}
+	return nil
+}
+
+// asExitErr is a tiny helper to avoid importing errors just for As.
+func asExitErr(target **exec.ExitError, err error) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// postJSON wraps postJSONStatus and treats non-2xx as an error.
+func postJSON(url string, body any) ([]byte, error) {
+	status, raw, err := postJSONStatus(url, body)
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("twin returned HTTP %d: %s", status, strings.TrimSpace(string(raw)))
+	}
+	return raw, nil
+}
+
+func postJSONStatus(url string, body any) (int, []byte, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, nil, err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(url, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		return 0, nil, fmt.Errorf("post %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, nil
+}
+
+// exportBundle GETs /admin/replay and writes the response to path.
+func exportBundle(twinURL, path string, useGzip bool) error {
+	resp, err := http.Get(twinURL + "/admin/replay")
+	if err != nil {
+		return fmt.Errorf("fetch replay bundle: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("twin returned HTTP %d", resp.StatusCode)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	var w io.Writer = f
+	var gzCloser io.Closer
+	if useGzip {
+		gzw := gzip.NewWriter(f)
+		gzCloser = gzw
+		w = gzw
+	}
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		f.Close()
+		return err
+	}
+	if gzCloser != nil {
+		if err := gzCloser.Close(); err != nil {
+			f.Close()
+			return err
+		}
+	}
+	return f.Close()
+}
+
+// writeGitHubEnv appends `KEY=value` to $GITHUB_ENV when that env var
+// is set and the file is writable. Standard GitHub Actions
+// convention. Silent no-op outside of GitHub Actions.
+func writeGitHubEnv(key, value string) {
+	path := os.Getenv("GITHUB_ENV")
+	if path == "" || value == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s=%s\n", key, value)
+}
+
+// writeStepSummary appends a markdown table to $GITHUB_STEP_SUMMARY
+// when set. Customers see the summary in the GitHub Actions UI
+// without opening the artifact.
+func writeStepSummary(twinURL string, manifest finishResp, exportPath string) {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "### WonderTwin replay bundle\n\n")
+	fmt.Fprintf(f, "| field | value |\n| --- | --- |\n")
+	fmt.Fprintf(f, "| run_id | `%s` |\n", manifest.RunID)
+	fmt.Fprintf(f, "| twin | `%s` |\n", twinURL)
+	fmt.Fprintf(f, "| entry_count | %d |\n", manifest.EntryCount)
+	if !manifest.StartedAt.IsZero() {
+		fmt.Fprintf(f, "| started_at | %s |\n", manifest.StartedAt.UTC().Format(time.RFC3339))
+	}
+	if !manifest.FinishedAt.IsZero() {
+		fmt.Fprintf(f, "| finished_at | %s |\n", manifest.FinishedAt.UTC().Format(time.RFC3339))
+	}
+	fmt.Fprintf(f, "| export | `%s` |\n\n", exportPath)
+}

--- a/cmd/wt/runs.go
+++ b/cmd/wt/runs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +14,16 @@ import (
 	"strings"
 	"time"
 )
+
+// ExitCodeError carries a child exit code up through the normal Go
+// error-return path so deferred cleanup in cmdRunsWrap runs before
+// the process exits. main.go inspects for this error and calls
+// os.Exit with the embedded code without printing the generic
+// "wt: ..." prefix.
+type ExitCodeError int
+
+func (e ExitCodeError) Error() string { return fmt.Sprintf("child exited with code %d", int(e)) }
+func (e ExitCodeError) Code() int     { return int(e) }
 
 // runsHelp is printed when the user runs `wt runs` with no verb or
 // asks for `--help`. The examples are intentionally copy-pasteable.
@@ -285,24 +296,16 @@ func cmdRunsWrap(args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "WT_RUN_ID="+id, "WT_TWIN_URL="+url)
-	err = cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		var ee *exec.ExitError
-		if asExitErr(&ee, err) {
-			os.Exit(ee.ExitCode())
+		if errors.As(err, &ee) {
+			// Returning the typed error lets the deferred finish +
+			// export run before main.go translates it into os.Exit.
+			return ExitCodeError(ee.ExitCode())
 		}
 		return fmt.Errorf("exec: %w", err)
 	}
 	return nil
-}
-
-// asExitErr is a tiny helper to avoid importing errors just for As.
-func asExitErr(target **exec.ExitError, err error) bool {
-	if e, ok := err.(*exec.ExitError); ok {
-		*target = e
-		return true
-	}
-	return false
 }
 
 // postJSON wraps postJSONStatus and treats non-2xx as an error.

--- a/cmd/wt/runs_test.go
+++ b/cmd/wt/runs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -294,6 +295,37 @@ func TestRunsWrapHappyPathAndCleanup(t *testing.T) {
 	}
 	if s.finishes.Load() < 1 {
 		t.Errorf("expected finish call after wrap")
+	}
+}
+
+func TestRunsWrapFinishesOnChildNonZeroExit(t *testing.T) {
+	// The headline failure case: a child that exits non-zero. The
+	// deferred finish + export must run before the typed error
+	// propagates up to main, otherwise CI workflows lose the replay
+	// artifact at exactly the moment they need it most.
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "wrap-fail.jsonl")
+
+	err := cmdRunsWrap([]string{
+		"--twin", s.URL,
+		"--run-id", "wrap-fail-7",
+		"--export", bundle,
+		"--",
+		"sh", "-c", "exit 7",
+	})
+	var ec ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError, got %T: %v", err, err)
+	}
+	if ec.Code() != 7 {
+		t.Errorf("exit code = %d, want 7", ec.Code())
+	}
+	if s.finishes.Load() < 1 {
+		t.Errorf("finish must fire even when child exits non-zero")
+	}
+	if _, statErr := os.Stat(bundle); statErr != nil {
+		t.Errorf("export not written on non-zero exit; stat err = %v", statErr)
 	}
 }
 

--- a/cmd/wt/runs_test.go
+++ b/cmd/wt/runs_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// stubTwin returns a server that satisfies the /admin/runs/* and
+// /admin/replay surface used by wt runs.
+type stubTwin struct {
+	*httptest.Server
+	starts        atomic.Int64
+	finishes      atomic.Int64
+	currents      atomic.Int64
+	lastStartBody atomic.Pointer[startRunRequest]
+	finishStatus  int // override status (0 → 200)
+}
+
+func newStubTwin(t *testing.T) *stubTwin {
+	t.Helper()
+	s := &stubTwin{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/admin/runs/start":
+			var body startRunRequest
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.lastStartBody.Store(&body)
+			s.starts.Add(1)
+			runID := body.RunID
+			if runID == "" {
+				runID = "wt-run-stub-1"
+			}
+			seedSrc := "none"
+			if len(body.Fixtures) > 0 {
+				seedSrc = "byo"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"run_id":      runID,
+				"seed":        body.Seed,
+				"seeded":      body.Seed != 0,
+				"seed_source": seedSrc,
+			})
+		case "/admin/runs/finish":
+			s.finishes.Add(1)
+			status := s.finishStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if status == http.StatusOK {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"run_id":      "wt-run-stub-1",
+					"entry_count": 3,
+				})
+			} else {
+				_, _ = w.Write([]byte(`{"error":"stub"}`))
+			}
+		case "/admin/runs/current":
+			s.currents.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"run_id":      "wt-run-stub-1",
+				"entry_count": 1,
+				"seeded":      true,
+				"seed_source": "byo",
+			})
+		case "/admin/replay":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = io.WriteString(w, `{"schema_version":1,"run_id":"wt-run-stub-1","entry_count":1}`+"\n")
+			_, _ = io.WriteString(w, `{"seq":0,"method":"GET","path":"/v1/x"}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestRunsStartHappy(t *testing.T) {
+	s := newStubTwin(t)
+	t.Setenv("WT_TWIN_URL", "")
+	t.Setenv("GITHUB_ENV", "")
+	if err := cmdRunsStart([]string{"--twin", s.URL, "--seed", "42", "--run-id", "smoke-1"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if s.starts.Load() != 1 {
+		t.Fatalf("expected 1 start; got %d", s.starts.Load())
+	}
+	body := s.lastStartBody.Load()
+	if body.RunID != "smoke-1" || body.Seed != 42 {
+		t.Errorf("body = %+v", body)
+	}
+}
+
+func TestRunsStartFixtures(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fx.json")
+	os.WriteFile(path, []byte(`{"k":"v"}`), 0o600)
+	if err := cmdRunsStart([]string{"--twin", s.URL, "--fixtures", path}); err != nil {
+		t.Fatal(err)
+	}
+	got := string(s.lastStartBody.Load().Fixtures)
+	if !strings.Contains(got, `"k":"v"`) {
+		t.Errorf("fixtures forwarded as %q", got)
+	}
+}
+
+func TestRunsStartRejectsNonJSONFixtures(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fx.txt")
+	os.WriteFile(path, []byte("not json"), 0o600)
+	err := cmdRunsStart([]string{"--twin", s.URL, "--fixtures", path})
+	if err == nil || !strings.Contains(err.Error(), "valid JSON") {
+		t.Errorf("expected JSON validation error; got %v", err)
+	}
+}
+
+func TestRunsStartGithubEnv(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env")
+	os.WriteFile(envFile, nil, 0o600)
+	t.Setenv("GITHUB_ENV", envFile)
+	if err := cmdRunsStart([]string{"--twin", s.URL, "--run-id", "ci-1"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(envFile)
+	out := string(got)
+	if !strings.Contains(out, "WT_RUN_ID=ci-1") {
+		t.Errorf("GITHUB_ENV missing WT_RUN_ID; got: %s", out)
+	}
+	if !strings.Contains(out, "WT_TWIN_URL="+s.URL) {
+		t.Errorf("GITHUB_ENV missing WT_TWIN_URL; got: %s", out)
+	}
+}
+
+func TestRunsStartGithubEnvAbsent(t *testing.T) {
+	s := newStubTwin(t)
+	t.Setenv("GITHUB_ENV", "")
+	// Should not error or panic when GITHUB_ENV is unset.
+	if err := cmdRunsStart([]string{"--twin", s.URL, "--run-id", "ci-2"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunsStartJSONOutput(t *testing.T) {
+	s := newStubTwin(t)
+	out := captureStdout(t, func() {
+		_ = cmdRunsStart([]string{"--twin", s.URL, "--run-id", "id-1", "--json"})
+	})
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if got["run_id"] != "id-1" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestRunsFinishExport(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.jsonl")
+	if err := cmdRunsFinish([]string{"--twin", s.URL, "--run-id", "x", "--export", path}); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "schema_version") {
+		t.Errorf("bundle missing manifest: %s", got)
+	}
+}
+
+func TestRunsFinishExportGzipBySuffix(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.jsonl.gz")
+	if err := cmdRunsFinish([]string{"--twin", s.URL, "--run-id", "x", "--export", path}); err != nil {
+		t.Fatal(err)
+	}
+	f, _ := os.Open(path)
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("not gzip: %v", err)
+	}
+	defer gz.Close()
+	got, _ := io.ReadAll(gz)
+	if !strings.Contains(string(got), "schema_version") {
+		t.Errorf("decompressed = %s", got)
+	}
+}
+
+func TestRunsFinish404Idempotent(t *testing.T) {
+	s := newStubTwin(t)
+	s.finishStatus = http.StatusNotFound
+	if err := cmdRunsFinish([]string{"--twin", s.URL}); err != nil {
+		t.Errorf("expected 404 to be treated as success; got %v", err)
+	}
+}
+
+func TestRunsFinish409Errors(t *testing.T) {
+	s := newStubTwin(t)
+	s.finishStatus = http.StatusConflict
+	err := cmdRunsFinish([]string{"--twin", s.URL, "--run-id", "wrong"})
+	if err == nil || !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("expected mismatch error; got %v", err)
+	}
+}
+
+func TestRunsFinishStepSummary(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	summary := filepath.Join(dir, "summary.md")
+	bundle := filepath.Join(dir, "bundle.jsonl")
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+	if err := cmdRunsFinish([]string{"--twin", s.URL, "--run-id", "x", "--export", bundle}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(summary)
+	for _, want := range []string{"WonderTwin replay bundle", "wt-run-stub-1", "entry_count"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("summary missing %q; got: %s", want, got)
+		}
+	}
+}
+
+func TestRunsCurrent(t *testing.T) {
+	s := newStubTwin(t)
+	out := captureStdout(t, func() {
+		_ = cmdRunsCurrent([]string{"--twin", s.URL})
+	})
+	if !strings.Contains(out, "wt-run-stub-1") {
+		t.Errorf("missing run id; got: %s", out)
+	}
+}
+
+func TestRunsCurrentJSON(t *testing.T) {
+	s := newStubTwin(t)
+	out := captureStdout(t, func() {
+		_ = cmdRunsCurrent([]string{"--twin", s.URL, "--json"})
+	})
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if got["run_id"] != "wt-run-stub-1" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestRunsWrapHappyPathAndCleanup(t *testing.T) {
+	s := newStubTwin(t)
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "wrap.jsonl")
+	envOut := filepath.Join(dir, "child-env.txt")
+
+	// Use a successful child so cmdRunsWrap doesn't os.Exit. The
+	// child writes its environment to envOut so we can verify the
+	// inherited WT_RUN_ID / WT_TWIN_URL.
+	err := cmdRunsWrap([]string{
+		"--twin", s.URL,
+		"--seed", "42",
+		"--run-id", "wrap-1",
+		"--export", bundle,
+		"--",
+		"sh", "-c", "env > " + envOut,
+	})
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	if _, statErr := os.Stat(bundle); statErr != nil {
+		t.Errorf("export not written; stat err = %v", statErr)
+	}
+	envBytes, _ := os.ReadFile(envOut)
+	envText := string(envBytes)
+	if !strings.Contains(envText, "WT_RUN_ID=wrap-1") {
+		t.Errorf("child missing WT_RUN_ID: %s", envText)
+	}
+	if !strings.Contains(envText, "WT_TWIN_URL=") {
+		t.Errorf("child missing WT_TWIN_URL: %s", envText)
+	}
+	if s.finishes.Load() < 1 {
+		t.Errorf("expected finish call after wrap")
+	}
+}
+
+func TestRunsWrapFinishesOnChildFailure(t *testing.T) {
+	// Validate that when the child exits non-zero, the deferred
+	// finish still fires before cmdRunsWrap exits the process.
+	// We can't observe os.Exit from a unit test, so verify by
+	// checking the recorded finish count via the stub server when
+	// the child is a *failing-but-doesn't-actually-call-exit* path
+	// — i.e. a missing binary that produces an exec error rather
+	// than a non-zero exit code.
+	s := newStubTwin(t)
+	err := cmdRunsWrap([]string{
+		"--twin", s.URL,
+		"--run-id", "wrap-fail",
+		"--",
+		"/nonexistent/binary-that-cannot-be-found",
+	})
+	if err == nil {
+		t.Errorf("expected exec error for missing binary")
+	}
+	if s.finishes.Load() < 1 {
+		t.Errorf("finish must fire even when exec fails; got %d", s.finishes.Load())
+	}
+}
+
+func TestRunsWrapRequiresCommand(t *testing.T) {
+	s := newStubTwin(t)
+	err := cmdRunsWrap([]string{"--twin", s.URL})
+	if err == nil || !strings.Contains(err.Error(), "<command>") {
+		t.Errorf("expected usage error; got %v", err)
+	}
+}


### PR DESCRIPTION
Adds `wt runs {start,finish,current,wrap}` driving the
`/admin/runs/*` surface from session 2B. Foundation for the GitHub
Actions wrapper (session 2D-2) and the customer-facing motion when
CI v2 launches.

## Adds

- **`wt runs start`** `[--twin URL] [--seed N] [--fixtures FILE] [--run-id ID] [--json]`
  Resolves twin URL via flag → `WT_TWIN_URL` → default
  `http://127.0.0.1:4111`. POSTs `{run_id, seed, fixtures}` to
  `/admin/runs/start`. Prints `WT_RUN_ID=<id>` to stderr; appends
  `WT_RUN_ID` and `WT_TWIN_URL` to `$GITHUB_ENV` when set so
  downstream Actions steps inherit them. Fixtures file contents are
  validated as JSON client-side and forwarded as a `json.RawMessage`
  (not stringified).
- **`wt runs finish`** `[--twin URL] [--run-id ID] [--export PATH] [--gzip] [--json]`
  Resolves run id via flag → `WT_RUN_ID`. POSTs to
  `/admin/runs/finish`. **404 (no run active) is treated as success**
  for `if: always()` cleanup steps; **409 (run-id mismatch)** errors
  out. `--export PATH` immediately follows with `GET /admin/replay`
  and writes JSONL (auto-gzip when `.gz` suffix or `--gzip`).
  Appends a markdown summary table to `$GITHUB_STEP_SUMMARY` when set.
- **`wt runs current`** `[--twin URL] [--json]`
  Pretty-prints the active run; `no run active` for empty state.
- **`wt runs wrap`** `[...] -- <command> [args...]`
  Convenience wrapper. Calls `runs start` in-process, spawns the
  child with `WT_RUN_ID` and `WT_TWIN_URL` in its environment,
  always finishes (and exports) on exit via `defer`. Returns the
  child's exit code. Help text explicitly states wrap does NOT
  spawn the twin — customers manage twin lifecycle externally
  (docker-compose, `&`, GitHub Actions service container).
- `--json` flag on every verb for scripting.

## Naming

`wt ci` is already taken by the npm-style "install from lock file"
command (`cmd/wt/main.go:122`); the new lifecycle commands live
under `wt runs` to mirror the HTTP `/admin/runs/*` surface
uniformly. Consistent with `kubectl get pods` / `gh pr list`
namespace+verb convention.

## Manual smoke

Pending — needs an interactive shell to run a real twin alongside
the CLI. Unit tests cover the equivalent paths against an
`httptest.Server` stub: start/finish/current happy paths, fixtures
file forwarding, fixtures JSON validation rejection, `--json`
output shape, gzip output by `.gz` suffix, 404 idempotency, 409
mismatch error, `$GITHUB_ENV` and `$GITHUB_STEP_SUMMARY` writes,
and `wrap` finishing on child failure (missing-binary path).

## Verification

- `go build ./... && go test ./... -short && go vet ./...` clean
- `cd twinkit && go build ./... && go test ./... -short` clean
- All 10 twin binaries compile
- `wt ci` (existing lock-file install) untouched
- No twin source modified
- No `wondertwin-docs/` edits

## Out of scope

- GitHub Action repo (session 2D-2 in `wondertwin-ai/twin-action/`)
- Quickstart doc (session 2D-3 in `wondertwin-docs/`)
- Twin spawning by `wt runs wrap`

Reference: ci-v2-implementation-plan.md §3 Phase 1, §3 Phase 4.