### PR TITLE
fix(twincore): rename RequestLogEntry.Duration json tag to duration_ns

### DIFF
--- a/twinkit/twincore/middleware.go
+++ b/twinkit/twincore/middleware.go
@@ -16,7 +16,7 @@ type RequestLogEntry struct {
 	Path       string            `json:"path"`
 	Headers    map[string]string `json:"headers,omitempty"`
 	StatusCode int               `json:"status_code"`
-	Duration   time.Duration     `json:"duration_ms"`
+	Duration   time.Duration     `json:"duration_ns"`
 	RequestID  string            `json:"request_id,omitempty"`
 }
 


### PR DESCRIPTION
Closes #240.

## What this PR does

One-line tag rename in \`twinkit/twincore/middleware.go\`: \`json:\"duration_ms\"\` → \`json:\"duration_ns\"\`. The \`Duration\` field type stays \`time.Duration\` (which marshals as nanoseconds) and the Go field name is unchanged, so Go callers are unaffected. Only the wire shape changes — and the wire shape is now honest about what it carries.

## Why

\`time.Duration\` JSON-marshals as nanoseconds, but the field was tagged \`duration_ms\`. Every consumer reading \`/admin/state\` request log entries or replay artifacts saw nanosecond values under a millisecond name (off by 10^6).

## Coordination

Part of the coordinated set tracked at #240:

- **this PR** — twincore tag rename (lands first)
- WonderTwin-AI/wondertwin-pro#104 — replay producer FormatVersion v1 → v2
- WonderTwin-AI/wondertwin-docs#23 — schema reference v1 → v2
- WonderTwin-AI/wondertwin-app#39 — ingestion reader v1 → v2; rejects v1
- #239 (\`wt replay show\`) — currently open with a v1-aware reader; needs a follow-up bump to v2 once this PR lands. Tracking that as a small follow-up rather than rebasing #239 on top of this; either order is fine since #239's reader was the only consumer of the old tag in this repo.

## Tests

\`go test ./twincore/... -count=1\` PASS in twinkit. No tests assert on the JSON tag itself in this repo (the \`twinkit/admin\` request-log tests assert on Method/Path).