### PR TITLE
fix(wt-replay): bump reader to format v2; reject v1 with #240 link

### DIFF
--- a/internal/replay/reader.go
+++ b/internal/replay/reader.go
@@ -18,7 +18,13 @@ import (
 // FormatVersionSupported is the highest format_version this reader
 // understands. Producers shipping a higher version surface a clear
 // error so operators can pin tooling.
-const FormatVersionSupported = "1"
+//
+// v2 (current) — duration tagged duration_ns (matches the marshalled
+// nanosecond value).
+// v1 — same wire shape but duration field was misnamed duration_ms
+// while still containing nanoseconds. v1 artifacts are rejected on
+// read; see WonderTwin-AI/wondertwin#240.
+const FormatVersionSupported = "2"
 
 // Manifest mirrors the producer's Manifest. Header lines populate
 // FormatVersion; trailer lines populate EntryCount/EndedAt.
@@ -45,7 +51,7 @@ type Entry struct {
 	Path            string            `json:"path"`
 	Headers         map[string]string `json:"headers,omitempty"`
 	StatusCode      int               `json:"status_code"`
-	Duration        time.Duration     `json:"duration_ms"` // ns on the wire; field tag is inherited drift
+	Duration        time.Duration     `json:"duration_ns"` // canonical twincore.RequestLogEntry shape (v2)
 	RequestID       string            `json:"request_id,omitempty"`
 	Seq             int64             `json:"seq"`
 	RunID           string            `json:"run_id,omitempty"`
@@ -124,6 +130,9 @@ func Read(r io.Reader) (Artifact, error) {
 		return Artifact{}, fmt.Errorf("%w: missing manifest header", ErrInvalidArtifact)
 	}
 	if art.Header.FormatVersion != FormatVersionSupported {
+		if art.Header.FormatVersion == "1" {
+			return Artifact{}, fmt.Errorf("%w: format_version=1 contained a duration_ms tag carrying nanosecond values (see WonderTwin-AI/wondertwin#240); regenerate the artifact with current twins", ErrUnsupportedFormat)
+		}
 		return Artifact{}, fmt.Errorf("%w: artifact is format_version=%q, reader supports %q", ErrUnsupportedFormat, art.Header.FormatVersion, FormatVersionSupported)
 	}
 	if !gotTrl {

--- a/internal/replay/reader_test.go
+++ b/internal/replay/reader_test.go
@@ -9,10 +9,18 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/replay"
 )
 
-const validArtifact = `{"format_version":"1","twin_name":"stripe","twin_version":"0.5.0","run_id":"run-1","started_at":"2026-05-04T12:00:00Z"}
-{"timestamp":"2026-05-04T12:00:01Z","method":"POST","path":"/v1/charges","status_code":200,"duration_ms":12000000,"seq":1,"run_id":"run-1","request_summary":{"amount":"number"},"response_summary":{"id":"string"}}
-{"timestamp":"2026-05-04T12:00:01.5Z","method":"GET","path":"/v1/charges/{id}","status_code":200,"duration_ms":3000000,"seq":2,"run_id":"run-1"}
+const validArtifact = `{"format_version":"2","twin_name":"stripe","twin_version":"0.5.0","run_id":"run-1","started_at":"2026-05-04T12:00:00Z"}
+{"timestamp":"2026-05-04T12:00:01Z","method":"POST","path":"/v1/charges","status_code":200,"duration_ns":12000000,"seq":1,"run_id":"run-1","request_summary":{"amount":"number"},"response_summary":{"id":"string"}}
+{"timestamp":"2026-05-04T12:00:01.5Z","method":"GET","path":"/v1/charges/{id}","status_code":200,"duration_ns":3000000,"seq":2,"run_id":"run-1"}
 {"ended_at":"2026-05-04T12:00:02Z","entry_count":2}
+`
+
+// v1Artifact is a sample of the deprecated format-v1 wire shape
+// (duration_ms tag carrying nanosecond values). The reader rejects
+// it with a v1-specific error message per WonderTwin-AI/wondertwin#240.
+const v1Artifact = `{"format_version":"1","twin_name":"stripe","started_at":"2026-05-04T12:00:00Z"}
+{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ms":1000000,"seq":1}
+{"ended_at":"2026-05-04T12:00:02Z","entry_count":1}
 `
 
 func TestReadValidArtifact(t *testing.T) {
@@ -42,14 +50,24 @@ func TestReadRejectsCountMismatch(t *testing.T) {
 }
 
 func TestReadRejectsUnsupportedVersion(t *testing.T) {
-	bad := strings.Replace(validArtifact, `"format_version":"1"`, `"format_version":"99"`, 1)
+	bad := strings.Replace(validArtifact, `"format_version":"2"`, `"format_version":"99"`, 1)
 	if _, err := replay.Read(strings.NewReader(bad)); !errors.Is(err, replay.ErrUnsupportedFormat) {
 		t.Errorf("err=%v, want ErrUnsupportedFormat", err)
 	}
 }
 
+func TestReadRejectsV1WithIssueLink(t *testing.T) {
+	_, err := replay.Read(strings.NewReader(v1Artifact))
+	if !errors.Is(err, replay.ErrUnsupportedFormat) {
+		t.Fatalf("err=%v, want ErrUnsupportedFormat", err)
+	}
+	if !strings.Contains(err.Error(), "#240") {
+		t.Errorf("v1 rejection should cite issue 240; got %v", err)
+	}
+}
+
 func TestReadRejectsMissingHeader(t *testing.T) {
-	noHeader := `{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ms":1000000,"seq":1}` + "\n" +
+	noHeader := `{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ns":1000000,"seq":1}` + "\n" +
 		`{"ended_at":"2026-05-04T12:00:02Z","entry_count":1}` + "\n"
 	if _, err := replay.Read(strings.NewReader(noHeader)); !errors.Is(err, replay.ErrInvalidArtifact) {
 		t.Errorf("err=%v, want ErrInvalidArtifact", err)
@@ -57,8 +75,8 @@ func TestReadRejectsMissingHeader(t *testing.T) {
 }
 
 func TestReadRejectsMissingTrailer(t *testing.T) {
-	noTrailer := `{"format_version":"1","twin_name":"stripe","started_at":"2026-05-04T12:00:00Z"}` + "\n" +
-		`{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ms":1000000,"seq":1}` + "\n"
+	noTrailer := `{"format_version":"2","twin_name":"stripe","started_at":"2026-05-04T12:00:00Z"}` + "\n" +
+		`{"timestamp":"2026-05-04T12:00:01Z","method":"GET","path":"/","status_code":200,"duration_ns":1000000,"seq":1}` + "\n"
 	if _, err := replay.Read(strings.NewReader(noTrailer)); !errors.Is(err, replay.ErrInvalidArtifact) {
 		t.Errorf("err=%v, want ErrInvalidArtifact", err)
 	}
@@ -74,7 +92,7 @@ func TestShowIncludesEntriesAndManifest(t *testing.T) {
 		t.Fatalf("Show: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"format_version=1", "stripe", "run-1", "POST", "/v1/charges", "GET", "/v1/charges/{id}", "12.0ms"} {
+	for _, want := range []string{"format_version=2", "stripe", "run-1", "POST", "/v1/charges", "GET", "/v1/charges/{id}", "12.0ms"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("Show output missing %q\nfull output:\n%s", want, out)
 		}


### PR DESCRIPTION
Follow-up flagged in #241 that didn't ship at the time. Surfaced again as part of the WonderTwin-AI/wondertwin-pro#91 session — the wt replay show subcommand is the community-side consumer of the artifact format and is a load-bearing part of the round-trip, so leaving it stale blocks any sanitizer end-to-end check.

## What this PR does

Bumps \`internal/replay/FormatVersionSupported\` from \`\"1\"\` to \`\"2\"\`, renames the \`Entry\` duration tag from \`duration_ms\` to \`duration_ns\` (matching the upstream rename in #241), and rejects v1 artifacts with an explicit error message citing #240.

## Why now

Format v2 is what producers (\`wondertwin-pro/twinkit-pro/replay\`) emit. The wt reader on main was still v1 — anyone running \`wt replay show\` against a current artifact was getting an unsupported-format error rather than a parsed artifact.

## Tests

- Fixture artifact bumped to v2 (\`duration_ns\`)
- New \`TestReadRejectsV1WithIssueLink\` asserts on the v1-specific error path
- Existing tests realigned to v2
- Local \`go test ./internal/replay/...\` PASS

## Cross-repo

Aligns the community CLI with the schema authoritatively documented at WonderTwin-AI/wondertwin-docs/product/replay/artifact-format.md.