### PR TITLE
feat(wt): replay show subcommand for the public artifact format

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -20,6 +20,7 @@
 //	wt registry remove <name>     Remove a named registry
 //	wt registry list              List configured registries
 //	wt conformance <binary>       Run conformance tests against a twin
+//	wt replay show <path>         Pretty-print a replay artifact (JSONL v1)
 //	wt login --org <slug>         Authenticate with WonderTwin platform
 //	wt catalog                    Browse the full twin catalog
 //	wt scan                       Detect project dependencies, match against catalog
@@ -139,6 +140,8 @@ func main() {
 		err = cmdCache(manifestPath, args)
 	case "conformance":
 		err = cmdConformance(args)
+	case "replay":
+		err = cmdReplay(args)
 	default:
 		fmt.Fprintf(os.Stderr, "wt: unknown command %q\n\n", cmd)
 		printUsage()
@@ -203,6 +206,7 @@ Commands:
   cache warm [twin...]       Fetch and cache content for manifest twins
   cache clear [twin...]      Remove cached content
   conformance <binary>       Run conformance tests against a twin binary
+  replay show <path>         Pretty-print a replay artifact (JSONL, format v1)
   version                    Print the wt version
 
 Options:

--- a/cmd/wt/replay.go
+++ b/cmd/wt/replay.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wondertwin-ai/wondertwin/internal/replay"
+)
+
+// cmdReplay dispatches `wt replay <subcommand>`. Currently only
+// `wt replay show <path>` is implemented; `wt replay diff` is flagged
+// as a future follow-up in WonderTwin-AI/wondertwin-pro#88.
+func cmdReplay(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: wt replay <show> <artifact-path>")
+	}
+	switch args[0] {
+	case "show":
+		return cmdReplayShow(args[1:])
+	case "diff":
+		return fmt.Errorf("wt replay diff: not yet implemented (tracked as a follow-up to WonderTwin-AI/wondertwin-pro#88)")
+	default:
+		return fmt.Errorf("wt replay: unknown subcommand %q (expected: show)", args[0])
+	}
+}
+
+func cmdReplayShow(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: wt replay show <artifact-path>")
+	}
+	path := args[0]
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	art, err := replay.Read(f)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	return replay.Show(os.Stdout, art)
+}

