### PR TITLE
feat: deterministic seeding for twin-twilio, twin-resend, twin-logodev

### DIFF
--- a/twin-logodev/internal/api/determinism_test.go
+++ b/twin-logodev/internal/api/determinism_test.go
@@ -1,0 +1,50 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+)
+
+// TestDeterminism_Logodev asserts byte-for-byte reproducibility per
+// seed across the basic asset-lookup surface plus the request log.
+// The pre-#234 leak (RecordRequest using time.Now()) is exactly what
+// this scenario exercises.
+func TestDeterminism_Logodev(t *testing.T) {
+	scenario := []testutil.Request{
+		{Method: "GET", Path: "/example.com?token=pk_test_123"},
+		{Method: "GET", Path: "/wikipedia.org?token=pk_test_123&size=64"},
+		{Method: "GET", Path: "/api/v1/search?q=tesla&token=pk_test_123"},
+		{Method: "GET", Path: "/missing.invalid?token=pk_test_123"},
+	}
+	testutil.AssertDeterministic(t, newDeterministicLogodev(t), 42, scenario)
+}
+
+func newDeterministicLogodev(t *testing.T) func(int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+	t.Helper()
+	return func(seed int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+		cfg := &twincore.Config{Name: "twin-logodev-determinism"}
+		twin := twincore.New(cfg)
+		memStore := store.New()
+
+		handler := api.NewHandler(memStore, twin.Middleware())
+		handler.Routes(twin.Router)
+
+		adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+		adminHandler.WireFromTwin(twin)
+		adminHandler.Routes(twin.Router)
+
+		srv := httptest.NewServer(twin.Router)
+		tc := testutil.NewTwinClient(t, srv)
+		ac := testutil.NewAdminClient(tc)
+		return tc, ac, func() {
+			srv.Close()
+			twin.Close()
+		}
+	}
+}

--- a/twin-logodev/internal/api/handlers_test.go
+++ b/twin-logodev/internal/api/handlers_test.go
@@ -17,12 +17,13 @@ import (
 
 func setupLogodev(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
 	t.Helper()
-	memStore := store.New()
 	cfg := &twincore.Config{Name: "twin-logodev-test"}
 	twin := twincore.New(cfg)
+	memStore := store.New()
 	handler := api.NewHandler(memStore, twin.Middleware())
 	handler.Routes(twin.Router)
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.WireFromTwin(twin)
 	adminHandler.Routes(twin.Router)
 	srv := httptest.NewServer(twin.Router)
 	t.Cleanup(srv.Close)

--- a/twin-logodev/internal/store/memory.go
+++ b/twin-logodev/internal/store/memory.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/base64"
 	"encoding/json"
-	"time"
 
 	pkgstate "github.com/wondertwin-ai/wondertwin/twinkit/state"
 )
@@ -34,7 +33,7 @@ func (s *MemoryStore) RecordRequest(domain string, size int, format string, grey
 		Size:      size,
 		Format:    format,
 		Greyscale: greyscale,
-		Timestamp: time.Now(),
+		Timestamp: s.Clock.Now(),
 	})
 }
 

