### PR TITLE
refactor: 3B-3c public skills — community generator + public researcher

### DIFF
--- a/skills/community-twin-generator.md
+++ b/skills/community-twin-generator.md
@@ -1,295 +1,803 @@
 ---
 skill: community-twin-generator
-skill_version: "1.0"
+skill_version: "2.0"
 schemas:
   provenance.schema.json: "1.1"
   twin-manifest.schema.json: "1.0"
   twin.schema.json: "1.0"
+  scenario.schema.json: "1.0"
 ---
 
 # SKILL: Community Twin Generator
 
 ## Purpose
 
-Generate a complete, MIT-licensed community twin from a third-party service's public SDK reference and/or API documentation. The output is a self-contained Go module that behaviorally clones the target service — maintaining state, implementing business logic, and targeting compatibility with the service's official SDK client libraries.
+Generate a complete, MIT-licensed community twin from a third-party service's
+public SDK reference and/or API documentation. The output is a self-contained
+Go module that behaviorally clones the target service — maintaining state,
+implementing business logic, and targeting compatibility with the service's
+official SDK client libraries.
 
-Community twins provide 100% API surface coverage with correct behavior.
+Community twins target **100% API surface coverage** with correct behavior
+(per `wondertwin/CLAUDE.md`).
 
-## Output Artifacts
+This skill is **application guidance** — how to apply the community canonical
+pattern at generation time. It does not redefine the pattern. The authoritative
+sources are:
 
-1. **Twin source code** — a Go module following the standard directory layout
-2. **`twin-manifest.json`** — describes the twin's capabilities, SDK target, service surface, and coverage
-3. **`provenance.json`** — records what sources were used during generation and when
-4. **`twin.json`** — twin metadata (name, description, category, SDK target, port)
+1. **`wondertwin/CLAUDE.md`** — community canonical pattern, coverage policy,
+   pre-push validation, scope-exception process. The source of truth.
+2. **Reference twins in `wondertwin/`** — copy-and-adapt examples by contract shape.
+3. **`wondertwin/schemas/`** — JSON Schemas every artifact must validate against
+   (`twin.schema.json`, `twin-manifest.schema.json`, `provenance.schema.json`,
+   `scenario.schema.json`).
+4. **`cmd/validate-schemas/`** — pre-push validator that catches schema and
+   structural defects.
 
-## Prerequisites
+When the docs in (1) and the code in (2) disagree, **the code is ground truth**.
+The skill reflects what reference twins do — not what older docs claim.
 
-1. The WonderTwin shared libraries via `github.com/wondertwin-ai/wondertwin/twinkit`:
-   - Core: `twincore`, `state`, `admin`, `webhook`, `testutil`, `pagination`
-   - Domain engines: `workspace`, `ledger`, `messaging`, `events`, `search`
-2. The target service's public API documentation or SDK reference
-3. Optionally, the official SDK client library source code for compatibility verification
+## Output artifacts
 
----
+A complete community twin produces:
 
-## Standard Directory Layout
+1. **Twin source code** — a Go module following the standard layout (see CLAUDE.md "Standard structure")
+2. **`twin.json`** — twin metadata (name, description, category, SDK target, port)
+3. **`twin-manifest.json`** — capabilities, SDK target, service surface, coverage
+4. **`provenance.json`** — generation provenance (sources, dates, archives)
+5. **`workflows/{name}.arazzo.json`** — Arazzo 1.0.1 multi-step workflow file (when multi-step sequences exist)
+6. **`scenarios/basic.json`** — starter scenario covering health + CRUD, ready for `wt test`
+7. **Handler tests** in `internal/api/handlers_test.go`
+
+## Inputs
+
+- **Platform name** — service identifier (lowercase, hyphenated; e.g., `quickbooks-online`, `mercury`)
+- **Research directory** — `wondertwin-docs/research/{platform}/` containing build-ready research artifacts. The research-to-build gate (`wondertwin-docs/skills/handoffs/research-to-build.md`) defines the required floor.
+- **SDK reference** — URL or document containing the SDK / API reference
+
+If the research directory is missing required artifacts or any artifact's
+confidence is below the gate's floor, do NOT proceed — return to research.
+
+## Canonical pattern (cite, don't restate)
+
+The community canonical pattern lives in **`wondertwin/CLAUDE.md`** under
+"Standard structure" and "Twin Build Process". Every twin MUST satisfy the
+orchestration shape verified by `cmd/validate-schemas/` and exemplified by
+existing community twins:
+
+- **Orchestration**: `cmd/twin-{name}/main.go` calls `twincore.New(twincore.ParseFlags(...))` — never `chi.NewRouter()` directly.
+- **Admin**: `admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)` from `twinkit/admin` — never a custom admin handler.
+- **Store**: `internal/store/memory.go` implements `Snapshot() any`, `LoadState([]byte) error`, `Reset()`, holds `Clock *state.Clock` initialized in `New()`.
+- **Routes**: `internal/api/router.go` mounts middleware (`h.authMiddleware`, `h.mw.FaultInjection`) inside the route group, then resource routes.
+- **Server lifecycle**: `twin.Serve()`. Never hand-roll `http.Server` + signal handling.
+
+For the live signatures, copy `twin-{ref}/cmd/twin-{ref}/main.go`,
+`internal/api/router.go`, `internal/api/handler.go`, `internal/store/memory.go`
+shapes from the matching reference twin (see "Vendor contract shape detection"
+below). The skill does not duplicate those file contents — they evolve, the
+references are canonical.
+
+### Tier boundary
+
+Community twins are MIT-licensed and have **no commercial infrastructure**:
+
+- No telemetry instrumentation
+- No quirks runtime engine (the "behavioral quirks" you discover during
+  research are documented in research artifacts and implemented as twin
+  behavior; the community tier has no runtime quirk-rule loader)
+- No replay, run lifecycle, or license verification
+
+Pro twins (separately licensed) layer commercial infrastructure on top of the
+same canonical orchestration. The community tier is the orchestration layer
+alone, which is sufficient for community use cases.
+
+## Vendor contract shape detection
+
+Canonical orchestration (above) is universal. Vendor-specific request and
+response handling — how the twin decodes requests and shapes responses —
+depends on the vendor's contract. Pick the matching pattern, copy the
+reference's resource-handler layer.
+
+| Vendor contract shape | Reference twin | Notes |
+|---|---|---|
+| JSON request + JSON response | `twin-hubspot`, `twin-shopify`, `twin-resend` | Most modern APIs. Resource handlers receive `*http.Request`, decode JSON via stdlib, write JSON responses directly. |
+| Form-encoded request + JSON response | `twin-stripe`, `twin-twilio` | Form parsing via `r.ParseForm()`; responses are JSON. SDK compatibility for `stripe-go`-shaped clients. |
+| GraphQL | `twin-linear` | Single `POST /graphql` endpoint; query/mutation discriminator in body. Uses `twinkit/graphql` for parsing. |
+| SOAP / XML | (none yet — see `twinkit/soap` package) | First community twin to implement defines the canonical reference. |
+
+Detect shape from:
+- `Content-Type` headers in the SDK's request construction
+- Response envelope structure in the SDK's response decoding
+- The vendor's developer documentation
+
+Once detected, **read the matching reference twin's
+`internal/api/router.go` + one `handlers_{resource}.go` end-to-end** before
+writing the new twin's handlers. Copy patterns; adapt for vendor-specific
+quirks. Per `CLAUDE.md` "Common pitfalls" — verify enum values, port
+collisions, and nil-slice JSON behavior against existing twins before
+finalizing.
+
+## Process
+
+### Phase 0: Verify research-to-build gate
+
+The research-to-build gate
+(`wondertwin-docs/skills/handoffs/research-to-build.md`) defines the
+artifacts and confidence floor required before scaffolding. Before any code:
+
+1. Read `wondertwin-docs/research/{platform}/RESEARCH-STATUS.md` — verify all
+   required confidence scores meet their floor.
+2. Confirm required artifacts exist: `system-model.md`, `record-type-catalog.json`,
+   `compatibility-path.md`, `architecture-spec.md` (with engine-analysis),
+   `roadmap.json`, `event-model.md` if applicable.
+3. Confirm `feasibility.md` says GO.
+4. Confirm engine-analysis says either "use existing engine X" or "no engine
+   needed". If it says "new engine required" — stop. New engine work is a
+   separate stream; community twin generation is blocked until the engine lands.
+
+If any check fails, the agent returns to research with the highest-EV gap
+from the gap list as the next target. The build is not started.
+
+### Phase 1: Scaffold + core resources
+
+**1. Create the directory structure** matching `CLAUDE.md` "Standard structure":
 
 ```
 twin-{name}/
-├── cmd/twin-{name}/main.go          # entry point
+├── cmd/twin-{name}/main.go
 ├── internal/
 │   ├── api/
-│   │   ├── router.go                # routes + auth middleware
-│   │   ├── handlers_{area}.go       # one file per resource area
-│   │   └── handlers_test.go         # tests using testutil
+│   │   ├── router.go
+│   │   ├── handlers_{area}.go
+│   │   └── handlers_test.go
 │   └── store/
-│       ├── memory.go                # in-memory store with snapshot/load/reset
-│       └── types.go                 # domain structs matching real service
-├── twin.json                        # twin metadata
-├── twin-manifest.json               # coverage manifest
-├── provenance.json                  # build provenance
-└── go.mod                           # module definition
+│       ├── memory.go
+│       └── types.go
+├── twin.json
+├── twin-manifest.json
+└── provenance.json
 ```
 
-For twins with webhooks, add:
+For twins with webhooks, add `internal/webhook/signer.go`.
+
+**2. Add to `go.work`** (if applicable) and initialize the module:
+
+```bash
+go mod init github.com/wondertwin-ai/wondertwin/twin-{name}
 ```