--- a/internal/replay/reader.go
+++ b/internal/replay/reader.go
@@ -1,0 +1,139 @@
+// Package replay reads the public-contract JSONL artifact format produced
+// by pro twins. The format spec is documented at
+// wondertwin-docs/product/replay/artifact-format.md; this package
+// implements the reader side independently of the producer (which lives
+// behind the MIT/BSL wall in wondertwin-pro/twinkit-pro/replay/) so the
+// community CLI stays MIT.
+package replay
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// FormatVersionSupported is the highest format_version this reader
+// understands. Producers shipping a higher version surface a clear
+// error so operators can pin tooling.
+const FormatVersionSupported = "1"
+
+// Manifest mirrors the producer's Manifest. Header lines populate
+// FormatVersion; trailer lines populate EntryCount/EndedAt.
+type Manifest struct {
+	FormatVersion string    `json:"format_version,omitempty"`
+	TwinName      string    `json:"twin_name,omitempty"`
+	TwinVersion   string    `json:"twin_version,omitempty"`
+	RunID         string    `json:"run_id,omitempty"`
+	StartedAt     time.Time `json:"started_at,omitempty"`
+	EndedAt       time.Time `json:"ended_at,omitempty"`
+	EntryCount    int       `json:"entry_count,omitempty"`
+	DroppedCount  int64     `json:"dropped_count,omitempty"`
+}
+
+// Entry mirrors the producer's Entry. The producer-side struct embeds
+// twincore.RequestLogEntry; on the wire the embedded fields are flat
+// (Method/Path/StatusCode/Duration/RequestID/Headers/Timestamp), so
+// this package declares them flat too. That keeps the community
+// reader free of any coupling to the producer's import graph while
+// still consuming the same wire format.
+type Entry struct {
+	Timestamp       time.Time         `json:"timestamp"`
+	Method          string            `json:"method"`
+	Path            string            `json:"path"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	StatusCode      int               `json:"status_code"`
+	Duration        time.Duration     `json:"duration_ms"` // ns on the wire; field tag is inherited drift
+	RequestID       string            `json:"request_id,omitempty"`
+	Seq             int64             `json:"seq"`
+	RunID           string            `json:"run_id,omitempty"`
+	RequestSummary  map[string]any    `json:"request_summary,omitempty"`
+	ResponseSummary map[string]any    `json:"response_summary,omitempty"`
+}
+
+// Artifact is the parsed result of one replay file.
+type Artifact struct {
+	Header  Manifest
+	Entries []Entry
+	Trailer Manifest
+}
+
+// ErrInvalidArtifact wraps every artifact-shape failure.
+var ErrInvalidArtifact = errors.New("invalid replay artifact")
+
+// ErrUnsupportedFormat is returned when format_version exceeds
+// FormatVersionSupported.
+var ErrUnsupportedFormat = errors.New("unsupported format_version")
+
+// Read parses a replay artifact from r. Enforces the public contract
+// documented at wondertwin-docs/product/replay/artifact-format.md:
+//
+//   - line 1 has format_version (header)
+//   - last line has entry_count or ended_at (trailer)
+//   - format_version == FormatVersionSupported
+//   - parsed entry-line count == trailer.entry_count
+func Read(r io.Reader) (Artifact, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64<<20) // 64 MiB max line — generous
+
+	var (
+		art      Artifact
+		gotHdr   bool
+		gotTrl   bool
+		lastLine int
+	)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		raw := append([]byte(nil), scanner.Bytes()...)
+		var m Manifest
+		if err := json.Unmarshal(raw, &m); err == nil && m.FormatVersion != "" {
+			if gotHdr {
+				return Artifact{}, fmt.Errorf("%w: extra header at line %d", ErrInvalidArtifact, lineNum)
+			}
+			art.Header = m
+			gotHdr = true
+			continue
+		}
+		// Try trailer (no format_version, has entry_count or ended_at).
+		var t Manifest
+		if err := json.Unmarshal(raw, &t); err == nil && (t.EntryCount > 0 || !t.EndedAt.IsZero()) && t.FormatVersion == "" {
+			art.Trailer = t
+			gotTrl = true
+			lastLine = lineNum
+			continue
+		}
+		if !gotHdr {
+			return Artifact{}, fmt.Errorf("%w: first line must be a manifest header", ErrInvalidArtifact)
+		}
+		if gotTrl {
+			return Artifact{}, fmt.Errorf("%w: entry at line %d after trailer", ErrInvalidArtifact, lineNum)
+		}
+		var e Entry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return Artifact{}, fmt.Errorf("%w: line %d not a valid entry: %v", ErrInvalidArtifact, lineNum, err)
+		}
+		art.Entries = append(art.Entries, e)
+	}
+	if err := scanner.Err(); err != nil {
+		return Artifact{}, fmt.Errorf("%w: scan: %v", ErrInvalidArtifact, err)
+	}
+	if !gotHdr {
+		return Artifact{}, fmt.Errorf("%w: missing manifest header", ErrInvalidArtifact)
+	}
+	if art.Header.FormatVersion != FormatVersionSupported {
+		return Artifact{}, fmt.Errorf("%w: artifact is format_version=%q, reader supports %q", ErrUnsupportedFormat, art.Header.FormatVersion, FormatVersionSupported)
+	}
+	if !gotTrl {
+		return Artifact{}, fmt.Errorf("%w: missing manifest trailer", ErrInvalidArtifact)
+	}
+	if lastLine != lineNum {
+		return Artifact{}, fmt.Errorf("%w: trailer is not the last line", ErrInvalidArtifact)
+	}
+	if art.Trailer.EntryCount != len(art.Entries) {
+		return Artifact{}, fmt.Errorf("%w: entry_count=%d but parsed %d entries", ErrInvalidArtifact, art.Trailer.EntryCount, len(art.Entries))
+	}
+	return art, nil
+}

--- a/internal/replay/reader_test.go
+++ b/internal/replay/reader_test.go
@@ -1,0 +1,82 @@
+package replay_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/internal/replay"
+)
+
+const validArtifact = `{"format_version":"1","twin_name":"stripe","twin_version":"0.5.0","run_id":"run-1","started_at":"2026-05-04T12:00:00Z"}
+{"timestamp":"2026-05-04T12:00:01Z","method":"POST","path":"/v1/charges","status_code":200,"duration_ms":12000000,"seq":1,"run_id":"run-1","request_summary":{"amount":"number"},"response_summary":{"id":"string"}}
+{"timestamp":"2026-05-04T12:00:01.5Z","method":"GET","path":"/v1/charges/{id}","status_code":200,"duration_ms":3000000,"seq":2,"run_id":"run-1"}
+{"ended_at":"2026-05-04T12:00:02Z","entry_count":2}
+`
+
+func TestReadValidArtifact(t *testing.T) {
+	a, err := replay.Read(strings.NewReader(validArtifact))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if a.Header.TwinName != "stripe" || a.Header.RunID != "run-1" {
+		t.Errorf("header = %+v", a.Header)
+	}
+	if len(a.Entries) != 2 {
+		t.Fatalf("entries=%d, want 2", len(a.Entries))
+	}
+	if a.Entries[0].Method != "POST" || a.Entries[1].Method != "GET" {
+		t.Errorf("entry methods: %s, %s", a.Entries[0].Method, a.Entries[1].Method)
+	}
+	if a.Trailer.EntryCount != 2 {
+		t.Errorf("trailer entry_count=%d, want 2", a.Trailer.EntryCount)
+	}
+}
+
+func TestReadRejectsCountMismatch(t *testing.T) {
+	bad := strings.Replace(validArtifact, `"entry_count":2`, `"entry_count":99`, 1)
+	if _, err := replay.Read(strings.NewReader(bad)); !errors.Is(err, replay.ErrInvalidArtifact) {
+		t.Errorf("err=%v, want ErrInvalidArtifact", err)
+	}
+}
+
+func TestReadRejectsUnsupportedVersion(t *testing.T) {
+	bad := strings.Replace(validArtifact, `"format_version":"1"`, `"format_version":"99"`, 1)
+	if _, err := replay.Read(strings.NewReader(bad)); !errors.Is(err, replay.ErrUnsupportedFormat) {
+		t.Errorf("err=%v, want ErrUnsupportedFormat", err)
+	}
+}
+
+func TestReadRejectsMissingHeader(t *testing.T) {
+	noHeader := `{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ms":1000000,"seq":1}` + "\n" +
+		`{"ended_at":"2026-05-04T12:00:02Z","entry_count":1}` + "\n"
+	if _, err := replay.Read(strings.NewReader(noHeader)); !errors.Is(err, replay.ErrInvalidArtifact) {
+		t.Errorf("err=%v, want ErrInvalidArtifact", err)
+	}
+}
+
+func TestReadRejectsMissingTrailer(t *testing.T) {
+	noTrailer := `{"format_version":"1","twin_name":"stripe","started_at":"2026-05-04T12:00:00Z"}` + "\n" +
+		`{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ms":1000000,"seq":1}` + "\n"
+	if _, err := replay.Read(strings.NewReader(noTrailer)); !errors.Is(err, replay.ErrInvalidArtifact) {
+		t.Errorf("err=%v, want ErrInvalidArtifact", err)
+	}
+}
+
+func TestShowIncludesEntriesAndManifest(t *testing.T) {
+	a, err := replay.Read(strings.NewReader(validArtifact))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := replay.Show(&buf, a); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"format_version=1", "stripe", "run-1", "POST", "/v1/charges", "GET", "/v1/charges/{id}", "12.0ms"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Show output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}

--- a/internal/replay/show.go
+++ b/internal/replay/show.go
@@ -1,0 +1,59 @@
+package replay
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// Show renders an Artifact in human-readable form. Output shape is
+// stable enough for shell scripting (header line, dashed separator,
+// one line per entry, trailer line) but is not a machine format —
+// `wt replay show --json <path>` (future) would be the right path for
+// programmatic consumers.
+func Show(w io.Writer, a Artifact) error {
+	h := a.Header
+	fmt.Fprintf(w, "replay artifact (format_version=%s)\n", h.FormatVersion)
+	fmt.Fprintf(w, "  twin:        %s", h.TwinName)
+	if h.TwinVersion != "" {
+		fmt.Fprintf(w, " (%s)", h.TwinVersion)
+	}
+	fmt.Fprintln(w)
+	if h.RunID != "" {
+		fmt.Fprintf(w, "  run_id:      %s\n", h.RunID)
+	}
+	fmt.Fprintf(w, "  started_at:  %s\n", h.StartedAt.Format(time.RFC3339))
+	if !a.Trailer.EndedAt.IsZero() {
+		fmt.Fprintf(w, "  ended_at:    %s\n", a.Trailer.EndedAt.Format(time.RFC3339))
+	}
+	fmt.Fprintf(w, "  entries:     %d\n", a.Trailer.EntryCount)
+	if a.Trailer.DroppedCount > 0 {
+		fmt.Fprintf(w, "  dropped:     %d (capacity pressure — see DefaultMaxEntries)\n", a.Trailer.DroppedCount)
+	}
+
+	fmt.Fprintln(w, strings.Repeat("─", 72))
+	fmt.Fprintf(w, "%-4s  %-8s  %-7s  %-30s  %s\n", "seq", "method", "status", "path", "duration")
+	fmt.Fprintln(w, strings.Repeat("─", 72))
+	for _, e := range a.Entries {
+		path := truncate(e.Path, 30)
+		// Duration is on the wire as the embedded twincore.RequestLogEntry's
+		// time.Duration (nanoseconds), tagged duration_ms. Render in ms.
+		ms := float64(e.Duration) / float64(time.Millisecond)
+		fmt.Fprintf(w, "%-4d  %-8s  %-7d  %-30s  %.1fms\n",
+			e.Seq, e.Method, e.StatusCode, path, ms,
+		)
+	}
+	fmt.Fprintln(w, strings.Repeat("─", 72))
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}


### PR DESCRIPTION
Slice 5 of WonderTwin-AI/wondertwin-pro#88. Community CLI side of the replay capability.

## What this PR adds

- \`wt replay show <artifact-path>\` — pretty-prints a v1 JSONL replay artifact.
- \`internal/replay/\` reader package — implements the public format spec independently of the producer at \`wondertwin-pro/twinkit-pro/replay/\`. The community CLI stays MIT; the format itself is the contract that crosses the wall.

The reader enforces the same shape rules documented at \`wondertwin-docs/product/replay/artifact-format.md\`:

- first line is a manifest header carrying \`format_version\`
- last line is a manifest trailer carrying \`entry_count\`/\`ended_at\`
- \`format_version\` matches \`FormatVersionSupported\` (currently \`\"1\"\`)
- parsed entry-line count equals \`trailer.entry_count\`
- rejects entries after trailer / extra headers / missing trailer

## Smoke output

\`\`\`
\$ wt replay show modern-treasury-run-1.jsonl
replay artifact (format_version=1)
  twin:        stripe (0.5.0)
  run_id:      run-1
  started_at:  2026-05-04T12:00:00Z
  ended_at:    2026-05-04T12:00:02Z
  entries:     2
────────────────────────────────────────────────────────────────────────
seq   method    status   path                            duration
────────────────────────────────────────────────────────────────────────
1     POST      200      /v1/charges                     12.0ms
2     GET       200      /v1/charges/{id}                3.0ms
────────────────────────────────────────────────────────────────────────
\`\`\`

## Deferred

\`wt replay diff <a> <b>\` is flagged as a future follow-up; calling it today prints a clear \"not yet implemented\" with a link to the issue.

## Test plan

- [x] Reader tests cover happy path + 4 invalid-shape cases
- [x] Show output asserted on key content
- [x] go build ./... clean
- [x] Smoke run against a hand-crafted artifact prints expected output