### PR TITLE
chore: add vendor_domain to all twin manifests

### DIFF
--- a/docs/TWIN_TEMPLATE/twin-manifest.json
+++ b/docs/TWIN_TEMPLATE/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "your-service",
   "display_name": "Your Service",
+  "vendor_domain": "your-service.example",
   "category": "your-category",
   "description": "Simulates the Your Service API, covering the core resource operations.",
   "sdk_target": {

--- a/internal/registry/testdata/twin-manifest.json
+++ b/internal/registry/testdata/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "stripe",
   "display_name": "Stripe",
+  "vendor_domain": "stripe.com",
   "category": "payments",
   "description": "Stripe twin for contract testing",
   "sdk_target": {

--- a/schemas/twin-manifest.schema.json
+++ b/schemas/twin-manifest.schema.json
@@ -21,6 +21,11 @@
       "type": "string",
       "description": "Human-readable display name for the twin."
     },
+    "vendor_domain": {
+      "type": "string",
+      "description": "Canonical brand domain for the vendor (e.g., \"stripe.com\", \"linear.app\"). Used by downstream tooling for logo rendering and brand identity. Pick the canonical brand site, not the corporate parent.",
+      "pattern": "^[a-z0-9][a-z0-9.-]*\\.[a-z]{2,}$"
+    },
     "category": {
       "type": "string",
       "description": "Category of the service the twin emulates."

--- a/twin-github/twin-manifest.json
+++ b/twin-github/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "github",
   "display_name": "GitHub",
+  "vendor_domain": "github.com",
   "tier": "community",
   "category": "workspace",
   "description": "Simulates the GitHub REST API: repos, issues, PRs, reviews, checks, labels, milestones, contents, deployments, orgs, teams, reactions, search, webhooks, Actions, and Git data.",

--- a/twin-hubspot/twin-manifest.json
+++ b/twin-hubspot/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "hubspot",
   "display_name": "HubSpot",
+  "vendor_domain": "hubspot.com",
   "tier": "community",
   "category": "workspace",
   "description": "Simulates the HubSpot CRM v3 API: generic CRM objects (contacts, companies, deals, tickets, engagements), batch operations, search, associations v4, properties, pipelines, owners, lists, webhooks, forms, and OAuth.",

--- a/twin-linear/twin-manifest.json
+++ b/twin-linear/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "linear",
   "display_name": "Linear",
+  "vendor_domain": "linear.app",
   "tier": "community",
   "category": "workspace",
   "description": "Simulates the Linear GraphQL API: issues, teams, projects, cycles, workflow states, labels, comments, attachments, relations, documents, project updates, webhooks, reactions, notifications, and favorites.",

--- a/twin-logodev/twin-manifest.json
+++ b/twin-logodev/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "logodev",
   "display_name": "Logo.dev",
+  "vendor_domain": "logo.dev",
   "tier": "community",
   "category": "media",
   "description": "Simulates the full Logo.dev API surface: logo retrieval by domain/name/ticker/crypto/ISIN, brand search, and describe.",

--- a/twin-posthog/twin-manifest.json
+++ b/twin-posthog/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "posthog",
   "display_name": "PostHog",
+  "vendor_domain": "posthog.com",
   "tier": "community",
   "category": "analytics",
   "description": "Simulates the PostHog event capture, feature flag evaluation, identify, alias, group identify, exception tracking, and local evaluation API surfaces for the PostHog Go SDK.",

--- a/twin-resend/twin-manifest.json
+++ b/twin-resend/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "resend",
   "display_name": "Resend",
+  "vendor_domain": "resend.com",
   "tier": "community",
   "category": "email",
   "description": "Simulates the Resend email sending API, including single and batch email dispatch with delivery tracking.",

--- a/twin-shopify/twin-manifest.json
+++ b/twin-shopify/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "shopify",
   "display_name": "Shopify",
+  "vendor_domain": "shopify.com",
   "tier": "community",
   "category": "workspace",
   "description": "Simulates the Shopify Admin REST API: products, variants, images, orders, transactions, refunds, customers, addresses, inventory, fulfillments, collections, webhooks, metafields, themes, assets, pages, blogs, articles, price rules, discount codes, gift cards, draft orders, script tags, and redirects.",

--- a/twin-slack/twin-manifest.json
+++ b/twin-slack/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "slack",
   "display_name": "Slack",
+  "vendor_domain": "slack.com",
   "tier": "community",
   "category": "workspace",
   "description": "Simulates the Slack Web API including chat, conversations, users, reactions, pins, files, and more.",

--- a/twin-stripe/twin-manifest.json
+++ b/twin-stripe/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "stripe",
   "display_name": "Stripe",
+  "vendor_domain": "stripe.com",
   "tier": "community",
   "category": "payments",
   "description": "Simulates the Stripe API — Customers, Products, Prices, PaymentIntents, PaymentMethods, Charges, Refunds, Subscriptions, Invoices, Coupons, SetupIntents, TaxRates, Disputes, Connect accounts, transfers, balance, payouts, events, checkout sessions, payment links, credit notes, promotion codes, subscription items, quotes, billing portal sessions, tokens, sources, mandates, confirmation tokens, application fees, application fee refunds, transfer reversals, account links, persons, topups, webhook endpoints, files, file links, shipping rates, reviews, and tax IDs with webhook delivery.",

--- a/twin-twilio/twin-manifest.json
+++ b/twin-twilio/twin-manifest.json
@@ -1,6 +1,7 @@
 {
   "twin": "twilio",
   "display_name": "Twilio",
+  "vendor_domain": "twilio.com",
   "tier": "community",
   "category": "communications",
   "description": "Simulates the Twilio Messaging and Verify API surfaces, including SMS message send/retrieve and phone number verification workflows.",


### PR DESCRIPTION
## Summary

Adds `"vendor_domain"` to all 12 twin manifests in this repo, matching the canonical-brand-domain field added in wondertwin-pro#133.

Includes the `docs/TWIN_TEMPLATE` manifest so future twin authors fill in the field by default, and the `internal/registry/testdata` fixture for shape consistency.

## Domain values

Same canonical-brand-site choices as wondertwin-pro#133. All entries here overlap with that PR's set (stripe, linear, slack, posthog, github, twilio, resend, hubspot, shopify, logodev), plus:

- `your-service` (template) → `your-service.example` placeholder

## Test plan

- [x] All 12 manifests parse as JSON
- [x] `vendor_domain` present in every manifest
- [x] Companion: wondertwin-pro#133