-├── internal/
-│   └── webhook/
-│       └── signer.go                # service-specific webhook signer
-```
 
----
+**3. Write store types and memory store** — copy the matching reference twin's
+`internal/store/types.go` and `internal/store/memory.go` shapes. Adapt struct
+fields to match the real API's response schemas. Use `pkgstate.Store[T]` per
+entity type with the service's ID prefix (`"cus"`, `"msg"`, etc.).
 
-## Entry Point Template
+Rules (verify against reference twin):
+- Use the EXACT JSON field names the real API returns; pointer types for nullable fields
+- Always reset the Clock in `Reset()`
+- Always nil-check snapshot fields in `LoadState()` to support partial seeding
 
-Every community twin's `main.go` follows this pattern:
+**4. Write the router and handlers** — copy the matching reference twin's
+`internal/api/router.go` shape. Adapt for the vendor's URL patterns, auth
+scheme, and contract shape. Use `chi.Router`; apply `h.authMiddleware` and
+`h.mw.FaultInjection` inside the route group.
+
+For form-encoded vendors (Stripe pattern): `r.ParseForm()` in the handler;
+responses are JSON.
+
+For GraphQL vendors (Linear pattern): single `POST /graphql` endpoint; switch
+on operation type via `twinkit/graphql` parser.
+
+**5. Write the entry point** (`cmd/twin-{name}/main.go`) — copy the reference
+twin's main.go and adapt the twin name + port. Default port: pick from the 41xx
+range; grep existing `cfg.Port` values per `CLAUDE.md` "Common pitfalls".
+
+The canonical entry-point shape:
+1. `cfg := twincore.ParseFlags("twin-{name}")`
+2. Set `cfg.Port = {default}` if zero
+3. `twin := twincore.New(cfg)`
+4. `memStore := store.New()`
+5. (Optional) Webhook dispatcher via `webhook.NewDispatcher(webhook.Config{...})`
+6. (Optional) Domain engine creation
+7. API handler via `api.NewHandler(memStore[, dispatcher], twin.Middleware()[, engine])`
+8. `apiHandler.Routes(twin.Router)`
+9. Admin handler via `admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)`
+10. `adminHandler.SetConfigProvider(twin)`
+11. `adminHandler.Routes(twin.Router)`
+12. Load seed data if `cfg.SeedFile != ""`
+13. `twin.Serve()`
+
+For exact form, see `twin-linear/cmd/twin-linear/main.go` (51L, the smallest
+canonical reference) or `twin-stripe/cmd/twin-stripe/main.go` (with webhook
+dispatcher).
+
+**6. Write `twin.json`, `twin-manifest.json`, `provenance.json`** — see
+"Schema files" below. **All three must validate** via
+`go run ./cmd/validate-schemas/` before pushing.
+
+**7. Write handler tests** — see "Tests" below.
+
+### Phase 2: Domain engine selection (when applicable)
+
+Community twins MAY use a `twinkit` domain engine for stateful behavior modeling.
+Engine selection is per-twin SDK analysis — not per-category. Engines live in
+`twinkit/{engine}`. The architecture-spec.md from research names the engine.
+
+| Service category | Engine | Package |
+|---|---|---|
+| Accounting / fintech (double-entry) | Ledger | `twinkit/ledger` |
+| Email / SMS / notifications | Messaging | `twinkit/messaging` |
+| Collaboration / CRM / project mgmt | Workspace | `twinkit/workspace` |
+| Analytics / CDPs / feature flags | Events | `twinkit/events` |
+| Search platforms | Search | `twinkit/search` |
+| Multi-domain (lifecycle tracking) | Workspace + custom | `twinkit/workspace` |
+| Simple CRUD APIs | None | Direct store operations |
+
+The engine runs alongside the store as a parallel behavioral path. The store
+remains the source of truth for API responses; the engine adds workflow
+validation and state-machine enforcement.
+
+For engine-backed twins, create the engine in `main.go`:
 
 ```go