--- a/twin-resend/cmd/twin-resend/main.go
+++ b/twin-resend/cmd/twin-resend/main.go
@@ -25,6 +25,7 @@ func main() {
 
 	twin := twincore.New(cfg)
 	memStore := store.New()
+	memStore.Rand = twin.Rand
 
 	// Messaging engine for email lifecycle.
 	msgEngine := messaging.NewEngine(

--- a/twin-resend/internal/api/determinism_test.go
+++ b/twin-resend/internal/api/determinism_test.go
@@ -1,0 +1,71 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
+)
+
+// TestDeterminism_Resend asserts byte-for-byte reproducibility per
+// seed across resource creation (domain + API key + audience), the
+// canonical leaky path (resendID-driven hex tokens), and a 404
+// lookup.
+func TestDeterminism_Resend(t *testing.T) {
+	hdr := map[string]string{"Authorization": "Bearer re_sim_test_123"}
+	scenario := []testutil.Request{
+		{
+			Method:  "POST",
+			Path:    "/domains",
+			Headers: hdr,
+			Body:    `{"name":"acme.example","region":"us-east-1"}`,
+		},
+		{
+			Method:  "POST",
+			Path:    "/api-keys",
+			Headers: hdr,
+			Body:    `{"name":"production"}`,
+		},
+		{
+			Method:  "POST",
+			Path:    "/audiences",
+			Headers: hdr,
+			Body:    `{"name":"newsletter"}`,
+		},
+		{
+			Method:  "GET",
+			Path:    "/emails/missing",
+			Headers: hdr,
+		},
+	}
+	testutil.AssertDeterministic(t, newDeterministicResend(t), 42, scenario)
+}
+
+func newDeterministicResend(t *testing.T) func(int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+	t.Helper()
+	return func(seed int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+		cfg := &twincore.Config{Name: "twin-resend-determinism"}
+		twin := twincore.New(cfg)
+		memStore := store.New()
+		memStore.Rand = twin.Rand
+
+		handler := api.NewHandler(memStore, twin.Middleware(), nil)
+		handler.Routes(twin.Router)
+
+		adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+		adminHandler.WireFromTwin(twin)
+		adminHandler.Routes(twin.Router)
+
+		srv := httptest.NewServer(twin.Router)
+		tc := testutil.NewTwinClient(t, srv)
+		ac := testutil.NewAdminClient(tc)
+		return tc, ac, func() {
+			srv.Close()
+			twin.Close()
+		}
+	}
+}

--- a/twin-resend/internal/api/handlers_api_keys.go
+++ b/twin-resend/internal/api/handlers_api_keys.go
@@ -33,8 +33,8 @@ func (h *Handler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := resendID()
-	token := "re_" + resendID() + "_" + resendID()
+	id := h.resendID()
+	token := "re_" + h.resendID() + "_" + h.resendID()
 	key := store.APIKey{
 		ID:        id,
 		Name:      req.Name,

--- a/twin-resend/internal/api/handlers_audiences.go
+++ b/twin-resend/internal/api/handlers_audiences.go
@@ -42,7 +42,7 @@ func (h *Handler) CreateAudience(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := resendID()
+	id := h.resendID()
 	audience := store.Audience{
 		ID:        id,
 		Object:    "audience",
@@ -128,7 +128,7 @@ func (h *Handler) CreateContact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := resendID()
+	id := h.resendID()
 	contact := store.Contact{
 		ID:           id,
 		Object:       "contact",

--- a/twin-resend/internal/api/handlers_broadcasts.go
+++ b/twin-resend/internal/api/handlers_broadcasts.go
@@ -53,7 +53,7 @@ func (h *Handler) CreateBroadcast(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := resendID()
+	id := h.resendID()
 	bc := store.Broadcast{
 		ID:         id,
 		Object:     "broadcast",

--- a/twin-resend/internal/api/handlers_domains.go
+++ b/twin-resend/internal/api/handlers_domains.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -47,7 +45,7 @@ func (h *Handler) CreateDomain(w http.ResponseWriter, r *http.Request) {
 		req.Region = "us-east-1"
 	}
 
-	id := resendID()
+	id := h.resendID()
 	domain := store.Domain{
 		ID:     id,
 		Object: "domain",
@@ -115,10 +113,11 @@ func (h *Handler) VerifyDomain(w http.ResponseWriter, r *http.Request) {
 	twincore.JSON(w, http.StatusOK, map[string]any{"object": "domain", "id": id})
 }
 
-func resendID() string {
-	b := make([]byte, 12)
-	rand.Read(b)
-	return hex.EncodeToString(b)
+// resendID generates a 24-char hex identifier from the deterministic
+// per-twin RNG. Routing through store.RandHex (rather than
+// crypto/rand) keeps replay capture reproducible per seed.
+func (h *Handler) resendID() string {
+	return h.store.RandHex(12)
 }
 
 func intPtr(i int) *int {

--- a/twin-resend/internal/api/handlers_test.go
+++ b/twin-resend/internal/api/handlers_test.go
@@ -13,12 +13,14 @@ import (
 
 func setupResend(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
 	t.Helper()
-	memStore := store.New()
 	cfg := &twincore.Config{Name: "twin-resend-test"}
 	twin := twincore.New(cfg)
+	memStore := store.New()
+	memStore.Rand = twin.Rand
 	handler := api.NewHandler(memStore, twin.Middleware(), nil)
 	handler.Routes(twin.Router)
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.WireFromTwin(twin)
 	adminHandler.Routes(twin.Router)
 	srv := httptest.NewServer(twin.Router)
 	t.Cleanup(srv.Close)

--- a/twin-resend/internal/store/memory.go
+++ b/twin-resend/internal/store/memory.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
+	"github.com/wondertwin-ai/wondertwin/twinkit/sim"
 	pkgstate "github.com/wondertwin-ai/wondertwin/twinkit/state"
 )
 
@@ -15,6 +17,25 @@ type MemoryStore struct {
 	Contacts   *pkgstate.Store[Contact]
 	Broadcasts *pkgstate.Store[Broadcast]
 	Clock      *pkgstate.Clock
+
+	// Rand is the deterministic per-twin random source. Wired by
+	// main.go (and test setups) to twin.Rand so /admin/runs/start's
+	// reseed propagates everywhere.
+	Rand *sim.Rand
+}
+
+// RandHex returns a deterministic hex string of n bytes drawn from
+// the store's Rand. Used in place of crypto/rand to keep replay
+// capture reproducible per seed.
+func (s *MemoryStore) RandHex(n int) string {
+	if s == nil || s.Rand == nil || n <= 0 {
+		return ""
+	}
+	buf := make([]byte, n)
+	for i := range buf {
+		buf[i] = byte(s.Rand.Intn(256))
+	}
+	return hex.EncodeToString(buf)
 }
 
 // New creates a new MemoryStore with empty state.

--- a/twin-twilio/cmd/twin-twilio/main.go
+++ b/twin-twilio/cmd/twin-twilio/main.go
@@ -25,6 +25,7 @@ func main() {
 
 	twin := twincore.New(cfg)
 	memStore := store.New()
+	memStore.Rand = twin.Rand
 
 	// Messaging engine for SMS lifecycle.
 	msgEngine := messaging.NewEngine(

--- a/twin-twilio/internal/api/determinism_test.go
+++ b/twin-twilio/internal/api/determinism_test.go
@@ -1,0 +1,74 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+)
+
+// TestDeterminism_Twilio asserts that twin-twilio is byte-for-byte
+// reproducible per seed. Scenario covers SMS send, Verify Service +
+// Verification creation, OTP check (the canonical leaky path), and
+// a 404 lookup. The canonicalizer in testutil strips timestamps.
+func TestDeterminism_Twilio(t *testing.T) {
+	scenario := []testutil.Request{
+		{
+			Method:  "POST",
+			Path:    "/2010-04-01/Accounts/AC_test_sim/Messages.json",
+			Headers: twilioAuthHeader(),
+			Body:    "From=%2B15005550006&To=%2B15555551234&Body=Hello",
+		},
+		{
+			Method:  "POST",
+			Path:    "/v2/Services",
+			Headers: twilioAuthHeader(),
+			Body:    "FriendlyName=otp-service",
+		},
+		{
+			Method:  "POST",
+			Path:    "/v2/Services/VA_sim/Verifications",
+			Headers: twilioAuthHeader(),
+			Body:    "To=%2B15555551234&Channel=sms",
+		},
+		{
+			Method:  "GET",
+			Path:    "/2010-04-01/Accounts/AC_test_sim/Messages/SM_missing.json",
+			Headers: twilioAuthHeader(),
+		},
+	}
+	testutil.AssertDeterministic(t, newDeterministicTwilio(t), 42, scenario)
+}
+
+func twilioAuthHeader() map[string]string {
+	return map[string]string{"Authorization": basicAuthHeader}
+}
+
+func newDeterministicTwilio(t *testing.T) func(int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+	t.Helper()
+	return func(seed int64) (*testutil.TwinClient, *testutil.AdminClient, func()) {
+		cfg := &twincore.Config{Name: "twin-twilio-determinism"}
+		twin := twincore.New(cfg)
+		memStore := store.New()
+		memStore.Rand = twin.Rand
+
+		handler := api.NewHandler(memStore, twin.Middleware(), nil)
+		handler.Routes(twin.Router)
+
+		adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+		adminHandler.WireFromTwin(twin)
+		adminHandler.Routes(twin.Router)
+
+		srv := httptest.NewServer(twin.Router)
+		tc := testutil.NewTwinClient(t, srv)
+		ac := testutil.NewAdminClient(tc)
+		return tc, ac, func() {
+			srv.Close()
+			twin.Close()
+		}
+	}
+}

--- a/twin-twilio/internal/api/handlers_messages_extra.go
+++ b/twin-twilio/internal/api/handlers_messages_extra.go
@@ -122,7 +122,7 @@ func (h *Handler) CreateMessagingService(w http.ResponseWriter, r *http.Request)
 	}
 
 	now := h.store.Clock.Now()
-	sid := fmt.Sprintf("MG%s", generateCode(32))
+	sid := fmt.Sprintf("MG%s", h.generateCode(32))
 
 	twincore.JSON(w, http.StatusCreated, map[string]any{
 		"sid":           sid,

--- a/twin-twilio/internal/api/handlers_test.go
+++ b/twin-twilio/internal/api/handlers_test.go
@@ -23,12 +23,14 @@ var basicAuthHeader = "Basic " + base64.StdEncoding.EncodeToString([]byte(testAc
 
 func setupTwilio(t *testing.T) (*httptest.Server, *testutil.TwinClient) {
 	t.Helper()
-	memStore := store.New()
 	cfg := &twincore.Config{Name: "twin-twilio-test"}
 	twin := twincore.New(cfg)
+	memStore := store.New()
+	memStore.Rand = twin.Rand
 	handler := api.NewHandler(memStore, twin.Middleware(), nil)
 	handler.Routes(twin.Router)
 	adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
+	adminHandler.WireFromTwin(twin)
 	adminHandler.Routes(twin.Router)
 	srv := httptest.NewServer(twin.Router)
 	t.Cleanup(srv.Close)

--- a/twin-twilio/internal/api/handlers_verify.go
+++ b/twin-twilio/internal/api/handlers_verify.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net/http"
 	"time"
 
@@ -35,7 +33,7 @@ func (h *Handler) CreateVerification(w http.ResponseWriter, r *http.Request) {
 
 	now := h.store.Clock.Now()
 	sid := h.store.Verifications.NextID()
-	code := generateCode(6)
+	code := h.generateCode(6)
 	ttl := time.Duration(h.store.OTPTTLSeconds) * time.Second
 
 	v := store.Verification{
@@ -227,12 +225,14 @@ func twilioError(w http.ResponseWriter, status int, code int, message string) {
 	w.Write(data)
 }
 
-// generateCode generates a random numeric code of the given length.
-func generateCode(length int) string {
+// generateCode generates a deterministic numeric code of the given
+// length using the store's RNG. Routing through store.RandDigit
+// (rather than crypto/rand) keeps replay capture reproducible per
+// seed: two seeded runs get the same OTP.
+func (h *Handler) generateCode(length int) string {
 	code := ""
 	for i := 0; i < length; i++ {
-		n, _ := rand.Int(rand.Reader, big.NewInt(10))
-		code += fmt.Sprintf("%d", n.Int64())
+		code += fmt.Sprintf("%d", h.store.RandDigit())
 	}
 	return code
 }

--- a/twin-twilio/internal/store/memory.go
+++ b/twin-twilio/internal/store/memory.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
+	"github.com/wondertwin-ai/wondertwin/twinkit/sim"
 	pkgstate "github.com/wondertwin-ai/wondertwin/twinkit/state"
 )
 
@@ -13,6 +15,34 @@ type MemoryStore struct {
 	VerifyServices *pkgstate.Store[VerifyService]
 	Clock          *pkgstate.Clock
 	OTPTTLSeconds  int // verification code TTL, default 600 (10 min)
+
+	// Rand is the deterministic per-twin random source. Wired by
+	// main.go (and test setups) to twin.Rand so /admin/runs/start's
+	// reseed propagates everywhere.
+	Rand *sim.Rand
+}
+
+// RandHex returns a deterministic hex string of n bytes drawn from
+// the store's Rand. Used in place of crypto/rand to keep replay
+// capture reproducible per seed.
+func (s *MemoryStore) RandHex(n int) string {
+	if s == nil || s.Rand == nil || n <= 0 {
+		return ""
+	}
+	buf := make([]byte, n)
+	for i := range buf {
+		buf[i] = byte(s.Rand.Intn(256))
+	}
+	return hex.EncodeToString(buf)
+}
+
+// RandDigit returns a deterministic decimal digit (0..9) drawn from
+// the store's Rand. Used by verification-code generation.
+func (s *MemoryStore) RandDigit() int {
+	if s == nil || s.Rand == nil {
+		return 0
+	}
+	return s.Rand.Intn(10)
 }
 
 // New creates a new MemoryStore with empty state.


### PR DESCRIPTION
Bulk rollout #1 of the deterministic-seeding pattern from PR #234.
Each twin's `TestDeterminism_<Twin>` enforces byte-for-byte
identical canonical replay JSONL across runs with the same seed
(verified 5/5 with `go test -count=5`).

## Per-twin audit findings

### twin-twilio

| File:Line | Kind | Source | Routing |
| --- | --- | --- | --- |
| `internal/api/handlers_verify.go:234` | OTP digit | `crypto/rand.Int(rand.Reader, big.NewInt(10))` | now `MemoryStore.RandDigit` via `twin.Rand` |
| `internal/api/handlers_verify.go` (`generateCode`) | OTP code | `crypto/rand` (free function) | `Handler.generateCode` (method, store-routed) |

Time was already routed via `h.store.Clock.Now()` everywhere before
this PR. `crypto/rand` import dropped; `math/big` import dropped.

### twin-resend

| File:Line | Kind | Source | Routing |
| --- | --- | --- | --- |
| `internal/api/handlers_domains.go:118` | resource id (`resendID()`) | `crypto/rand.Read(b)` + hex | now `Handler.resendID` → `MemoryStore.RandHex(12)` |

`resendID()` is the only random source — used for domain ids, API
keys, audiences, broadcasts, and within-API-key tokens
(`re_<hex>_<hex>`). Routing it through the store covers every
caller automatically. `crypto/rand` and `encoding/hex` imports
dropped from `handlers_domains.go`.

### twin-logodev

| File:Line | Kind | Source | Routing |
| --- | --- | --- | --- |
| `internal/store/memory.go:37` | `LogoRequest.Timestamp` | `time.Now()` | `s.Clock.Now()` |

No `crypto/rand` use anywhere — this is the lightest twin.
`time` import dropped from `internal/store/memory.go`.

## Wiring

Each twin's `cmd/twin-<name>/main.go` adds one line:

    memStore.Rand = twin.Rand

Test setups got the same line plus `adminHandler.WireFromTwin(twin)`
where it was missing (twin-resend, twin-logodev) so /admin/runs/start
can drive reseed + clock pin in `TestDeterminism_*`.

## Verification

- `go test -count=5 -run TestDeterminism_Twilio ./twin-twilio/internal/api/...` 5/5 pass
- `go test -count=5 -run TestDeterminism_Resend ./twin-resend/internal/api/...` 5/5 pass
- `go test -count=5 -run TestDeterminism_Logodev ./twin-logodev/internal/api/...` 5/5 pass
- `go build ./...` clean (root + twinkit)
- `go test ./... -short` clean (root + twinkit)
- `go vet ./...` clean
- All 10 twin binaries compile
- twin-stripe untouched (no diff in `twin-stripe/`)
- No twinkit changes

## Manual smoke

Pending — needs an interactive shell to run `wt runs start --seed 42`
twice against a live twin. Determinism contract is asserted by the
in-process tests, which run the same code path the wt CLI drives.

## Next batches

- 2A-3: twin-posthog, twin-slack, twin-github (webhook/event surfaces)
- 2A-4: twin-hubspot, twin-linear, twin-shopify (rich domain models)

Reference: wondertwin-docs/skills/twin-builder/twin-determinism.md is
the canonical playbook this PR applies.