-package main
+wsEngine := workspace.NewEngine(
+    workspace.WithClock(memStore.Clock),
+    workspace.WithWorkflow(workspace.WorkflowConfig{
+        EntityType:     "issue",
+        InitialStatus:  "backlog",
+        TerminalStates: []string{"done", "canceled"},
+        Transitions: map[string][]string{
+            "backlog":     {"todo"},
+            "todo":        {"in_progress"},
+            "in_progress": {"done", "canceled"},
+        },
+    }),
+)
+```
+
+Pass the engine to `api.NewHandler`; in tests, pass `nil` and nil-check before
+calling engine methods (`if h.wsEngine != nil`).
+
+### Phase 3: Webhook signer (when applicable)
+
+Only implement if the target service sends webhooks (per `event-model.md`).
+
+`internal/webhook/signer.go` implements the `webhook.Signer` interface. The
+signer returns header name → value pairs for every webhook POST.
+
+Example (HMAC-SHA256 with timestamp):
+
+```go
+package webhook
 
 import (
-    "log"
-    "os"
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/hex"
+    "fmt"
+    "time"
+)
+
+type ServiceSigner struct{}
+
+func NewServiceSigner() *ServiceSigner {
+    return &ServiceSigner{}
+}
+
+func (s *ServiceSigner) Sign(payload []byte, secret string) map[string]string {
+    ts := fmt.Sprintf("%d", time.Now().Unix())
+    mac := hmac.New(sha256.New, []byte(secret))
+    mac.Write([]byte(ts + "."))
+    mac.Write(payload)
+    sig := hex.EncodeToString(mac.Sum(nil))
+
+    return map[string]string{
+        "X-Service-Signature": fmt.Sprintf("t=%s,v1=%s", ts, sig),
+        "X-Service-Timestamp": ts,
+    }
+}
+```
+
+The exact header names and signing scheme come from the vendor's webhook
+documentation. `twin-stripe/internal/webhook/signer.go` is the canonical
+reference.
+
+When the twin has webhooks, the Handler struct gains a `dispatcher *webhook.Dispatcher`
+field, and `main.go` constructs the dispatcher with the vendor signer.
+
+### Phase 4: Arazzo workflow generation
+
+After implementing handlers, identify multi-step workflows that span multiple
+resources or require sequenced operations. Produce an Arazzo 1.0.1 JSON file at
+`workflows/{name}.arazzo.json`.
+
+**When to produce a workflow:**
+- A resource must be created before it can be used (e.g., create a sender before sending a message)
+- Operations have dependencies (e.g., verify a domain, then send from that domain)
+- A common integration pattern involves 3+ sequential SDK calls
+
+**Arazzo 1.0.1 structure:**
+
+```json
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "{Service} Twin Workflows",
+    "version": "1.0.0",
+    "description": "Multi-step workflows discovered during twin generation."
+  },
+  "sourceDescriptions": [
+    {
+      "name": "{name}-twin",
+      "type": "openapi",
+      "url": "./specs/{name}-openapi.json"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "create-and-send-message",
+      "description": "Create a contact, then send a message to that contact.",
+      "steps": [
+        {
+          "stepId": "create-contact",
+          "operationId": "createContact",
+          "requestBody": {
+            "payload": { "email": "$inputs.recipient_email" }
+          },
+          "successCriteria": [
+            { "condition": "$statusCode == 201" }
+          ],
+          "outputs": { "contact_id": "$response.body.id" }
+        },
+        {
+          "stepId": "send-message",
+          "operationId": "sendMessage",
+          "requestBody": {
+            "payload": {
+              "to": "$steps.create-contact.outputs.contact_id",
+              "body": "$inputs.message_body"
+            }
+          },
+          "successCriteria": [
+            { "condition": "$statusCode == 201" }
+          ],
+          "outputs": { "message_id": "$response.body.id" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Rules:**
+- Each workflow has a descriptive `workflowId` (kebab-case)
+- Steps reference `operationId` values that match the twin's handlers
+- Use runtime expressions (`$response.body.*`, `$statusCode`, `$inputs.*`) to wire steps together
+- Include `successCriteria` for every step (at minimum, the expected status code)
+- If no OpenAPI spec exists, use `operationPath` with method + path instead of `operationId` (e.g., `"operationPath": "POST /v1/contacts"`)
+
+**Update provenance** after generating Arazzo:
+
+```json
+{
+  "sources": {
+    "arazzo": {
+      "origin": "generated",
+      "generated_from": ["sdk_analysis", "handler_implementation"],
+      "sha256": "{hash of arazzo file}"
+    }
+  }
+}
+```
+
+### Phase 5: Starter scenario
+
+Produce a starter scenario JSON at `scenarios/basic.json`. Validates against
+`schemas/scenario.schema.json`. Provides baseline test coverage for `wt test`.
+
+**The starter scenario MUST include:**
+
+1. A health check step (verifying `/admin/health`)
+2. A state reset step (calling `/admin/reset`)
+3. One complete CRUD cycle per primary resource (create, get, update, list, delete)
+4. Variable capture between steps (capturing the created resource ID for subsequent get/update/delete)
+
+**Starter scenario template:**
+
+```json
+{
+  "name": "Basic CRUD - {Service}",
+  "description": "Health check and CRUD cycle for primary {Service} resources.",
+  "setup": { "reset": ["{name}"] },
+  "variables": {
+    "auth_token": "Bearer test_123"
+  },
+  "steps": [
+    {
+      "name": "Health check",
+      "request": { "method": "GET", "url": "{{base_url}}/admin/health" },
+      "assert": { "status": 200, "body": { "$.status": "ok" } }
+    },
+    {
+      "name": "Reset state",
+      "request": { "method": "POST", "url": "{{base_url}}/admin/reset" },
+      "assert": { "status": 200 }
+    },
+    {
+      "name": "Create contact",
+      "request": {
+        "method": "POST",
+        "url": "{{base_url}}/v1/contacts",
+        "headers": { "Authorization": "{{auth_token}}" },
+        "body": { "email": "test@example.com", "first_name": "Test" }
+      },
+      "capture": { "contact_id": "$.id" },
+      "assert": {
+        "status": 201,
+        "body": { "$.email": "test@example.com" }
+      }
+    },
+    {
+      "name": "Get contact",
+      "request": {
+        "method": "GET",
+        "url": "{{base_url}}/v1/contacts/{{contact_id}}",
+        "headers": { "Authorization": "{{auth_token}}" }
+      },
+      "assert": {
+        "status": 200,
+        "body": {
+          "$.id": "{{contact_id}}",
+          "$.email": "test@example.com"
+        }
+      }
+    },
+    {
+      "name": "Update contact",
+      "request": {
+        "method": "PATCH",
+        "url": "{{base_url}}/v1/contacts/{{contact_id}}",
+        "headers": { "Authorization": "{{auth_token}}" },
+        "body": { "first_name": "Updated" }
+      },
+      "assert": {
+        "status": 200,
+        "body": { "$.first_name": "Updated" }
+      }
+    },
+    {
+      "name": "List contacts",
+      "request": {
+        "method": "GET",
+        "url": "{{base_url}}/v1/contacts?limit=10",
+        "headers": { "Authorization": "{{auth_token}}" }
+      },
+      "assert": { "status": 200 }
+    },
+    {
+      "name": "Delete contact",
+      "request": {
+        "method": "DELETE",
+        "url": "{{base_url}}/v1/contacts/{{contact_id}}",
+        "headers": { "Authorization": "{{auth_token}}" }
+      },
+      "assert": {
+        "status": 200,
+        "body": { "$.deleted": true }
+      }
+    }
+  ]
+}
+```
+
+**Rules:**
+- Use the v2 JSON format matching `schemas/scenario.schema.json` (NOT YAML)
+- Always start with health check and reset steps
+- Capture IDs from create responses; reuse via `{{variable}}` syntax
+- Include at least one assertion per step (status code at minimum, body assertions preferred)
+
+### Phase 6: Local-dev loop with `wt`
+
+`wt` is the canonical local-dev CLI for community twins. The full loop is
+**mandatory**, not optional. Every community twin must be exercised via `wt`
+before opening the PR.
+
+**1. Build the twin locally:**
+
+```bash
+go build -o ./bin/twin-{name} ./twin-{name}/cmd/twin-{name}/
+```
+
+Or use the Makefile: `make build-twins`.
+
+**2. Add to your project's `wondertwin.json`:**
+
+```json
+{
+  "twins": {
+    "{name}": {
+      "binary": "./bin/twin-{name}",
+      "port": {port}
+    }
+  }
+}
+```
+
+The `binary` field supports relative paths — they resolve against the
+`wondertwin.json` location.
+
+**3. Run the offline workflow:**
+
+```bash
+wt up        # Start the twin
+wt status    # Verify it's healthy
+wt test      # Run scenarios against it
+wt down      # Stop when done
+```
+
+**4. Run the starter scenario** generated in Phase 5:
+
+```bash
+wt test scenarios/basic.json
+```
+
+**5. Run conformance to validate the admin contract:**
+
+```bash
+wt conformance ./bin/twin-{name} --port 9999
+```
+
+This validates the standard admin checks: health, reset, state POST/GET, fault
+injection, time advance, clean shutdown.
+
+**6. Iterate:**
+
+```bash
+make build-twins && wt down && wt up && wt test
+```
+
+**Test-as-deliverable for community:** the tools (`wt up`/`test`/`conformance`)
+are **available**; running them is **expected** for development; passing them
+is **required** before the PR opens. The community tier does not enforce
+test-suite coverage as a CI contract — that's a pro-tier-only concern. For
+community, "the tools work and the local loop passes" is the deliverable.
+
+### Phase 7: Pre-push validation
+
+Per `CLAUDE.md` "Pre-push validation":
+
+```bash
+go run ./cmd/validate-schemas/   # All twin JSON files validate
+go test ./twin-{name}/...        # New twin's tests pass
+go test ./... -short             # No regressions in other twins
+go build -o /dev/null ./twin-{name}/cmd/twin-{name}/   # Compiles
+```
+
+The `validate-schemas` tool catches missing files, invalid enum values, and
+structural errors before they reach CI. **All four checks must pass before
+push.**
+
+### Phase 8: Gap audit (final)
+
+Before declaring the twin complete, per `CLAUDE.md` "Final Phase: Gap Audit":
+
+1. Cross-reference every endpoint from `record-type-catalog.json` against the
+   handlers actually implemented.
+2. Implement every missing endpoint, no matter how niche. Per `CLAUDE.md`
+   "Twin Coverage Policy": **the agent does not make scope decisions** — if
+   the real API supports it, the twin must support it. Use the Scope Exception
+   Request Template (in CLAUDE.md) when surfacing genuine blockers.
+3. Update `twin-manifest.json` to `coverage.estimated_coverage_pct: 100` with
+   empty `resources_not_implemented`.
+4. Re-run the local-dev loop (Phase 6) and pre-push validation (Phase 7).
+
+A twin is not complete until coverage is 100%, all artifacts validate, and the
+local-dev loop passes end-to-end.
+
+## Tests
+
+Use `twinkit/testutil` helpers. Tests create the handler directly:
+
+```go
+package api_test
+
+import (
+    "testing"
 
     "github.com/wondertwin-ai/wondertwin/twinkit/admin"
+    "github.com/wondertwin-ai/wondertwin/twinkit/testutil"
     "github.com/wondertwin-ai/wondertwin/twinkit/twincore"
     "github.com/wondertwin-ai/wondertwin/twin-{name}/internal/api"
     "github.com/wondertwin-ai/wondertwin/twin-{name}/internal/store"
 )
 
-func main() {
-    cfg := twincore.ParseFlags("twin-{name}")
-    if cfg.Port == 0 {
-        cfg.Port = {default_port}
-    }
-
+func setupTestServer(t *testing.T) (*testutil.TwinClient, *testutil.AdminClient) {
+    cfg := &twincore.Config{Name: "twin-{name}-test"}
     twin := twincore.New(cfg)
     memStore := store.New()
 
-    // API handlers
-    handler := api.NewHandler(memStore, twin.Middleware())
-    handler.Routes(twin.Router)
+    apiHandler := api.NewHandler(memStore, twin.Middleware())
+    apiHandler.Routes(twin.Router)
 
-    // Admin control plane
     adminHandler := admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)
     adminHandler.Routes(twin.Router)
 
-    // Load seed data if provided
-    if cfg.SeedFile != "" {
-        data, err := os.ReadFile(cfg.SeedFile)
-        if err != nil {
-            log.Fatalf("failed to read seed file: %v", err)
-        }
-        if err := memStore.LoadState(data); err != nil {
-            log.Fatalf("failed to load seed data: %v", err)
-        }
-        twin.Logger.Info("loaded seed data", "file", cfg.SeedFile)
-    }
+    server := httptest.NewServer(twin)
+    t.Cleanup(server.Close)
 
-    twin.Logger.Info("twin-{name} ready", "port", cfg.Port)
-
-    if err := twin.Serve(); err != nil {
-        log.Fatalf("server error: %v", err)
-    }
+    tc := testutil.NewTwinClient(t, server)
+    ac := testutil.NewAdminClient(tc)
+    return tc, ac
 }
 ```
 
-### With webhook support
+For exact test shapes, see `twin-{ref}/internal/api/handlers_test.go` of the
+matching reference twin. Pass `nil` for optional engine/dispatcher parameters
+in tests where they aren't needed for the test case.
 
-Add the dispatcher between store creation and handler creation:
+**Coverage floor for every twin:**
 
-```go
-    dispatcher := webhook.NewDispatcher(webhook.Config{
-        URL:         cfg.WebhookURL,
-        Secret:      webhookSecret,
-        Signer:      {service}wh.New{Service}Signer(),
-        Logger:      twin.Logger,
-        EventPrefix: "{prefix}",
-        AutoDeliver: cfg.WebhookURL != "",
-    })
+- Create, get, list, update, delete for each resource (happy path)
+- Pagination test with multiple items
+- Admin reset clears all state
+- Admin seed loads fixtures correctly
+- 404 for nonexistent resources
+- 401 for missing auth header
+- Required field validation returns the vendor's error format
 
-    handler := api.NewHandler(memStore, dispatcher, twin.Middleware())
-```
+## Schema files
 
-### With domain engine
+### `twin.json`
 
-Add the engine after store creation:
-
-```go
-    wsEngine := workspace.NewEngine(
-        workspace.WithClock(memStore.Clock),
-        workspace.WithWorkflow(workspace.WorkflowConfig{
-            // ... workflow definitions
-        }),
-    )
-
-    handler := api.NewHandler(memStore, twin.Middleware(), wsEngine)
-```
-
----
-
-## Handler Pattern
-
-### Handler struct and constructor
-
-```go
-type Handler struct {
-    store *store.MemoryStore
-    mw    *twincore.Middleware
-    // Add domain engine fields as needed (ws, msgs, events, etc.)
-}
-
-func NewHandler(s *store.MemoryStore, mw *twincore.Middleware) *Handler {
-    return &Handler{store: s, mw: mw}
-}
-```
-
-### Routes method
-
-```go
-func (h *Handler) Routes(r chi.Router) {
-    r.Route("/v1", func(r chi.Router) {
-        r.Use(h.authMiddleware)
-        r.Use(h.mw.FaultInjection)
-
-        r.Post("/{resources}", h.Create{Resource})
-        r.Get("/{resources}/{id}", h.Get{Resource})
-        // ...
-    })
-}
-```
-
----
-
-## Domain Engine Selection
-
-Choose the domain engine based on the service category:
-
-| Category | Engine | Package |
-|----------|--------|---------|
-| Payments, fintech, accounting | `ledger` | `twinkit/ledger` |
-| CRM, project mgmt, collaboration | `workspace` | `twinkit/workspace` |
-| Email, SMS, notifications | `messaging` | `twinkit/messaging` |
-| Analytics, CDPs, feature flags | `events` | `twinkit/events` |
-| Search platforms | `search` | `twinkit/search` |
-| Simple CRUD APIs | None needed | Direct store operations |
-
-When using a domain engine, the engine runs alongside the store. The store is the source of truth for API responses; the engine provides workflow validation and state machine enforcement.
-
----
-
-## Build Process
-
-### Phase 0: Research
-Use the `twin-researcher` skill to investigate the target API. Research artifacts go to `wondertwin-docs/research/{platform}/`.
-
-### Phase 1: Scaffold + Core
-1. Create directory structure following the standard layout
-2. Write store types for all known resource areas
-3. Write the memory store with snapshot/load/reset
-4. Write the router with auth middleware matching the service's style
-5. Implement the highest-traffic endpoints first
-6. Include all 3 schema files from commit 1
-7. Write tests, PR
-
-### Phase 2+: Expand to 100%
-1. Work through remaining resource areas in logical batches
-2. One PR per logical batch
-3. Update manifest coverage after each phase
-
-### Final: Gap Audit
-1. Cross-reference every endpoint from research against the router
-2. Implement every missing endpoint
-3. Update manifest to 100% coverage
-
----
-
-## Testing
-
-Use `twinkit/testutil` for test helpers. Tests create a handler directly:
-
-```go
-func TestCreateCustomer(t *testing.T) {
-    s := store.New()
-    mw := twincore.NewTestMiddleware()
-    h := NewHandler(s, mw)
-
-    r := chi.NewRouter()
-    h.Routes(r)
-
-    // ... make requests against r
-}
-```
-
-Pass `nil` for optional domain engine parameters in tests where the engine isn't needed for the test case.
-
----
-
-## Schema Files
-
-### twin.json
 ```json
 {
-    "name": "{name}",
-    "description": "Simulates the {Service} API surface...",
-    "category": "{category}",
-    "sdk": {
-        "package": "{sdk_import_path}",
-        "version": "{version}"
+  "name": "{name}",
+  "description": "Behavioral clone of the {Service} API.",
+  "category": "{category}",
+  "sdk": {
+    "package": "{sdk_import_path}",
+    "version": "{version}"
+  },
+  "default_port": {port}
+}
+```
+
+### `twin-manifest.json`
+
+Minimum shape (validates against `schemas/twin-manifest.schema.json`):
+
+```json
+{
+  "twin": "{name}",
+  "display_name": "{Service}",
+  "tier": "community",
+  "category": "{category}",
+  "description": "Behavioral clone of the {Service} service for SDK-compatible local testing.",
+  "sdk_target": {
+    "primary": {
+      "package": "{sdk_import_path}",
+      "language": "go",
+      "version": "{version}",
+      "repo_url": "https://github.com/{org}/{sdk-repo}"
+    }
+  },
+  "service_surface": {
+    "openapi_spec": {
+      "available": true,
+      "origin": "vendor_published",
+      "url": "https://api.example.com/openapi.json"
     },
-    "default_port": {port}
+    "auth_pattern": "api_key",
+    "has_webhooks": false,
+    "resource_count": 0
+  },
+  "coverage": {
+    "resources_implemented": [],
+    "resources_not_implemented": [],
+    "estimated_coverage_pct": 0
+  }
 }
 ```
 
-### twin-manifest.json
-```json
-{
-    "twin": "{name}",
-    "display_name": "{Service}",
-    "tier": "community",
-    "category": "{category}",
-    "description": "...",
-    "sdk_target": { ... },
-    "service_surface": { ... },
-    "coverage": { ... }
-}
-```
+`auth_pattern` must be one of: `api_key`, `oauth2`, `basic`, `jwt`, `custom`,
+`none` (per `CLAUDE.md` "Common pitfalls" — do not invent values).
 
-### provenance.json
+### `provenance.json`
+
 ```json
 {
-    "twin": "twin-{name}",
-    "version": "0.1.0",
-    "generated_at": "{ISO 8601}",
-    "api_version": "{version}",
-    "platform": "{Service}",
-    "platform_url": "{docs_url}",
-    "category": "{category}",
-    "sources": [ ... ],
-    "sdk_target": {
-        "package": "{sdk_import_path}",
-        "version": "{version}",
-        "language": "go"
+  "twin": "twin-{name}",
+  "version": "0.1.0",
+  "api_version": "{pinned API version}",
+  "platform": "{Service}",
+  "platform_url": "{developer docs URL}",
+  "category": "{category}",
+  "research_archive": "wondertwin-docs/research/{platform}",
+  "research_completed": "{ISO 8601}",
+  "generated_at": "{ISO 8601 timestamp}",
+  "sources": [
+    {
+      "type": "{source_type}",
+      "url": "{url}",
+      "accessed": "{date}",
+      "archived_at": "{archive_path}"
     }
+  ],
+  "sdk_target": {
+    "package": "{sdk_import_path}",
+    "version": "{pinned version}",
+    "language": "go"
+  }
 }
 ```
+
+## Common mistakes
+
+Per `CLAUDE.md` "Common pitfalls" plus mistakes surfaced from prior twin builds:
+
+1. **Using `time.Now()` instead of `store.Clock.Now()`** — breaks simulated time and `wt` time-advance tests
+2. **Hardcoding the port** — always use `twincore.ParseFlags()` and allow `--port` override
+3. **Inventing `auth_pattern` enum values** — must be one of the schema's allowed values; `validate-schemas` catches this
+4. **Port collisions** — grep existing `cfg.Port` values before assigning a new one
+5. **Nil-slice JSON drift** — `json.Marshal(nil_slice)` produces `null`, not `[]`. Tests must handle both when asserting on empty lists
+6. **Skipping `validate-schemas`** — runs in seconds locally; catches errors that would otherwise surface in CI
+7. **Hand-rolling `http.Server` + signal handling in main.go** — bypasses canonical lifecycle in `twin.Serve()`
+8. **Missing `FaultInjection` middleware** — must be applied inside the route group with `r.Use(h.mw.FaultInjection)`
+9. **Returning the wrong error format** — each service has its own error envelope; match it exactly
+10. **Using `http.StatusOK` for creates** — check what the real service returns (often 201)
+11. **Skipping `omitempty` on optional JSON fields** — SDK clients may break on unexpected null fields
+12. **Not nil-checking in `LoadState()`** — partial seed data should work
+13. **Skipping any of `twin.json` / `twin-manifest.json` / `provenance.json`** — all three are required, all three validate against schemas
+14. **Writing scenarios in YAML instead of JSON** — the v2 scenario format is JSON, validated against `schemas/scenario.schema.json`
+15. **Omitting health check and reset steps from starter scenarios** — every scenario should begin with these
+16. **Forgetting to update provenance after Arazzo generation** — add the `arazzo` source entry with `origin` and `sha256`
+17. **Making scope decisions silently** — per `CLAUDE.md` "Twin Coverage Policy", the agent never decides what to skip; surface scope exceptions via the template, do not omit endpoints
+
+## Completion checklist
+
+A community twin is complete when ALL of these are true:
+
+**Source code and structure:**
+- [ ] Directory structure matches `CLAUDE.md` "Standard structure"
+- [ ] `cmd/twin-{name}/main.go` follows canonical pattern (`twincore.New` + `twin.Serve()`)
+- [ ] `internal/api/router.go` mounts `h.authMiddleware` and `h.mw.FaultInjection` inside the route group
+- [ ] `internal/store/memory.go` implements `Snapshot`, `LoadState`, `Reset`; holds `Clock`
+- [ ] All routes match the real service's URL patterns exactly
+- [ ] Request parsing matches the SDK's content type (JSON, form-encoded, GraphQL)
+- [ ] Response format matches the real service's envelope and field names
+- [ ] Error responses match the real service's error format
+- [ ] ID generation matches the real service's ID format and prefix
+- [ ] Timestamps use `store.Clock.Now()` (not `time.Now()`)
+- [ ] Pagination matches the real service's pagination pattern
+- [ ] Auth middleware validates header presence (accepts any value)
+
+**Pipeline artifacts (same PR as code):**
+- [ ] `twin.json` validates against `schemas/twin.schema.json`
+- [ ] `twin-manifest.json` validates against `schemas/twin-manifest.schema.json`
+- [ ] `provenance.json` validates against `schemas/provenance.schema.json`
+- [ ] `workflows/{name}.arazzo.json` present (if multi-step sequences exist)
+- [ ] `scenarios/basic.json` validates against `schemas/scenario.schema.json`
+- [ ] `coverage.resources_implemented` lists every resource the twin handles
+- [ ] `coverage.resources_not_implemented` empty (gap audit complete)
+- [ ] `coverage.estimated_coverage_pct: 100`
+
+**Local-dev loop and validation:**
+- [ ] `wt up` + `wt status` + `wt test` + `wt down` works end-to-end
+- [ ] `wt test scenarios/basic.json` passes
+- [ ] `wt conformance ./bin/twin-{name} --port 9999` passes
+- [ ] `go run ./cmd/validate-schemas/` clean
+- [ ] `go test ./twin-{name}/...` passes
+- [ ] `go test ./... -short` clean (no regressions in other twins)
+- [ ] `go build -o /dev/null ./twin-{name}/cmd/twin-{name}/` succeeds
+- [ ] `go vet ./...` clean
+
+**Domain engine (if applicable):**
+- [ ] Engine created with `WithClock(memStore.Clock)` for simulated time
+- [ ] Handlers call engine methods after store writes
+- [ ] Engine passed to Handler struct and nil-safe (`if h.engine != nil`)
+
+**Webhooks (if applicable):**
+- [ ] Signer implements `webhook.Signer`
+- [ ] Dispatcher created via `webhook.NewDispatcher(webhook.Config{...})`
+
+A twin is NOT complete until coverage is 100%, all artifacts validate, and the
+local-dev loop passes end-to-end.

--- a/skills/twin-researcher.md
+++ b/skills/twin-researcher.md
@@ -1,115 +1,103 @@
 ---
 skill: twin-researcher
-skill_version: "1.0"
+skill_version: "2.0"
 schemas:
   provenance.schema.json: "1.1"
 ---
 
-# SKILL: WonderTwin Twin Researcher
+# SKILL: Twin Researcher (community)
 
 ## Purpose
 
-Investigate a target platform well enough to build a twin against it, and produce archived, provenanced research artifacts that pin the twin to a specific version of the platform's API. This skill is the entry point in the twin lifecycle — it precedes the twin generator and feeds into the twin maintainer.
+Research a target platform well enough to build a community twin against it,
+and produce structured, provenanced research artifacts that pin the twin to
+specific versions of the platform's API and SDK.
 
-Research starts from inquiry, not confirmation. The goal is to build a mental model of the target system complete enough to simulate its observable behavior — and to know where our model is uncertain.
+This skill is the entry point of the community twin lifecycle. It precedes the
+community twin generator and feeds into the twin maintainer when platform
+releases require updates.
 
-This skill produces two categories of output:
-1. **Research artifacts** — structured knowledge about the target system, archived with provenance
-2. **Decision artifacts** — feasibility assessment, architecture spec, and build roadmap
+Research starts from inquiry, not confirmation. The goal is to build a mental
+model of the target system complete enough to simulate its observable behavior
+— and to know where the model is uncertain.
 
-## When to Use
+## Audience and tier
 
-- Evaluating a new platform as a twin candidate
-- Deepening knowledge before building a new twin (feeds into `twin-generator`)
-- Investigating a specific platform area for a twin extension (feeds into `twin-extender`)
-- Responding to a platform release that may affect an existing twin (feeds into `twin-maintainer`)
+This is the **public, MIT-licensed** researcher skill, intended for community
+contributors. Two cases this skill serves:
 
-## Prerequisites
+1. A developer building a twin of commercial software they integrate with
+   (e.g., a Stripe twin for testing their payment flow without hitting Stripe's
+   sandbox).
+2. A vendor building a twin of their own software so customers can develop
+   integrations offline.
 
-1. A target platform name and general category (accounting, payments, CRM, etc.)
-2. Access to public internet for documentation, SDK repos, and community sources
-3. The `wondertwin-docs/` repo for storing research archives
+The skill scope is "how to research a twin from public information." It covers
+discovery from SDKs, OpenAPI specs, and public docs; behavior observation
+methods that respect ToS; quirk identification from documented edge cases and
+community signal; and the artifact set the community twin generator needs.
 
-## Agent Permissions
-
-When this skill runs as a subagent, it needs write access to `wondertwin-docs/research/` which is **outside** the main `wondertwin/` working directory. To avoid permission denials:
-
-- The **parent conversation** should pre-create the research directory structure before launching the agent:
-  ```bash
-  platform="{platform}"
-  base="/Users/tela/dev/wondertwin-docs/research/${platform}"
-  mkdir -p "${base}/archive/"{official-docs,schemas,sdks,release-notes,community,observations}
-  ```
-- Alternatively, the parent should write all artifact files itself after the agent completes research, since the parent conversation has broader file permissions than subagents.
-- Subagents spawned from the `wondertwin/` directory cannot write to `wondertwin-docs/` due to sandbox scoping. This is a known limitation.
+Internal operator concerns (market analysis, vendor prioritization, customer-
+demand signal integration, internal pipelines) are out of scope for this
+skill. Operators running an internal twin pipeline use a separately-maintained,
+private flavor of this skill.
 
 ## Inputs
 
-The user will provide:
+- **Platform name** — the target platform (e.g., `quickbooks-online`, `mercury`, `stripe`)
+- **Category** — functional category (e.g., `accounting`, `banking-as-a-service`, `payments`)
+- **Research scope** — one of:
+  - `candidate` — minimum viable research for go/no-go (Phases 0, 1, 2, 4, 7, 8)
+  - `build-ready` — full research for first implementation phase (all phases applicable to the planned roadmap phase)
+  - `targeted` — investigate a specific area (specify which Section 1 questions)
+- **Known context** (optional) — anything you already know: SDK names, doc URLs, prior research
 
-- **Platform name**: The SaaS platform to research (e.g., "QuickBooks Online", "Plaid", "Modern Treasury")
-- **Category**: The platform's functional category (e.g., "accounting", "banking-as-a-service", "money-movement")
-- **Research scope**: One of:
-  - `candidate` — Minimum viable research for go/no-go (Sections 1.1, 1.2, 1.4, 1.7, 1.8)
-  - `build-ready` — Full research for first implementation phase (all Section 1 questions for phase 1 scope)
-  - `targeted` — Investigate a specific area (user specifies which Section 1 questions)
-- **Known context** (optional): Anything the user already knows — SDK names, API docs URLs, prior research
-- **Fintech primitives** (optional, for fintech twins): Which `twinkit/` engines this platform is expected to use
+## Output structure
 
-## Output Structure
-
-All research artifacts are stored under `wondertwin-docs/research/{platform}/`:
+All research artifacts live under `wondertwin-docs/research/{platform}/`:
 
 ```
 wondertwin-docs/research/{platform}/
-├── system-model.md              # Answers to Section 1 questions with confidence scores
-├── record-type-catalog.json     # Inventory of all types, fields, operations, relationships
-├── compatibility-path.md        # SDK landscape, spectrum position, build strategy
-├── event-model.md               # Webhook/event classification and twin strategy
-├── release-timeline.json        # Historical and projected releases, deprecation dates
-├── observations.json            # Notable API behaviors with provenance
-├── feature-gap-register.json    # What the twin does NOT cover, by domain
-├── source-catalog.json          # Index of all discovered and archived sources
-├── provenance-log.jsonl         # Append-only log of research activities
-├── feasibility.md               # Go/no-go with rationale
-├── architecture-spec.md         # Technical design for twin implementation
-├── roadmap.json                 # Phased build plan
-├── archive/                     # Archived source materials
-│   ├── official-docs/           # Fetched doc tree, versioned by date
-│   │   ├── {date}/
-│   │   └── latest -> {date}/
-│   ├── schemas/                 # OpenAPI specs, WSDL files, metadata
-│   │   ├── {api-version}/
-│   │   └── latest -> {api-version}/
-│   ├── sdks/                    # SDK metadata and analysis (not full clones)
-│   │   └── {sdk-name}@{version}.md
-│   ├── release-notes/           # Archived release notes per version
-│   │   └── {version}.md
-│   ├── community/               # Forum threads, blog posts, SO answers
-│   │   └── {source-id}.md
-│   └── observations/            # Behavioral observations from probing
-│       └── {date}-{description}.md
-└── RESEARCH-STATUS.md           # Current state, confidence/curiosity scores, next steps
+├── RESEARCH-STATUS.md              # Status, confidence + gap list with EV, next steps
+├── system-model.md                 # Section 1 questions with confidence scores
+├── record-type-catalog.json        # Inventory of types, fields, operations, relationships
+├── compatibility-path.md           # SDK landscape, target version, build strategy
+├── event-model.md                  # Webhook/event classification (when applicable)
+├── release-timeline.json           # Historical/projected releases, deprecation dates
+├── observations.json               # Notable API behaviors with provenance
+├── source-catalog.json             # Index of all discovered and archived sources
+├── provenance-log.jsonl            # Append-only log of research activities
+├── feasibility.md                  # Go/no-go with rationale
+├── architecture-spec.md            # Technical design for twin (incl. engine analysis)
+├── roadmap.json                    # Phased build plan
+├── quirk-hypotheses.json           # Behavioral quirks from SDK audit (15-30 items)
+└── archive/
+    ├── official-docs/{date}/
+    ├── schemas/{api-version}/
+    ├── sdks/{sdk-name}@{version}.md
+    ├── release-notes/{version}.md
+    ├── community/{source-id}.md
+    └── observations/{date}-{description}.md
 ```
-
----
 
 ## Process
 
-### Phase 0: Initialize Research Directory
+### Phase 0: Initialize and meta-research
 
-Create the research directory structure and initialize tracking files.
+Start here regardless of scope. Understanding what sources exist determines
+how to investigate everything else.
 
-**1. Create the directory tree:**
+**1. Initialize the directory:**
 
 ```bash
-platform="{platform}"  # lowercase, hyphenated (e.g., "quickbooks-online")
+platform="{platform}"  # lowercase, hyphenated
 base="wondertwin-docs/research/${platform}"
 mkdir -p "${base}/archive/"{official-docs,schemas,sdks,release-notes,community,observations}
 ```
 
-**2. Initialize `source-catalog.json`:**
+**2. Initialize tracking files:**
 
+`source-catalog.json`:
 ```json
 {
   "platform": "{platform}",
@@ -120,83 +108,58 @@ mkdir -p "${base}/archive/"{official-docs,schemas,sdks,release-notes,community,o
 }
 ```
 
-**3. Initialize `provenance-log.jsonl`:**
-
-Write the first entry:
-
+`provenance-log.jsonl` — first entry:
 ```json
-{"timestamp": "{ISO 8601}", "action": "research_initiated", "scope": "{candidate|build-ready|targeted}", "agent": "twin-researcher"}
+{"timestamp": "{ISO 8601}", "action": "research_initiated", "scope": "{candidate|build-ready|targeted}"}
 ```
 
-**4. Initialize `RESEARCH-STATUS.md`:**
+`RESEARCH-STATUS.md` — see template below ("RESEARCH-STATUS template").
 
-```markdown
-# Research Status: {Platform}
-
-**Category**: {category}
-**Scope**: {scope}
-**Initiated**: {date}
-**Status**: In Progress
-
-## Confidence / Curiosity Scores
-
-| Area | Confidence | Curiosity | Notes |
-|------|-----------|-----------|-------|
-| 1.1 What is this system? | 0.0 | — | Not started |
-| 1.2 How does it expose itself? | 0.0 | — | Not started |
-| 1.3 What does it remember? | 0.0 | — | Not started |
-| 1.4 How does it protect itself? | 0.0 | — | Not started |
-| 1.5 How does it communicate changes? | 0.0 | — | Not started |
-| 1.6 How does it allow customization? | 0.0 | — | Not started |
-| 1.7 How can we learn about it? | 0.0 | — | Not started |
-| 1.8 How does it change over time? | 0.0 | — | Not started |
-
-## Open Questions
-
-(populated as research progresses)
-
-## Next Actions
-
-(populated as research progresses)
-```
-
----
-
-### Phase 1: Meta-Research (Section 1.7)
-
-Start here regardless of scope. Understanding what sources exist determines how to investigate everything else.
-
-**1. Discover official documentation:**
+**3. Discover official sources:**
 
 - Search for the platform's developer documentation portal
 - Identify the documentation structure (REST reference, guides, tutorials, changelog)
-- Record the base URL and structure in `source-catalog.json`
-
-**2. Discover API specifications:**
-
-- Search for OpenAPI/Swagger specs: check `{api-domain}/openapi.json`, GitHub repos, doc pages
+- Search for OpenAPI/Swagger specs at `{api-domain}/openapi.json`, GitHub repos, doc pages
 - Search for WSDL, GraphQL schema, or other machine-readable definitions
-- If found, fetch and archive to `archive/schemas/{api-version}/`
+- Fetch and archive everything found to `archive/{schemas|official-docs}/`
 
-**3. Survey the SDK landscape:**
+**4. Search for deprecation and lifecycle information:**
 
-- Search major package registries for official and community SDKs:
-  - Go: `pkg.go.dev` search
-  - Python: PyPI search
-  - Node: npmjs.com search
-  - Ruby: rubygems.org search
-- For each SDK found, record: name, maintainer (official vs. community), version, last updated, stars/downloads
-- Assess the SDK spectrum position (see Section 5 of the research framework)
+This is critical and easily missed. Always search for:
 
-**4. Identify community sources:**
+- "{platform} API deprecation"
+- "{platform} SOAP deprecated" / "REST deprecated"
+- "{platform} API sunset timeline"
+- "{platform} API end of life"
+- Release notes for "deprecation", "sunset", "end of support"
+- Developer blogs for migration announcements
+- Support bulletins for breaking changes
 
-- Search for the platform's developer forum, Slack/Discord, Stack Overflow tag
-- Note any iPaaS connector documentation (Workato, Celigo, Tray.io)
-- Search GitHub for existing mocks/simulators of this platform (prior art)
+**Why:** choosing a deprecated API wastes effort. Deprecation timelines
+validate API target choice and inform migration planning.
 
-**5. Archive and catalog:**
+**5. Survey the SDK landscape:**
 
-For every source discovered:
+Search major package registries:
+- Go: `pkg.go.dev` search
+- Python: PyPI search
+- Node: npmjs.com search
+- Ruby: rubygems.org search
+
+For each SDK found, record: name, maintainer (official vs. community), version,
+last updated, stars/downloads. Assess the SDK spectrum position (multiple
+canonical, single canonical, canonical + community, community only, API docs +
+schema, API docs only, restricted access).
+
+**6. Identify community sources:**
+
+- Platform's developer forum, Slack/Discord, Stack Overflow tag
+- iPaaS connector documentation (Workato, Celigo, Tray.io) — often documents auth quirks
+- GitHub for existing mocks/simulators of this platform (prior art)
+
+**7. Catalog every source:**
+
+For each, append to `source-catalog.json` sources array:
 
 ```json
 {
@@ -212,13 +175,9 @@ For every source discovered:
 }
 ```
 
-Append to `source-catalog.json` sources array.
+**Update Section 1.7 confidence in `RESEARCH-STATUS.md`.**
 
-**6. Update confidence scores for 1.7.**
-
----
-
-### Phase 2: System Identity (Section 1.1)
+### Phase 1: System identity (Section 1.1)
 
 **Must answer:**
 - What does this system do? What problem does it solve?
@@ -226,15 +185,12 @@ Append to `source-catalog.json` sources array.
 - What are the system's boundaries?
 - Who uses it? (End users, developers, integrators)
 
-**Sources to consult:** Official "what is" / overview pages, Wikipedia, vendor marketing, industry analysis.
+**Sources:** Official "what is" / overview pages, Wikipedia, vendor marketing,
+industry analysis.
 
-**For fintech twins:** Identify which of the seven fintech primitives (money movement, ledger, card, identity, risk, billing, compliance) this platform maps to. This determines which `twinkit/` engines to use.
+**Output:** `system-model.md` Section 1.1 with provenance citations.
 
-**Output:** Write the 1.1 section of `system-model.md` with provenance citations.
-
----
-
-### Phase 3: API Surface Discovery (Section 1.2)
+### Phase 2: API surface (Section 1.2)
 
 **Must answer:**
 - What API protocols exist? (REST, SOAP, GraphQL, gRPC, webhooks)
@@ -242,43 +198,36 @@ Append to `source-catalog.json` sources array.
 - Do protocols share underlying state?
 - URL structure, versioning model, serialization formats
 
-**Method:** Doc tree crawl of API reference. If OpenAPI spec was found in Phase 1, parse it for endpoint inventory.
+**Method:** Doc tree crawl of API reference. If OpenAPI spec was found in
+Phase 0, parse it for endpoint inventory.
 
-**Output:** Write the 1.2 section of `system-model.md`. Begin populating `record-type-catalog.json` with the endpoint/resource inventory.
+**Output:** `system-model.md` Section 1.2. Begin populating
+`record-type-catalog.json` with the endpoint/resource inventory.
 
----
+**Include deprecation status from Phase 0** — document if the chosen API is
+modern/stable vs. deprecated. This is the single most expensive research
+mistake to discover late.
 
-### Phase 4: Auth & Protection (Section 1.4)
+### Phase 3: Data model (Section 1.3)
 
-**Must answer:**
-- Authentication mechanisms per API surface
-- Authorization/permission model
-- Rate limiting and throttling (limits, headers, backoff)
-- Request/response size limits
+For `candidate` scope: high-level entity inventory with relationships;
+field-level detail not required.
 
-**This must be answered completely even for `candidate` scope** — auth must work for any phase of twin implementation.
-
-**Output:** Write the 1.4 section of `system-model.md`.
-
----
-
-### Phase 5: Data Model Deep Dive (Section 1.3)
-
-**For `candidate` scope:** High-level entity inventory with relationships. Field-level detail is not required.
-
-**For `build-ready` scope:** Complete field-level detail for phase 1 record types.
+For `build-ready` scope: complete field-level detail for the planned roadmap
+phase's record types.
 
 **Must answer:**
 - All record/resource types
 - Fields, types, constraints, required/optional
 - Relationships between types
-- State machines for stateful records
+- State machines for stateful records (e.g., `invoice: draft → open → paid → voided`)
 - Identification scheme (IDs, external IDs, natural keys)
 - Query/search/pagination capabilities
 
-**Method:** Schema extraction (if OpenAPI available), SDK deep audit (read source of target SDK), doc tree crawl.
+**Method:** Schema extraction (if OpenAPI available), SDK deep audit (read SDK
+source), doc tree crawl.
 
-**Output:** Complete `record-type-catalog.json`:
+**Output:** `record-type-catalog.json`:
 
 ```json
 {
@@ -314,9 +263,26 @@ Append to `source-catalog.json` sources array.
 }
 ```
 
----
+**Note:** for `candidate` scope, restrict the catalog to the planned roadmap
+phase's types — don't try to catalog 100+ types when only 10 are in scope.
 
-### Phase 6: Event Model (Section 1.5)
+### Phase 4: Authentication and protection (Section 1.4)
+
+**Must answer:**
+- Authentication mechanisms per API surface
+- Authorization/permission model (scopes, roles)
+- Rate limiting and throttling (limits, headers, backoff)
+- Request/response size limits
+
+**This must be answered completely even for `candidate` scope.** Auth must
+work for any phase of twin implementation; surfacing an auth blocker late is
+the most expensive feasibility miss.
+
+**Output:** `system-model.md` Section 1.4. Document the twin's auth simulation
+strategy: full OAuth flow vs. simplified bearer-token acceptance vs. accept-any-
+header.
+
+### Phase 5: Event model (Section 1.5)
 
 **Must answer:**
 - Does the platform provide native webhooks?
@@ -325,7 +291,7 @@ Append to `source-catalog.json` sources array.
 - Subscription/registration API
 - Polling patterns when events aren't available
 
-**Output:** Write `event-model.md`:
+**Output:** `event-model.md`:
 
 ```markdown
 # Event Model: {Platform}
@@ -342,21 +308,48 @@ Append to `source-catalog.json` sources array.
 | ... | ... | ... | ... |
 
 ## Twin Strategy
-{How the twin will implement events — which webhook package features to use, signing scheme, etc.}
+{How the twin will implement events — webhook signing scheme, event types, dispatcher configuration}
 ```
 
----
+Many platforms lack native webhooks (e.g., NetSuite). Document this explicitly
+— "polling only" is a finding, not an absence of finding.
 
-### Phase 7: Release Lifecycle (Section 1.8)
+### Phase 6: Customization and extensibility (Section 1.6)
 
 **Must answer:**
-- Release cadence and naming
+- Can customers add custom fields?
+- Can customers write custom code (e.g., SuiteScript, Apex)?
+- Are there workflow engines (e.g., NetSuite SuiteFlow)?
+- Can the twin simulate generic customizations?
+- What is out of scope (customer-specific logic)?
+
+**Principle:** the twin simulates platform APIs, not customer customizations.
+Customer-specific code is permanently out of scope.
+
+**Output:** `system-model.md` Section 1.6.
+
+### Phase 7: Source quality (Section 1.7 wrap-up)
+
+**Must answer:**
+- How good is the official documentation?
+- Are there mature SDKs in target languages?
+- Are there code examples, Postman collections?
+- What are the gaps in documentation?
+- Where will we get answers during build?
+
+**Output:** `system-model.md` Section 1.7. Update `source-catalog.json` with
+quality ratings.
+
+### Phase 8: Release lifecycle (Section 1.8)
+
+**Must answer:**
 - Versioning model (URL, header, date-based)
+- Release cadence (continuous, quarterly, annual)
 - Deprecation policy and timeline
 - Breaking change history
-- Interface velocity vs. logic velocity vs. platform velocity
+- What APIs are deprecated or being sunset (from Phase 0 findings)
 
-**Output:** Write `release-timeline.json`:
+**Output:** `system-model.md` Section 1.8. Write `release-timeline.json`:
 
 ```json
 {
@@ -377,13 +370,59 @@ Append to `source-catalog.json` sources array.
 }
 ```
 
----
+### Phase 8.5: SDK behavioral audit
 
-### Phase 8: Compatibility Path Assessment (Section 5)
+**Goal:** Discover behavioral quirks by auditing SDK source code and community
+knowledge.
 
-Using findings from Phases 1-7, assess the SDK compatibility path.
+**Must answer:**
+- What workarounds do SDKs implement?
+- What issues do developers report (GitHub issues, Stack Overflow)?
+- What validation rules, edge cases, error handling patterns exist?
+- What are the "gotchas" (null vs. empty string, timezone handling, etc.)?
 
-**Output:** Write `compatibility-path.md`:
+**Output:** `quirk-hypotheses.json` — 15-30 behavioral quirks to verify and
+implement. Organize by domain:
+
+- AUTH (auth scheme deviations, token format quirks)
+- IDENTITY (user/account ID generation, external IDs)
+- CRUD (validation rules, default values, partial updates)
+- QUERY (filter syntax, search behavior, includes)
+- LIFECYCLE (state machine edge cases, soft delete behavior)
+- ERROR_HANDLING (status code conventions, error envelope shape)
+- PAGINATION (cursor format, has_more semantics, default page sizes)
+- TIMESTAMPS (timezone handling, ISO format variations, epoch precision)
+- NULL_HANDLING (null vs. omitted vs. empty string)
+
+Focus on high-priority domains (AUTH, IDENTITY, CRUD) first. Lower-priority
+domains can be deferred.
+
+### Phase 9: Synthesis and decision
+
+**1. Write `feasibility.md`:**
+
+Cover:
+- Is there enough public information to build a useful twin?
+- What is the SDK compatibility strategy?
+- What is the estimated scope (number of endpoints, complexity)?
+- Go/no-go recommendation with rationale
+
+**2. Write `architecture-spec.md`:**
+
+For approved candidates, produce the technical design:
+
+- **Engine analysis** (mandatory section): which `twinkit/` engines (workspace,
+  ledger, messaging, events, search, or none) the twin will use. Whether the
+  existing engine satisfies requirements or has gaps. If gaps: enhancement of
+  existing engine, or new engine required. **"New engine required" blocks
+  generation** — the engine must land first as a separate work stream.
+- Directory structure (per `wondertwin/CLAUDE.md` "Standard structure")
+- API surface (endpoints to implement)
+- Auth simulation strategy (per Phase 4)
+- Key design decisions
+- What is in scope vs. out of scope for v0.1
+
+**3. Write `compatibility-path.md`:**
 
 ```markdown
 # Compatibility Path: {Platform}
@@ -397,36 +436,13 @@ Using findings from Phases 1-7, assess the SDK compatibility path.
 - **Conformance gate**: {What tests/checks confirm compatibility}
 
 ## Risk Factors
-- {List risks: SDK staleness, undocumented behaviors, breaking change frequency, etc.}
+- {SDK staleness, undocumented behaviors, breaking change frequency, etc.}
 
 ## Build Strategy
 {How to build the twin given the SDK landscape — test against SDK tests, build from OpenAPI, etc.}
 ```
 
----
-
-### Phase 9: Synthesis & Decision
-
-**1. Write `feasibility.md`:**
-
-Assess whether a twin is viable. Cover:
-- Is there enough public information to build a useful twin?
-- What is the SDK compatibility strategy?
-- What is the estimated scope (number of endpoints, complexity)?
-- What is the commercial demand signal?
-- Go/no-go recommendation with rationale
-
-**2. Write `architecture-spec.md`:**
-
-For approved candidates, produce the technical design:
-- Which `twinkit/` packages to use (and which new ones to build)
-- For fintech twins: primitive composition and hook requirements
-- Directory structure
-- API surface (endpoints to implement)
-- Key design decisions
-- What is in scope vs. out of scope for v0.1
-
-**3. Write `roadmap.json`:**
+**4. Write `roadmap.json`:**
 
 ```json
 {
@@ -445,17 +461,15 @@ For approved candidates, produce the technical design:
 }
 ```
 
-**4. Update `RESEARCH-STATUS.md`** with final confidence/curiosity scores and status.
+**5. Update `RESEARCH-STATUS.md`** with final confidence scores and the
+remaining gap list.
 
----
+### Phase 10: Version pinning and provenance
 
-### Phase 10: Version Pinning & Provenance
+Before handing off to the twin generator, lock down the provenance record that
+pins the twin to specific versions.
 
-Before handing off to the twin generator, lock down the provenance record that pins the twin to specific versions.
-
-**1. Finalize `provenance-log.jsonl`:**
-
-Append the completion entry:
+**1. Append the completion entry to `provenance-log.jsonl`:**
 
 ```json
 {"timestamp": "{ISO 8601}", "action": "research_complete", "scope": "{scope}", "api_version": "{pinned version}", "sdk_version": "{pinned version}", "archive_sha": "{git commit of archive}"}
@@ -463,9 +477,9 @@ Append the completion entry:
 
 **2. Generate the twin's `provenance.json` template:**
 
-This is the file that ships with the twin (in `twin-{name}/provenance.json`). It extends the existing provenance format with research lineage:
+This is the file that ships with the twin (in `twin-{name}/provenance.json`).
+It validates against `wondertwin/schemas/provenance.schema.json`:
 
-<!-- schema: provenance.schema.json -->
 ```json
 {
   "twin": "twin-{name}",
@@ -485,7 +499,6 @@ This is the file that ships with the twin (in `twin-{name}/provenance.json`). It
       "archived_at": "{archive_path}"
     }
   ],
-  "fintech_primitives": [],
   "twinkit_packages": [],
   "sdk_target": {
     "package": "{sdk_import_path}",
@@ -499,21 +512,57 @@ This is the file that ships with the twin (in `twin-{name}/provenance.json`). It
 }
 ```
 
----
+## RESEARCH-STATUS template
 
-## Provenance Rules
+`RESEARCH-STATUS.md` is the live document the build gate consults. It tracks
+confidence per Section-1 area and the **gap list with expected-value**.
 
-Every claim in research output must link to its source. Follow these rules:
+```markdown
+# Research Status: {Platform}
 
-1. **Every claim cites sources.** Use inline citations in markdown: `[source: {source_id}]`
-2. **Single-source claims carry the source's confidence level.** Official docs = high, community = medium, undated forum posts = low.
-3. **Multi-source agreement elevates confidence.** Two independent sources agreeing = higher than either alone.
-4. **Community-only claims are flagged.** Mark as "community-reported, unverified" until confirmed against official sources.
-5. **Contradictions are recorded, not hidden.** When sources disagree, record both and flag for resolution.
-6. **Provenance is append-only.** When a claim is updated, the old record is superseded, not deleted.
-7. **Dates matter.** Always record when a source was accessed. A 2024 doc page accessed in 2026 may describe outdated behavior.
+**Category**: {category}
+**Scope**: {scope}
+**Initiated**: {date}
+**Status**: In Progress | Build-Ready | Complete
 
-## Confidence Scoring Guide
+## Confidence Scores
+
+| Area | Confidence | Notes |
+|------|-----------|-------|
+| 1.1 System identity            | 0.0 | Not started |
+| 1.2 API surface                | 0.0 | Not started |
+| 1.3 Data model                 | 0.0 | Not started |
+| 1.4 Auth & protection          | 0.0 | Not started |
+| 1.5 Event model                | 0.0 | Not started |
+| 1.6 Customization              | 0.0 | Not started |
+| 1.7 Source quality             | 0.0 | Not started |
+| 1.8 Release lifecycle          | 0.0 | Not started |
+
+## Gap List (sorted by expected value of filling)
+
+Each gap entry includes:
+- **What artifact closes the gap** — concrete deliverable
+- **Confidence improvement** — what score moves and by how much
+- **Residual twin-functionality risk if NOT filled** — concrete failure mode
+
+| # | Gap | Closing artifact | Confidence delta | Risk if unfilled |
+|---|-----|------------------|------------------|------------------|
+| 1 | ... | ... | ... | ... |
+
+## Open Questions
+
+(populated as research progresses)
+
+## Next Actions
+
+(populated as research progresses; default to highest-EV gap as next target)
+```
+
+The gap list drives prioritization. When the build-skill consults this file at
+its Phase 0, **high-EV gaps unfilled** = research not yet build-ready, return
+to research with the highest-EV gap as the next target.
+
+## Confidence scoring guide
 
 | Score | Meaning |
 |-------|---------|
@@ -523,47 +572,133 @@ Every claim in research output must link to its source. Follow these rules:
 | 0.7–0.8 | Good coverage from reliable sources, minor gaps |
 | 0.9–1.0 | Comprehensive coverage from authoritative sources, corroborated |
 
-## Curiosity Scoring Guide
+## Provenance rules
 
-| Score | Meaning |
-|-------|---------|
-| Low | Area is well-understood or not important for twin fidelity |
-| Medium | Some expected value from additional research |
-| High | Significant undiscovered knowledge likely — behavioral quirks, undocumented features, or commercial intelligence |
+Every claim in research output must link to its source.
 
----
+1. **Every claim cites sources.** Use inline citations: `[source: {source_id}]`
+2. **Single-source claims carry the source's confidence level.** Official docs = high; community = medium; undated forum posts = low.
+3. **Multi-source agreement elevates confidence.** Two independent sources agreeing = higher than either alone.
+4. **Community-only claims are flagged.** Mark as "community-reported, unverified" until confirmed against official sources.
+5. **Contradictions are recorded, not hidden.** When sources disagree, record both and flag for resolution.
+6. **Provenance is append-only.** When a claim is updated, the old record is superseded, not deleted.
+7. **Dates matter.** Always record when a source was accessed. A 2024 doc page accessed in 2026 may describe outdated behavior.
 
-## Common Mistakes
+## Behavior observation (respect ToS)
+
+Some research requires running the SDK or hitting the platform's sandbox to
+discover behavior that docs don't describe. Rules:
+
+- **Use sandbox / test environments only.** Never run probes against production tenants you don't own.
+- **Read the platform's Terms of Service.** Some platforms prohibit reverse-engineering or automated probing even of sandbox endpoints. If ToS prohibits, document the gap and rely on doc + SDK sources only.
+- **Archive observations with provenance.** Record the request shape, response shape, timestamps, and the credentials class used (sandbox / test account). Never archive real customer credentials.
+- **Disclose probe-discovered behavior in commit messages.** When a quirk is implemented based on probing rather than docs, the commit cites the observation file.
+
+For platforms whose ToS prohibits even sandbox probing (rare), the twin is
+limited to doc-based behavior. Note this limitation in `feasibility.md`.
+
+## SPA Documentation Extraction Playbook
+
+Many modern API docs (Readme.io, Redocly, Docusaurus, Stoplight) are SPAs that
+return empty shells to plain HTTP fetch. Use a headless browser to extract
+rendered content.
+
+### Readme.io (proven technique)
+
+Readme.io sites embed OpenAPI specs in page metadata. This is the most
+valuable extraction target — a single spec file contains every endpoint,
+schema, query parameter, and enum.
+
+**Step 1:** Fetch any `/reference/` page; the HTML contains a JSON registry
+of all spec files with UUIDs and filenames.
+
+**Step 2:** Extract the spec registry by parsing embedded JSON in the page's
+`<script type="application/json">` blocks. Registry entries contain:
+`filename`, `uuid`, `type` (`"openapi"`), `last_updated`.
+
+**Step 3:** Fetch the spec directly via a URL like
+`https://docs.{platform}.com/openapi/{uuid}` — returns the full OpenAPI
+YAML/JSON.
+
+**Key patterns:**
+- Spec files typically named `{product}-openapi.yaml` or `{product}-api.json`
+- Multiple specs may exist (main API, OAuth, onboarding, etc.)
+- UUIDs are stable — can be re-fetched in future research passes
+- Spec `last_updated` timestamps indicate freshness
+
+**Fallback if direct URL 404s:** parse the embedded JSON registry from the
+SPA's hydration data and build the URL manually.
+
+### Other SPA platforms
+
+| Platform | Extraction strategy | Status |
+|---|---|---|
+| Readme.io | OpenAPI spec from page metadata (above) | **Proven** (Mercury) |
+| Redocly | Look for `__redoc_state` or bundled OpenAPI in `<script>` tags | Untested |
+| Docusaurus | Content often in static JSON; check `/api/` routes | Untested |
+| Stoplight | OpenAPI typically at predictable paths (`/api.yaml`) | Untested |
+| Custom React | Headless fetch with `wait_for` selector, then parse HTML | Case-by-case |
+
+### General SPA tips
+
+- Always try a headless fetch with `wait_for` targeting content selectors (`article`, `main`, `[class*="content"]`)
+- Extract structured data (sidebar links, endpoint lists, schema tables) as JSON via in-page `evaluate` calls
+- Use action-driven fetches to expand collapsed sections or navigate paginated docs
+- Archive raw extractions in `archive/` with provenance notes
+
+## Common mistakes
 
 ### Research mistakes
-- **Assuming docs are complete.** Official documentation routinely omits edge cases, error shapes, and behavioral quirks. Treat docs as a starting point, not ground truth.
-- **Ignoring community sources.** Forum posts and GitHub issues often contain the most valuable behavioral observations — the things docs don't say.
+- **Assuming docs are complete.** Documentation routinely omits edge cases, error shapes, behavioral quirks. Treat docs as a starting point, not ground truth.
+- **Ignoring community sources.** Forum posts and GitHub issues often contain the most valuable behavioral observations.
 - **Not archiving.** URLs go stale. Doc pages change. Always fetch and archive locally before citing.
 - **Conflating versions.** A blog post from 2023 may describe behavior that changed in 2025. Always check recency.
 
 ### Provenance mistakes
-- **Blanket confidence scores.** Never assign a single confidence score to an entire platform. Score per knowledge area (Section 1 subsection).
+- **Blanket confidence scores.** Never assign a single confidence score to an entire platform. Score per Section-1 subsection.
 - **Forgetting to pin versions.** The twin must be pinned to a specific API version and SDK version. "Latest" is not a version.
 - **Not recording access dates.** A URL accessed on 2026-03-17 is a different source than the same URL accessed on 2026-06-01 if the content changed.
 
 ### Scope mistakes
 - **Researching everything for a candidate assessment.** `candidate` scope only needs enough for go/no-go. Don't do field-level data modeling until approved.
-- **Skipping auth for candidate scope.** Auth must be understood even for candidates — if auth is exotic or undocumented, that's a feasibility risk.
-- **Not identifying the fintech primitive composition early.** For fintech twins, the primitive mapping determines which `twinkit/` engines to use and must be established in Phase 2.
+- **Skipping auth for candidate scope.** Auth must be understood even for candidates — exotic or undocumented auth is a feasibility risk.
+- **Not catching deprecations early.** Phase 0's deprecation searches are not optional. Building on a sunset API wastes the entire effort.
 
----
+### Engine-analysis mistakes
+- **Treating engine selection as code-generation-time concern.** Engine choice is a research-stage decision recorded in `architecture-spec.md`. The build gate verifies engine analysis is complete; "new engine required" blocks generation.
+- **Forcing a fit.** If no existing `twinkit/` engine fits, document the gap honestly. Cramming an entity model into the wrong engine produces twins that drift from the canonical pattern.
 
-## Integration with Other Skills
+## Learning capture
 
-| Skill | Handoff |
-|-------|---------|
-| `twin-generator` | Research produces `architecture-spec.md`, `provenance.json` template, and `roadmap.json`. Generator consumes these as inputs. |
-| `twin-extender` | Targeted research on a new area produces updated `record-type-catalog.json` and `feature-gap-register.json`. Extender uses these to add capabilities. |
-| `twin-maintainer` | Research triggered by platform release produces delta analysis. Maintainer uses this to plan updates. |
+Every research pass produces two kinds of output:
 
-## Archive Maintenance
+1. **Platform-specific artifacts** (system-model, feasibility, etc.)
+2. **Generalizable techniques, patterns, and discoveries** that improve the research process itself
 
-- Research archives live in `wondertwin-docs/research/{platform}/`
-- Archives are committed to the `wondertwin-docs` repo with descriptive commit messages
-- The `source-catalog.json` is the index — it must be kept in sync with archived files
-- When a source is re-fetched (e.g., docs updated after a platform release), archive the new version with a new date directory. Do not overwrite previous versions.
+The second kind is easily lost if not explicitly captured. At the end of every
+research pass, before declaring it complete, ask:
+
+1. **New extraction technique?** A way to get data from a previously inaccessible source? (e.g., Readme.io OpenAPI extraction.) → add to "SPA Documentation Extraction Playbook" above.
+2. **New source pattern?** A class of source that applies across platforms? → add to Phase 0 activities.
+3. **Process improvement?** A phase ordering, tool combination, or strategy that worked better than this skill describes? → update the relevant phase.
+4. **Correction to assumptions?** A common assumption that turned out wrong? (e.g., "Bearer auth" turning out to be Basic auth.) → reinforce in the relevant phase.
+5. **Tool capability gap?** A wall hit that a new tool or technique could solve for future passes? → flag in the platform's `archive/` and surface upstream.
+
+**Capture rules:**
+- Be specific — "Readme.io embeds OpenAPI specs in page metadata with UUID-based URLs" beats "SPA docs can be scraped"
+- Include provenance — which platform research produced this learning? What date?
+- Mark confidence — Proven (tested on a real platform) vs. Untested (hypothesis from observation)
+- Update the skill file directly — learnings deferred are learnings lost
+
+## Integration with the build skill
+
+This skill produces the artifact set the community twin generator
+(`wondertwin/skills/community-twin-generator.md`) consumes at its Phase 0.
+The build gate is documented in
+`wondertwin-docs/skills/handoffs/research-to-build.md` (which lives in the
+docs repo so both community and pro generators reference the same gate).
+
+Research is iterative. Findings update with each pass. The gap list shrinks.
+Build-readiness emerges over multiple research passes, not in one shot. The
+build gate is "met the floor for this twin's planned coverage", not "research
+is final."


### PR DESCRIPTION
## Summary

Session **3B-3c** (public side). Two coordinated PRs total; this one delivers the public-tier deliverables. Companion PR in `wondertwin-docs` covers the private-tier overlay + research-to-build gate.

Per [twin-factory-design-2026-05-04 §5.3, §5.4, §6, §8, §9](../../wondertwin-docs/blob/main/thinking/explorations/twin-factory-design-2026-05-04.md):

### `skills/community-twin-generator.md` (§5.3)

Refactored from 295L flat-state to **803L** (within 600–900 budget). Key changes:

- **Cites `wondertwin/CLAUDE.md`** as canonical community pattern source (analog of how `twin-generator-pro` cites `wondertwin-pro/CONTRIBUTING.md`). No restated canonical pattern in skill prose.
- **Reference twins by contract shape** (verified against actual code):
  - JSON request + JSON response: `twin-hubspot`, `twin-shopify`, `twin-resend`
  - Form-encoded request + JSON response: `twin-stripe`, `twin-twilio` (verified `r.ParseForm()` usage)
  - GraphQL: `twin-linear` (verified `POST /graphql` + `twinkit/graphql`)
- **Phase 4: Arazzo workflow generation** (community version of pro's pattern, full 1.0.1 example)
- **Phase 5: Starter scenarios** validating against `schemas/scenario.schema.json` (which I verified exists)
- **Phase 6: `wt up`/`test`/`conformance` mandatory local-dev loop** (verified subcommands present in `cmd/wt/main.go`)
- **Phase 7: Pre-push validation** per CLAUDE.md (`cmd/validate-schemas/`, twin tests, no regressions, build)
- **Phase 8: Gap audit for 100% coverage** per CLAUDE.md "Twin Coverage Policy"
- **Explicit tier boundary**: NO telemetry, NO quirks runtime engine, NO replay, NO run lifecycle, NO license verification (per §8 hard MIT/BSL wall)
- **Test-as-deliverable**: tools available + expected for development, contract optional (per founder direction; pro-only enforcement)

### `skills/twin-researcher.md` (§5.4 public)

Refactored from 569L to **704L** (the public skill has more methodology than I thought, after stripping operator-only content and adding `RESEARCH-STATUS.md` template with explicit gap-list-EV table per §6).

In scope:
- Discovery from SDKs, OpenAPI specs, public docs
- Behavior observation methods that respect ToS
- Quirk identification from documented edge cases (community-sense "behavioral quirks" — explicitly distinguished from the pro `quirks` runtime engine)
- Output artifact set (canonical-required subset; no market analysis)
- SPA Documentation Extraction Playbook (general technique, harness-agnostic framing)
- Engine-analysis as a mandatory section in `architecture-spec.md`; "new engine required" is a build blocker

Removed (operator-only, per §5.4):
- Phase 0.5 platform decomposition (operational concern)
- Confidence-score thresholds for build gate (the gate doc owns these now)
- "Integration with twin-opportunity-skill" section
- "Status / Skill Owner / Last Updated" meta sections
- Specific browser MCP tool names (replaced with harness-agnostic "headless browser" / "in-page evaluate" framing per §9)

### Public/private split verification (per §8)

```
$ grep -nE "telemetry|operator-skills|wondertwin-pro|market analysis|pricing|research-retriever|internal vendor pipeline" skills/community-twin-generator.md skills/twin-researcher.md
```

Output reviewed; the only matches are **explicit out-of-scope boundary statements** (community generator's "Tier boundary" section saying community has NO telemetry/replay/lifecycle; public researcher's "Audience and tier" section saying market analysis / vendor prioritization are out of scope for the community skill). These are required framing per §8, not pro-tier leakage.

### Harness independence (per §9)

```
$ grep -nE "TaskCreate|TaskUpdate|claude code|/skill-name|the Edit tool|Use the.*tool" skills/community-twin-generator.md skills/twin-researcher.md
```

Returns empty for both files. Skills describe work products and verification, not specific tool invocations.

### Multi-source drift verification

Phase 1 reading verified every API/path reference against actual code:

- All 10 community twins use `twincore.New(twincore.ParseFlags(...))` + `twin.Serve()` + `admin.NewHandler(memStore, twin.Middleware(), memStore.Clock)` — confirmed by reading `twin-{stripe,linear,posthog}/cmd/.../main.go`
- `cmd/wt/main.go` confirms subcommands `up`, `down`, `status`, `test`, `install`, `conformance`
- `schemas/scenario.schema.json` confirmed present
- `twinkit/` packages confirmed: admin, twincore, state, webhook, testutil, pagination, workspace, ledger, messaging, events, search, scheduler, graphql, grpc, soap, ws
- Reference twin contract shapes verified by `grep "ParseForm\|graphql\|POST.*graphql"` across all twins

No drift defects found at source during this session.

## Coordinated PR

Companion `wondertwin-docs` PR (linked when opened) covers:
- `skills/twin-researcher.md` (private overlay flavor)
- `skills/handoffs/research-to-build.md` (operationalized per §6)

Either PR can land first — they don't have a hard ordering dependency. The community generator's Phase 0 references the gate doc by path; that path was already valid, just less operational pre-this-session.

## Test plan

- [x] `community-twin-generator.md` length 803L within 600–900 budget
- [x] Cites `wondertwin/CLAUDE.md` as canonical (4 citations)
- [x] Cites reference twins by contract shape verified against actual code
- [x] Phases 4–8 (Arazzo, scenarios, wt loop, pre-push validation, gap audit) all present
- [x] Tier boundary explicit; zero pro-tier feature leakage
- [x] `twin-researcher.md` (public) trimmed to community contributor scope
- [x] `RESEARCH-STATUS.md` template includes gap-list-with-EV table
- [x] Harness independence: no Claude-Code-specific tool refs
- [x] Public/private split: zero forbidden-token leakage (modulo explicit boundary statements)
- [ ] Reviewer: pick one of the new phases (e.g., Phase 5 starter scenario) and verify the JSON template validates against `schemas/scenario.schema.json` semantically