### PR TITLE
add(twinkit): contract engine v0.1

### DIFF
--- a/twinkit/contract/engine.go
+++ b/twinkit/contract/engine.go
@@ -1,0 +1,459 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/state"
+)
+
+// Engine is the contract workflow engine. It owns the canonical state
+// machine, party model with routing-order semantics, and audit log.
+// Storage delegates to a per-twin StateStore; downstream effects compose
+// via Hooks.
+type Engine struct {
+	mu        sync.Mutex
+	store     StateStore
+	hooks     Hooks
+	clock     *state.Clock
+	idCounter int
+	idPrefix  string
+}
+
+// Option configures the Engine.
+type Option func(*Engine)
+
+// WithStore sets the per-twin StateStore.
+func WithStore(s StateStore) Option {
+	return func(e *Engine) { e.store = s }
+}
+
+// WithHooks sets the Hooks implementation. Defaults to NoOpHooks.
+func WithHooks(h Hooks) Option {
+	return func(e *Engine) { e.hooks = h }
+}
+
+// WithClock sets the clock used for all engine timestamps. Defaults to
+// a fresh state.Clock. Tests should pin the clock for determinism.
+func WithClock(c *state.Clock) Option {
+	return func(e *Engine) { e.clock = c }
+}
+
+// WithIDPrefix sets the prefix used for engine-generated contract IDs.
+// Default "ctr". Twins typically override per platform vocabulary
+// ("envelope" for DocuSign, "contract" for Measure).
+func WithIDPrefix(p string) Option {
+	return func(e *Engine) { e.idPrefix = p }
+}
+
+// NewEngine creates a contract engine with the given options.
+// A StateStore is required; NewEngine panics if one is not provided.
+func NewEngine(opts ...Option) *Engine {
+	e := &Engine{
+		hooks:    NoOpHooks{},
+		idPrefix: "ctr",
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	if e.clock == nil {
+		e.clock = state.NewClock()
+	}
+	if e.store == nil {
+		panic("contract.NewEngine: WithStore is required")
+	}
+	return e
+}
+
+// -- ID + audit helpers ---------------------------------------------------
+
+// nextID generates the next contract ID. Caller must hold e.mu.
+func (e *Engine) nextID() string {
+	e.idCounter++
+	return fmt.Sprintf("%s_%06d", e.idPrefix, e.idCounter)
+}
+
+// appendAudit appends an audit entry to the contract. Caller must own
+// the contract reference exclusively (engine holds e.mu).
+func (e *Engine) appendAudit(c *Contract, t AuditEventType, partyID string, from, to Status, msg string, extras map[string]any) {
+	seq := uint64(len(c.AuditLog) + 1)
+	c.AuditLog = append(c.AuditLog, AuditEntry{
+		Sequence:  seq,
+		At:        e.clock.Now(),
+		EventType: t,
+		PartyID:   partyID,
+		From:      from,
+		To:        to,
+		Message:   msg,
+		Extras:    extras,
+	})
+}
+
+// -- Lifecycle operations -------------------------------------------------
+
+// Create drafts a new contract. The input parties are validated
+// (routing-order, witness pairing, role rules) and the engine assigns
+// an ID + timestamps. Status is DRAFT on success.
+func (e *Engine) Create(ctx context.Context, in CreateInput) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if err := validateParties(in.Parties); err != nil {
+		return nil, err
+	}
+
+	now := e.clock.Now()
+	c := &Contract{
+		ID:        in.ID,
+		Status:    StatusDraft,
+		Parties:   cloneParties(in.Parties),
+		Documents: cloneDocuments(in.Documents),
+		Metadata:  cloneMetadata(in.Metadata),
+		AuditLog:  make([]AuditEntry, 0, 4),
+		CreatedAt: now,
+		UpdatedAt: now,
+		ExpiresAt: in.ExpiresAt,
+	}
+	if c.ID == "" {
+		c.ID = e.nextID()
+	}
+
+	e.appendAudit(c, AuditCreated, "", "", StatusDraft, "", nil)
+
+	if err := e.hooks.ValidateCreate(ctx, c); err != nil {
+		return nil, fmt.Errorf("validate create: %w", err)
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Update applies a Mutation to a DRAFT contract. Returns ErrInvalidStatus
+// if the contract is past DRAFT.
+func (e *Engine) Update(ctx context.Context, id string, mut Mutation) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	if c.Status != StatusDraft {
+		return nil, fmt.Errorf("%w: cannot update a %s contract", ErrInvalidStatus, c.Status)
+	}
+
+	if mut.Parties != nil {
+		if err := validateParties(*mut.Parties); err != nil {
+			return nil, err
+		}
+		c.Parties = cloneParties(*mut.Parties)
+	}
+	if mut.Documents != nil {
+		c.Documents = cloneDocuments(*mut.Documents)
+	}
+	if mut.Metadata != nil {
+		if c.Metadata == nil {
+			c.Metadata = make(map[string]any, len(mut.Metadata))
+		}
+		for k, v := range mut.Metadata {
+			c.Metadata[k] = v
+		}
+	}
+	if mut.ExpiresAt != nil {
+		c.ExpiresAt = *mut.ExpiresAt
+	}
+	c.UpdatedAt = e.clock.Now()
+	e.appendAudit(c, AuditUpdated, "", c.Status, c.Status, "", nil)
+
+	if err := e.hooks.ValidateMutation(ctx, c); err != nil {
+		return nil, fmt.Errorf("validate mutation: %w", err)
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Send transitions DRAFT → SENT. From this point, signatures may be
+// recorded against parties in the active routing-order group.
+func (e *Engine) Send(ctx context.Context, id string) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	if c.Status != StatusDraft {
+		return nil, fmt.Errorf("%w: cannot send a %s contract", ErrInvalidStatus, c.Status)
+	}
+
+	now := e.clock.Now()
+	c.SentAt = now
+	c.UpdatedAt = now
+	if err := e.transition(ctx, c, StatusSent, AuditSent, "", ""); err != nil {
+		return nil, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// SubmitForApproval is reserved for v0.2.
+func (e *Engine) SubmitForApproval(_ context.Context, _ string) (*Contract, error) {
+	return nil, ErrApprovalChainNotImplemented
+}
+
+// Approve is reserved for v0.2.
+func (e *Engine) Approve(_ context.Context, _, _ string, _ any, _ string) (*Contract, error) {
+	return nil, ErrApprovalChainNotImplemented
+}
+
+// RecordSignature records a signature for one party. Engine enforces:
+//   - contract is SENT or PARTIALLY_SIGNED
+//   - party exists, is a SIGNER (or paired WITNESS), and is in the
+//     active routing-order group
+//   - party hasn't already signed
+//
+// On the last required signature, the contract advances SIGNED → and
+// (if Hooks.OnExecuted returns nil) → EXECUTED.
+func (e *Engine) RecordSignature(ctx context.Context, id, partyID string, att Attestation) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	switch c.Status {
+	case StatusSent, StatusPartiallySigned:
+		// allowed
+	default:
+		return nil, fmt.Errorf("%w: cannot record signature on %s", ErrInvalidStatus, c.Status)
+	}
+
+	idx := findPartyIdx(c.Parties, partyID)
+	if idx < 0 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParty, partyID)
+	}
+	p := &c.Parties[idx]
+	if p.Role != RoleSigner && !(p.Role == RoleWitness && p.PairedWith != nil) {
+		return nil, fmt.Errorf("%w: role %s cannot sign", ErrInvalidParty, p.Role)
+	}
+	if !p.SignedAt.IsZero() {
+		return nil, ErrAlreadySigned
+	}
+	if !partyInActiveSet(c.Parties, p) {
+		return nil, ErrPartyNotInActiveSet
+	}
+
+	now := e.clock.Now()
+	att.PartyID = partyID
+	if att.Timestamp.IsZero() {
+		att.Timestamp = now
+	}
+	p.SignedAt = att.Timestamp
+	p.Attestation = &att
+	c.UpdatedAt = now
+	e.appendAudit(c, AuditSignatureRecorded, partyID, c.Status, c.Status, "", nil)
+
+	if err := e.hooks.OnSignatureRecorded(ctx, c, p); err != nil {
+		// Non-fatal: recorded but hook failed. Persist the signature.
+		_ = e.store.Save(c)
+		return nil, fmt.Errorf("hook OnSignatureRecorded: %w", err)
+	}
+
+	// State transitions driven by remaining required signatures.
+	if !allRequiredSigned(c.Parties) {
+		// Move to PARTIALLY_SIGNED on first signature if still SENT.
+		if c.Status == StatusSent {
+			if err := e.transition(ctx, c, StatusPartiallySigned, AuditPartiallySigned, partyID, ""); err != nil {
+				return nil, err
+			}
+		}
+		if err := e.store.Save(c); err != nil {
+			return nil, fmt.Errorf("save: %w", err)
+		}
+		return c, nil
+	}
+
+	// All required parties signed → SIGNED, then attempt EXECUTED.
+	if err := e.transition(ctx, c, StatusSigned, AuditSigned, partyID, ""); err != nil {
+		return nil, err
+	}
+	if err := e.tryExecute(ctx, c); err != nil {
+		// Persist SIGNED state; surface the error.
+		if saveErr := e.store.Save(c); saveErr != nil {
+			return nil, fmt.Errorf("save after execute failure: %w (original: %v)", saveErr, err)
+		}
+		return c, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Execute is normally fired automatically by RecordSignature when all
+// required parties have signed. Exposed for manual recovery from a
+// SIGNED-but-not-EXECUTED state (e.g., OnExecuted previously errored).
+func (e *Engine) Execute(ctx context.Context, id string) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	if c.Status != StatusSigned {
+		return nil, fmt.Errorf("%w: cannot execute a %s contract", ErrInvalidStatus, c.Status)
+	}
+	if err := e.tryExecute(ctx, c); err != nil {
+		return nil, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Decline records a party's refusal and transitions the contract to
+// DECLINED. The party must be a SIGNER (or paired WITNESS).
+func (e *Engine) Decline(ctx context.Context, id, partyID, reason string) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	switch c.Status {
+	case StatusSent, StatusPartiallySigned:
+	default:
+		return nil, fmt.Errorf("%w: cannot decline a %s contract", ErrInvalidStatus, c.Status)
+	}
+
+	idx := findPartyIdx(c.Parties, partyID)
+	if idx < 0 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParty, partyID)
+	}
+	p := c.Parties[idx]
+	if p.Role != RoleSigner && !(p.Role == RoleWitness && p.PairedWith != nil) {
+		return nil, fmt.Errorf("%w: role %s cannot decline", ErrInvalidParty, p.Role)
+	}
+
+	c.UpdatedAt = e.clock.Now()
+	if err := e.transition(ctx, c, StatusDeclined, AuditDeclined, partyID, reason); err != nil {
+		return nil, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Void cancels a non-terminal contract.
+func (e *Engine) Void(ctx context.Context, id, reason string) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	if isTerminal(c.Status) {
+		return nil, fmt.Errorf("%w: cannot void a %s contract", ErrInvalidStatus, c.Status)
+	}
+
+	now := e.clock.Now()
+	c.VoidedAt = now
+	c.UpdatedAt = now
+	if err := e.transition(ctx, c, StatusVoided, AuditVoided, "", reason); err != nil {
+		return nil, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Expire transitions a non-terminal contract to EXPIRED. Typically
+// invoked by a scheduler watching Contract.ExpiresAt; the engine does
+// not own that timer.
+func (e *Engine) Expire(ctx context.Context, id string) (*Contract, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	c, err := e.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	if isTerminal(c.Status) {
+		return nil, fmt.Errorf("%w: cannot expire a %s contract", ErrInvalidStatus, c.Status)
+	}
+	c.UpdatedAt = e.clock.Now()
+	if err := e.transition(ctx, c, StatusExpired, AuditExpired, "", ""); err != nil {
+		return nil, err
+	}
+	if err := e.store.Save(c); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+	return c, nil
+}
+
+// Get returns a snapshot of the contract by ID.
+func (e *Engine) Get(_ context.Context, id string) (*Contract, error) {
+	return e.store.Load(id)
+}
+
+// List returns all contracts in insertion order.
+func (e *Engine) List(_ context.Context) ([]*Contract, error) {
+	return e.store.List()
+}
+
+// -- internal -------------------------------------------------------------
+
+// transition records a state change and invokes OnStateTransition. The
+// caller updates timestamps before this is called. Audit entry is
+// emitted; hook errors are non-fatal but surfaced.
+func (e *Engine) transition(ctx context.Context, c *Contract, to Status, evt AuditEventType, partyID, msg string) error {
+	from := c.Status
+	c.Status = to
+	e.appendAudit(c, evt, partyID, from, to, msg, nil)
+	if err := e.hooks.OnStateTransition(ctx, c, from, to); err != nil {
+		return fmt.Errorf("hook OnStateTransition %s→%s: %w", from, to, err)
+	}
+	return nil
+}
+
+// tryExecute attempts to advance a SIGNED contract to EXECUTED via
+// Hooks.OnExecuted. If the hook errors, contract stays at SIGNED and
+// the error bubbles up.
+func (e *Engine) tryExecute(ctx context.Context, c *Contract) error {
+	if c.Status != StatusSigned {
+		return fmt.Errorf("%w: tryExecute from %s", ErrInvalidStatus, c.Status)
+	}
+	if err := e.hooks.OnExecuted(ctx, c); err != nil {
+		return fmt.Errorf("hook OnExecuted: %w", err)
+	}
+	now := e.clock.Now()
+	c.ExecutedAt = now
+	c.UpdatedAt = now
+	return e.transition(ctx, c, StatusExecuted, AuditExecuted, "", "")
+}
+
+func isTerminal(s Status) bool {
+	switch s {
+	case StatusExecuted, StatusDeclined, StatusVoided, StatusExpired:
+		return true
+	}
+	return false
+}
+
+// Now exposes the engine's clock for twins that want to share the same
+// time source for their non-engine timestamps.
+func (e *Engine) Now() time.Time { return e.clock.Now() }

--- a/twinkit/contract/engine_test.go
+++ b/twinkit/contract/engine_test.go
@@ -1,0 +1,506 @@
+package contract
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/twinkit/state"
+)
+
+// -- helpers --------------------------------------------------------------
+
+func newTestEngine(t *testing.T) (*Engine, *MemoryStore, *state.Clock) {
+	t.Helper()
+	clk := state.NewClock()
+	clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	store := NewMemoryStore()
+	eng := NewEngine(WithStore(store), WithClock(clk))
+	return eng, store, clk
+}
+
+func ptr(s string) *string { return &s }
+
+func twoSignerInput() CreateInput {
+	return CreateInput{
+		Parties: []Party{
+			{ID: "p1", Role: RoleSigner, RoutingOrder: 0, Required: true, Contact: "alice@example.com"},
+			{ID: "p2", Role: RoleSigner, RoutingOrder: 1, Required: true, Contact: "bob@example.com"},
+		},
+	}
+}
+
+// -- create / update ------------------------------------------------------
+
+func TestCreate_AssignsIDAndAuditEntry(t *testing.T) {
+	eng, _, clk := newTestEngine(t)
+	c, err := eng.Create(context.Background(), twoSignerInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if c.ID != "ctr_000001" {
+		t.Errorf("ID = %q, want ctr_000001", c.ID)
+	}
+	if c.Status != StatusDraft {
+		t.Errorf("status = %s, want DRAFT", c.Status)
+	}
+	if got, want := c.CreatedAt, clk.Now(); !got.Equal(want) {
+		t.Errorf("CreatedAt = %v, want %v", got, want)
+	}
+	if len(c.AuditLog) != 1 {
+		t.Fatalf("audit log len = %d, want 1", len(c.AuditLog))
+	}
+	if c.AuditLog[0].EventType != AuditCreated {
+		t.Errorf("audit[0].EventType = %s, want %s", c.AuditLog[0].EventType, AuditCreated)
+	}
+	if c.AuditLog[0].Sequence != 1 {
+		t.Errorf("audit[0].Sequence = %d, want 1", c.AuditLog[0].Sequence)
+	}
+}
+
+func TestCreate_RespectsExplicitID(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	in := twoSignerInput()
+	in.ID = "custom-id"
+	c, err := eng.Create(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if c.ID != "custom-id" {
+		t.Errorf("ID = %q, want custom-id", c.ID)
+	}
+}
+
+func TestCreate_RejectsNoSigner(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	_, err := eng.Create(context.Background(), CreateInput{
+		Parties: []Party{{ID: "p1", Role: RoleCC, RoutingOrder: 0}},
+	})
+	if !errors.Is(err, ErrInvalidParty) {
+		t.Fatalf("err = %v, want ErrInvalidParty", err)
+	}
+}
+
+func TestCreate_RejectsDuplicatePartyID(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	_, err := eng.Create(context.Background(), CreateInput{
+		Parties: []Party{
+			{ID: "p1", Role: RoleSigner, Required: true},
+			{ID: "p1", Role: RoleSigner, Required: true},
+		},
+	})
+	if !errors.Is(err, ErrInvalidParty) {
+		t.Fatalf("err = %v, want ErrInvalidParty", err)
+	}
+}
+
+func TestUpdate_OnlyDraft(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	if _, err := eng.Send(context.Background(), c.ID); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	_, err := eng.Update(context.Background(), c.ID, Mutation{})
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("Update on SENT err = %v, want ErrInvalidStatus", err)
+	}
+}
+
+// -- send / signature / execute --------------------------------------------
+
+func TestHappyPath_SequentialSigners(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, err := eng.Create(context.Background(), twoSignerInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := eng.Send(context.Background(), c.ID); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// p2 cannot sign first (routing-order 1 not yet active)
+	_, err = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{AuthMethod: "email_link"})
+	if !errors.Is(err, ErrPartyNotInActiveSet) {
+		t.Fatalf("p2 first-sign err = %v, want ErrPartyNotInActiveSet", err)
+	}
+
+	// p1 signs → PARTIALLY_SIGNED
+	c, err = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{AuthMethod: "email_link"})
+	if err != nil {
+		t.Fatalf("p1 sign: %v", err)
+	}
+	if c.Status != StatusPartiallySigned {
+		t.Errorf("after p1 status = %s, want PARTIALLY_SIGNED", c.Status)
+	}
+
+	// p2 signs → SIGNED → EXECUTED
+	c, err = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{AuthMethod: "sso"})
+	if err != nil {
+		t.Fatalf("p2 sign: %v", err)
+	}
+	if c.Status != StatusExecuted {
+		t.Errorf("final status = %s, want EXECUTED", c.Status)
+	}
+	if c.ExecutedAt.IsZero() {
+		t.Error("ExecutedAt is zero")
+	}
+}
+
+func TestParallelSigners_BothMustSign(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), CreateInput{
+		Parties: []Party{
+			{ID: "p1", Role: RoleSigner, RoutingOrder: 0, Required: true},
+			{ID: "p2", Role: RoleSigner, RoutingOrder: 0, Required: true},
+		},
+	})
+	_, _ = eng.Send(context.Background(), c.ID)
+
+	// Either order is fine — both at order 0
+	if _, err := eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{}); err != nil {
+		t.Fatalf("p2 sign: %v", err)
+	}
+	c, err := eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	if err != nil {
+		t.Fatalf("p1 sign: %v", err)
+	}
+	if c.Status != StatusExecuted {
+		t.Errorf("status = %s, want EXECUTED", c.Status)
+	}
+}
+
+func TestRecordSignature_AlreadySigned(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	_, _ = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	_, err := eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	if !errors.Is(err, ErrAlreadySigned) {
+		t.Fatalf("err = %v, want ErrAlreadySigned", err)
+	}
+}
+
+func TestRecordSignature_CCCannotSign(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), CreateInput{
+		Parties: []Party{
+			{ID: "p1", Role: RoleSigner, Required: true},
+			{ID: "cc1", Role: RoleCC},
+		},
+	})
+	_, _ = eng.Send(context.Background(), c.ID)
+	_, err := eng.RecordSignature(context.Background(), c.ID, "cc1", Attestation{})
+	if !errors.Is(err, ErrInvalidParty) {
+		t.Fatalf("err = %v, want ErrInvalidParty", err)
+	}
+}
+
+// -- witness pairing ------------------------------------------------------
+
+func TestWitness_PairedRequiredToExecute(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, err := eng.Create(context.Background(), CreateInput{
+		Parties: []Party{
+			{ID: "signer", Role: RoleSigner, RoutingOrder: 0, Required: true},
+			{ID: "witness", Role: RoleWitness, RoutingOrder: 0, PairedWith: ptr("signer")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, _ = eng.Send(context.Background(), c.ID)
+
+	// Signing only the signer is not enough.
+	c, err = eng.RecordSignature(context.Background(), c.ID, "signer", Attestation{})
+	if err != nil {
+		t.Fatalf("signer sign: %v", err)
+	}
+	if c.Status != StatusPartiallySigned {
+		t.Errorf("after signer status = %s, want PARTIALLY_SIGNED", c.Status)
+	}
+
+	// Witness signs in same routing slot → EXECUTED.
+	c, err = eng.RecordSignature(context.Background(), c.ID, "witness", Attestation{})
+	if err != nil {
+		t.Fatalf("witness sign: %v", err)
+	}
+	if c.Status != StatusExecuted {
+		t.Errorf("after witness status = %s, want EXECUTED", c.Status)
+	}
+}
+
+func TestWitness_PairingValidation(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	tests := []struct {
+		name    string
+		parties []Party
+	}{
+		{
+			name: "paired with unknown party",
+			parties: []Party{
+				{ID: "s", Role: RoleSigner, Required: true},
+				{ID: "w", Role: RoleWitness, PairedWith: ptr("nope")},
+			},
+		},
+		{
+			name: "paired with non-signer",
+			parties: []Party{
+				{ID: "s", Role: RoleSigner, Required: true},
+				{ID: "cc", Role: RoleCC},
+				{ID: "w", Role: RoleWitness, PairedWith: ptr("cc")},
+			},
+		},
+		{
+			name: "routing-order mismatch",
+			parties: []Party{
+				{ID: "s", Role: RoleSigner, RoutingOrder: 0, Required: true},
+				{ID: "w", Role: RoleWitness, RoutingOrder: 1, PairedWith: ptr("s")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := eng.Create(context.Background(), CreateInput{Parties: tt.parties})
+			if !errors.Is(err, ErrWitnessPairing) {
+				t.Fatalf("err = %v, want ErrWitnessPairing", err)
+			}
+		})
+	}
+}
+
+// -- decline / void / expire ----------------------------------------------
+
+func TestDecline(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	c, err := eng.Decline(context.Background(), c.ID, "p1", "no thanks")
+	if err != nil {
+		t.Fatalf("Decline: %v", err)
+	}
+	if c.Status != StatusDeclined {
+		t.Errorf("status = %s, want DECLINED", c.Status)
+	}
+	// Cannot record signature on DECLINED.
+	_, err = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{})
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("sign on DECLINED err = %v, want ErrInvalidStatus", err)
+	}
+}
+
+func TestVoid(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	c, err := eng.Void(context.Background(), c.ID, "rescinded")
+	if err != nil {
+		t.Fatalf("Void: %v", err)
+	}
+	if c.Status != StatusVoided {
+		t.Errorf("status = %s, want VOIDED", c.Status)
+	}
+	_, err = eng.Void(context.Background(), c.ID, "again")
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("re-void err = %v, want ErrInvalidStatus", err)
+	}
+}
+
+func TestExpire(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	c, err := eng.Expire(context.Background(), c.ID)
+	if err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+	if c.Status != StatusExpired {
+		t.Errorf("status = %s, want EXPIRED", c.Status)
+	}
+}
+
+// -- approval chain reserved ----------------------------------------------
+
+func TestApprovalChain_NotImplementedV01(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, err := eng.SubmitForApproval(context.Background(), c.ID)
+	if !errors.Is(err, ErrApprovalChainNotImplemented) {
+		t.Errorf("SubmitForApproval err = %v, want ErrApprovalChainNotImplemented", err)
+	}
+	_, err = eng.Approve(context.Background(), c.ID, "approver", nil, "")
+	if !errors.Is(err, ErrApprovalChainNotImplemented) {
+		t.Errorf("Approve err = %v, want ErrApprovalChainNotImplemented", err)
+	}
+}
+
+// -- hooks ----------------------------------------------------------------
+
+type recordingHooks struct {
+	NoOpHooks
+	executed       int
+	sigRecorded    int
+	transitions    []string // "FROM->TO"
+	executeErr     error
+	validateErr    error
+}
+
+func (r *recordingHooks) ValidateCreate(_ context.Context, _ *Contract) error {
+	return r.validateErr
+}
+func (r *recordingHooks) OnExecuted(_ context.Context, _ *Contract) error {
+	r.executed++
+	return r.executeErr
+}
+func (r *recordingHooks) OnSignatureRecorded(_ context.Context, _ *Contract, _ *Party) error {
+	r.sigRecorded++
+	return nil
+}
+func (r *recordingHooks) OnStateTransition(_ context.Context, _ *Contract, from, to Status) error {
+	r.transitions = append(r.transitions, string(from)+"->"+string(to))
+	return nil
+}
+
+func TestHooks_OnExecutedFires(t *testing.T) {
+	clk := state.NewClock()
+	clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	h := &recordingHooks{}
+	eng := NewEngine(WithStore(NewMemoryStore()), WithClock(clk), WithHooks(h))
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	_, _ = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	_, _ = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{})
+	if h.executed != 1 {
+		t.Errorf("OnExecuted called %d times, want 1", h.executed)
+	}
+	if h.sigRecorded != 2 {
+		t.Errorf("OnSignatureRecorded called %d times, want 2", h.sigRecorded)
+	}
+	wantTransitions := []string{"DRAFT->SENT", "SENT->PARTIALLY_SIGNED", "PARTIALLY_SIGNED->SIGNED", "SIGNED->EXECUTED"}
+	if got := h.transitions; !equalStrings(got, wantTransitions) {
+		t.Errorf("transitions = %v, want %v", got, wantTransitions)
+	}
+}
+
+func TestHooks_OnExecutedErrorHaltsAtSigned(t *testing.T) {
+	clk := state.NewClock()
+	clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	h := &recordingHooks{executeErr: errors.New("downstream failed")}
+	store := NewMemoryStore()
+	eng := NewEngine(WithStore(store), WithClock(clk), WithHooks(h))
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	_, _ = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	_, err := eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{})
+	if err == nil {
+		t.Fatal("expected error from OnExecuted")
+	}
+	got, _ := store.Load(c.ID)
+	if got.Status != StatusSigned {
+		t.Errorf("status after hook error = %s, want SIGNED", got.Status)
+	}
+	// Manual recovery: clear the hook error and call Execute.
+	h.executeErr = nil
+	got2, err := eng.Execute(context.Background(), c.ID)
+	if err != nil {
+		t.Fatalf("recovery Execute: %v", err)
+	}
+	if got2.Status != StatusExecuted {
+		t.Errorf("status after recovery = %s, want EXECUTED", got2.Status)
+	}
+}
+
+func TestHooks_ValidateCreateBlocksPersist(t *testing.T) {
+	clk := state.NewClock()
+	clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	h := &recordingHooks{validateErr: errors.New("nope")}
+	store := NewMemoryStore()
+	eng := NewEngine(WithStore(store), WithClock(clk), WithHooks(h))
+	_, err := eng.Create(context.Background(), twoSignerInput())
+	if err == nil {
+		t.Fatal("expected validate error")
+	}
+	all, _ := store.List()
+	if len(all) != 0 {
+		t.Errorf("store has %d contracts, want 0 (validate should block persist)", len(all))
+	}
+}
+
+// -- audit log ------------------------------------------------------------
+
+func TestAuditLog_MonotonicSequence(t *testing.T) {
+	eng, _, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	_, _ = eng.Send(context.Background(), c.ID)
+	_, _ = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{})
+	c, _ = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{})
+	for i, e := range c.AuditLog {
+		if e.Sequence != uint64(i+1) {
+			t.Errorf("audit[%d].Sequence = %d, want %d", i, e.Sequence, i+1)
+		}
+	}
+	// Spot-check: last entry should be EXECUTED.
+	last := c.AuditLog[len(c.AuditLog)-1]
+	if last.EventType != AuditExecuted {
+		t.Errorf("last audit event = %s, want %s", last.EventType, AuditExecuted)
+	}
+}
+
+// -- determinism ----------------------------------------------------------
+
+func TestDeterminism_SameInputsSameOutputs(t *testing.T) {
+	run := func() *Contract {
+		clk := state.NewClock()
+		clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+		eng := NewEngine(WithStore(NewMemoryStore()), WithClock(clk))
+		c, _ := eng.Create(context.Background(), twoSignerInput())
+		_, _ = eng.Send(context.Background(), c.ID)
+		_, _ = eng.RecordSignature(context.Background(), c.ID, "p1", Attestation{AuthMethod: "email_link"})
+		c, _ = eng.RecordSignature(context.Background(), c.ID, "p2", Attestation{AuthMethod: "sso"})
+		return c
+	}
+	a, b := run(), run()
+	if a.ID != b.ID {
+		t.Errorf("ID differs: %q vs %q", a.ID, b.ID)
+	}
+	if !a.ExecutedAt.Equal(b.ExecutedAt) {
+		t.Errorf("ExecutedAt differs: %v vs %v", a.ExecutedAt, b.ExecutedAt)
+	}
+	if len(a.AuditLog) != len(b.AuditLog) {
+		t.Fatalf("audit log lengths differ: %d vs %d", len(a.AuditLog), len(b.AuditLog))
+	}
+	for i := range a.AuditLog {
+		if a.AuditLog[i].EventType != b.AuditLog[i].EventType {
+			t.Errorf("audit[%d].EventType differs: %s vs %s", i, a.AuditLog[i].EventType, b.AuditLog[i].EventType)
+		}
+		if !a.AuditLog[i].At.Equal(b.AuditLog[i].At) {
+			t.Errorf("audit[%d].At differs: %v vs %v", i, a.AuditLog[i].At, b.AuditLog[i].At)
+		}
+	}
+}
+
+// -- state-store isolation ------------------------------------------------
+
+func TestStore_LoadReturnsCopy(t *testing.T) {
+	eng, store, _ := newTestEngine(t)
+	c, _ := eng.Create(context.Background(), twoSignerInput())
+	got, _ := store.Load(c.ID)
+	got.Status = StatusVoided // mutate copy
+	got2, _ := store.Load(c.ID)
+	if got2.Status != StatusDraft {
+		t.Errorf("store leaked mutation: status = %s, want DRAFT", got2.Status)
+	}
+}
+
+// -- util -----------------------------------------------------------------
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/twinkit/contract/errors.go
+++ b/twinkit/contract/errors.go
@@ -1,0 +1,36 @@
+package contract
+
+import "errors"
+
+var (
+	// ErrContractNotFound is returned by StateStore.Load when no contract
+	// with the given ID exists.
+	ErrContractNotFound = errors.New("contract: not found")
+
+	// ErrInvalidStatus is returned when an operation is attempted from a
+	// status that doesn't permit it (e.g., RecordSignature on a DRAFT).
+	ErrInvalidStatus = errors.New("contract: invalid status for operation")
+
+	// ErrInvalidParty is returned when a party reference doesn't match
+	// any party on the contract, or when a party's role doesn't permit
+	// the action (e.g., RecordSignature on a CC).
+	ErrInvalidParty = errors.New("contract: invalid party")
+
+	// ErrPartyNotInActiveSet is returned when RecordSignature targets a
+	// party whose RoutingOrder hasn't been reached yet.
+	ErrPartyNotInActiveSet = errors.New("contract: party not in active routing-order set")
+
+	// ErrAlreadySigned is returned when RecordSignature targets a party
+	// that already has a signature recorded.
+	ErrAlreadySigned = errors.New("contract: party already signed")
+
+	// ErrWitnessPairing is returned when a WITNESS party's PairedWith
+	// references a non-existent party, a non-SIGNER, or has a
+	// RoutingOrder that doesn't match the paired signer.
+	ErrWitnessPairing = errors.New("contract: invalid witness pairing")
+
+	// ErrApprovalChainNotImplemented is returned by SubmitForApproval
+	// and Approve in v0.1. The approval-chain surface lands in v0.2 and
+	// will be shaped by the first CLM consumer.
+	ErrApprovalChainNotImplemented = errors.New("contract: approval chain is v0.2 (not yet implemented)")
+)

--- a/twinkit/contract/hooks.go
+++ b/twinkit/contract/hooks.go
@@ -1,0 +1,52 @@
+package contract
+
+import "context"
+
+// Hooks is the per-twin extension surface for the contract engine. The
+// engine invokes these at behavioral inflection points; implementations
+// must not call back into the engine (would deadlock).
+//
+// All methods receive a snapshot of the contract at the point of the
+// callback. Mutations to the snapshot are not persisted.
+type Hooks interface {
+	// ValidateCreate is called before a contract is persisted. Returning
+	// a non-nil error aborts the Create.
+	ValidateCreate(ctx context.Context, c *Contract) error
+
+	// ValidateMutation is called before an Update is persisted. The
+	// engine has already merged the mutation into the snapshot.
+	ValidateMutation(ctx context.Context, c *Contract) error
+
+	// OnStateTransition is called after a contract transitions state and
+	// is persisted. Errors are logged via the bridge but do not roll
+	// back the transition.
+	OnStateTransition(ctx context.Context, c *Contract, from, to Status) error
+
+	// OnSignatureRecorded is called after a signature is recorded.
+	// Errors are non-fatal.
+	OnSignatureRecorded(ctx context.Context, c *Contract, party *Party) error
+
+	// OnExecuted is called when a contract transitions SIGNED → EXECUTED.
+	// This is the post-execution observer hook — the canonical place to
+	// materialise downstream resources (Measure subscription/invoice,
+	// CPQ contract activation, etc.).
+	//
+	// Returning a non-nil error halts the transition: the contract stays
+	// at SIGNED and the error is surfaced to the caller of
+	// RecordSignature/Execute. The twin is responsible for retry/repair.
+	OnExecuted(ctx context.Context, c *Contract) error
+}
+
+// NoOpHooks is a default no-op implementation. Embed this in a twin's
+// hook implementation to override only the methods that matter.
+type NoOpHooks struct{}
+
+func (NoOpHooks) ValidateCreate(_ context.Context, _ *Contract) error  { return nil }
+func (NoOpHooks) ValidateMutation(_ context.Context, _ *Contract) error { return nil }
+func (NoOpHooks) OnStateTransition(_ context.Context, _ *Contract, _, _ Status) error {
+	return nil
+}
+func (NoOpHooks) OnSignatureRecorded(_ context.Context, _ *Contract, _ *Party) error {
+	return nil
+}
+func (NoOpHooks) OnExecuted(_ context.Context, _ *Contract) error { return nil }

--- a/twinkit/contract/interface.go
+++ b/twinkit/contract/interface.go
@@ -1,0 +1,164 @@
+// Package contract provides a contract-and-signature workflow engine for
+// twins that simulate platforms with multi-party agreement lifecycles —
+// e-signature (DocuSign-shape), CLM (Ironclad-shape), CPQ contracts, and
+// billing-platform contracts (Measure-shape).
+//
+// The engine owns the canonical state machine, party model with routing-
+// order semantics, witness counter-signatory pairing, and an append-only
+// audit log per contract. Document storage, webhook emission, and any
+// downstream materialisation (e.g. billing twins creating a subscription
+// when a contract executes) are delegated to the consuming twin via the
+// StateStore and Hooks interfaces.
+//
+// This is the v0.1 surface. The pre-signature approval chain
+// (PENDING_APPROVAL state, ApprovalStep, SubmitForApproval, Approve) is
+// reserved as design but returns ErrApprovalChainNotImplemented from the
+// engine until v0.2.
+package contract
+
+import "time"
+
+// Status is the canonical lifecycle state of a contract. Twins map
+// platform-specific vocabularies (DocuSign envelope status, Measure
+// contract status, etc.) onto this set via their EventMapper.
+type Status string
+
+const (
+	StatusDraft           Status = "DRAFT"
+	StatusPendingApproval Status = "PENDING_APPROVAL" // reserved for v0.2
+	StatusSent            Status = "SENT"
+	StatusPartiallySigned Status = "PARTIALLY_SIGNED"
+	StatusSigned          Status = "SIGNED"   // all required parties signed; pre-execution
+	StatusExecuted        Status = "EXECUTED" // terminal success
+	StatusDeclined        Status = "DECLINED"
+	StatusVoided          Status = "VOIDED"
+	StatusExpired         Status = "EXPIRED"
+)
+
+// RoleType is the canonical party role.
+type RoleType string
+
+const (
+	RoleSigner   RoleType = "SIGNER"
+	RoleApprover RoleType = "APPROVER" // observed in v0.1; ignored for state transitions until v0.2
+	RoleCC       RoleType = "CC"
+	RoleWitness  RoleType = "WITNESS"
+	RoleAgent    RoleType = "AGENT"
+	RoleEditor   RoleType = "EDITOR"
+)
+
+// DocumentRef is an opaque reference to a document attached to a
+// contract. The engine never reads or writes document bytes — twins wire
+// storage themselves via twinkit/workspace.
+type DocumentRef struct {
+	ID       string         `json:"id"`
+	Name     string         `json:"name,omitempty"`
+	Hash     string         `json:"hash,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Party is one signer/approver/observer attached to a contract.
+type Party struct {
+	ID           string         `json:"id"`
+	Role         RoleType       `json:"role"`
+	DisplayName  string         `json:"display_name,omitempty"`
+	Contact      string         `json:"contact,omitempty"` // email or platform-specific
+	RoutingOrder int            `json:"routing_order"`     // 0 = first; equal values = parallel
+	Required     bool           `json:"required"`
+	PairedWith   *string        `json:"paired_with,omitempty"` // WITNESS only: paired SIGNER's ID
+	SignedAt     time.Time      `json:"signed_at,omitempty"`
+	Attestation  *Attestation   `json:"attestation,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+}
+
+// Attestation captures the audit-relevant context of a single signature.
+// Engines record what's supplied; PKI cert generation is out of scope.
+type Attestation struct {
+	PartyID    string         `json:"party_id"`
+	Timestamp  time.Time      `json:"timestamp"`
+	AuthMethod string         `json:"auth_method,omitempty"` // e.g., "email_link", "sso", "in_person"
+	Source     string         `json:"source,omitempty"`      // IP, geo, or platform-specific
+	Hash       string         `json:"hash,omitempty"`        // optional document hash at signing time
+	Extras     map[string]any `json:"extras,omitempty"`      // PKI cert serial, BankID nonce, etc.
+}
+
+// AuditEventType enumerates the canonical audit-log entry kinds. The
+// engine emits these on every state-changing operation; twins translate
+// to platform-specific webhook event names via their EventMapper.
+type AuditEventType string
+
+const (
+	AuditCreated         AuditEventType = "CONTRACT_CREATED"
+	AuditUpdated         AuditEventType = "CONTRACT_UPDATED"
+	AuditSent            AuditEventType = "CONTRACT_SENT"
+	AuditSignatureRecorded AuditEventType = "SIGNATURE_RECORDED"
+	AuditPartiallySigned AuditEventType = "CONTRACT_PARTIALLY_SIGNED"
+	AuditSigned          AuditEventType = "CONTRACT_SIGNED"
+	AuditExecuted        AuditEventType = "CONTRACT_EXECUTED"
+	AuditDeclined        AuditEventType = "CONTRACT_DECLINED"
+	AuditVoided          AuditEventType = "CONTRACT_VOIDED"
+	AuditExpired         AuditEventType = "CONTRACT_EXPIRED"
+)
+
+// AuditEntry is one append-only entry in a contract's audit log.
+// Sequence is monotonic per contract starting at 1.
+type AuditEntry struct {
+	Sequence  uint64         `json:"sequence"`
+	At        time.Time      `json:"at"`
+	EventType AuditEventType `json:"event_type"`
+	PartyID   string         `json:"party_id,omitempty"`
+	From      Status         `json:"from,omitempty"`
+	To        Status         `json:"to,omitempty"`
+	Message   string         `json:"message,omitempty"`
+	Extras    map[string]any `json:"extras,omitempty"`
+}
+
+// Contract is the canonical contract record.
+type Contract struct {
+	ID         string         `json:"id"`
+	Status     Status         `json:"status"`
+	Parties    []Party        `json:"parties"` // in routing order
+	Documents  []DocumentRef  `json:"documents,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	AuditLog   []AuditEntry   `json:"audit_log"`
+	CreatedAt  time.Time      `json:"created_at"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	SentAt     time.Time      `json:"sent_at,omitempty"`
+	ExecutedAt time.Time      `json:"executed_at,omitempty"`
+	VoidedAt   time.Time      `json:"voided_at,omitempty"`
+	ExpiresAt  time.Time      `json:"expires_at,omitempty"`
+}
+
+// CreateInput is the input to Engine.Create.
+type CreateInput struct {
+	ID        string         // optional; engine generates if empty
+	Parties   []Party        // engine validates routing-order + witness pairing
+	Documents []DocumentRef
+	Metadata  map[string]any
+	ExpiresAt time.Time      // optional
+}
+
+// Mutation is a partial update to a draft contract via Engine.Update.
+// Nil fields are left unchanged.
+type Mutation struct {
+	Parties   *[]Party
+	Documents *[]DocumentRef
+	Metadata  map[string]any // merged shallowly
+	ExpiresAt *time.Time
+}
+
+// StateStore persists contracts. Implementations are typically the
+// twin's in-memory store. The engine holds a reference, never inspects
+// internals beyond these methods.
+type StateStore interface {
+	// Save persists a contract. Implementations must store a snapshot
+	// (deep copy) so subsequent engine mutations don't leak.
+	Save(c *Contract) error
+
+	// Load returns a snapshot of the contract by ID.
+	// Returns ErrContractNotFound if absent.
+	Load(id string) (*Contract, error)
+
+	// List returns all contracts, in insertion order.
+	List() ([]*Contract, error)
+}

--- a/twinkit/contract/memory_store.go
+++ b/twinkit/contract/memory_store.go
@@ -1,0 +1,82 @@
+package contract
+
+import "sync"
+
+// MemoryStore is a reference in-memory StateStore for tests and simple
+// twins. Stores deep copies on Save so external mutations don't leak
+// into engine state, and returns deep copies from Load.
+type MemoryStore struct {
+	mu        sync.RWMutex
+	contracts map[string]*Contract
+	order     []string
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{contracts: make(map[string]*Contract)}
+}
+
+// Save stores a deep copy of the contract.
+func (m *MemoryStore) Save(c *Contract) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.contracts[c.ID]; !exists {
+		m.order = append(m.order, c.ID)
+	}
+	m.contracts[c.ID] = cloneContract(c)
+	return nil
+}
+
+// Load returns a deep copy of the contract.
+func (m *MemoryStore) Load(id string) (*Contract, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	c, ok := m.contracts[id]
+	if !ok {
+		return nil, ErrContractNotFound
+	}
+	return cloneContract(c), nil
+}
+
+// List returns deep copies of all contracts in insertion order.
+func (m *MemoryStore) List() ([]*Contract, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*Contract, 0, len(m.order))
+	for _, id := range m.order {
+		out = append(out, cloneContract(m.contracts[id]))
+	}
+	return out, nil
+}
+
+// Reset clears all contracts.
+func (m *MemoryStore) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.contracts = make(map[string]*Contract)
+	m.order = nil
+}
+
+func cloneContract(c *Contract) *Contract {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	cp.Parties = cloneParties(c.Parties)
+	cp.Documents = cloneDocuments(c.Documents)
+	cp.Metadata = cloneMetadata(c.Metadata)
+	if c.AuditLog != nil {
+		cp.AuditLog = make([]AuditEntry, len(c.AuditLog))
+		for i, a := range c.AuditLog {
+			cp.AuditLog[i] = a
+			if a.Extras != nil {
+				m := make(map[string]any, len(a.Extras))
+				for k, v := range a.Extras {
+					m[k] = v
+				}
+				cp.AuditLog[i].Extras = m
+			}
+		}
+	}
+	return &cp
+}

--- a/twinkit/contract/parties.go
+++ b/twinkit/contract/parties.go
@@ -1,0 +1,184 @@
+package contract
+
+import "fmt"
+
+// validateParties enforces the v0.1 party model rules:
+//   - at least one SIGNER
+//   - WITNESS parties must have PairedWith referencing an existing
+//     SIGNER on the contract
+//   - WITNESS RoutingOrder must equal its paired signer's RoutingOrder
+//   - PairedWith on non-WITNESS roles is ignored (set to nil)
+//
+// APPROVER parties may appear; the engine ignores them for v0.1
+// transitions (reserved for v0.2).
+func validateParties(parties []Party) error {
+	if len(parties) == 0 {
+		return fmt.Errorf("%w: at least one party required", ErrInvalidParty)
+	}
+	hasSigner := false
+	idIndex := make(map[string]int, len(parties))
+	for i, p := range parties {
+		if p.ID == "" {
+			return fmt.Errorf("%w: party at index %d has empty ID", ErrInvalidParty, i)
+		}
+		if _, dup := idIndex[p.ID]; dup {
+			return fmt.Errorf("%w: duplicate party ID %s", ErrInvalidParty, p.ID)
+		}
+		idIndex[p.ID] = i
+		if p.Role == RoleSigner {
+			hasSigner = true
+		}
+	}
+	if !hasSigner {
+		return fmt.Errorf("%w: at least one SIGNER required", ErrInvalidParty)
+	}
+	// Witness pairing.
+	for _, p := range parties {
+		if p.Role != RoleWitness {
+			continue
+		}
+		if p.PairedWith == nil {
+			// Unpaired witness is observer-only — allowed.
+			continue
+		}
+		pairedIdx, ok := idIndex[*p.PairedWith]
+		if !ok {
+			return fmt.Errorf("%w: witness %s paired with unknown party %s", ErrWitnessPairing, p.ID, *p.PairedWith)
+		}
+		paired := parties[pairedIdx]
+		if paired.Role != RoleSigner {
+			return fmt.Errorf("%w: witness %s paired with non-SIGNER %s (role %s)", ErrWitnessPairing, p.ID, paired.ID, paired.Role)
+		}
+		if p.RoutingOrder != paired.RoutingOrder {
+			return fmt.Errorf("%w: witness %s routing_order=%d mismatches paired signer %s routing_order=%d", ErrWitnessPairing, p.ID, p.RoutingOrder, paired.ID, paired.RoutingOrder)
+		}
+	}
+	return nil
+}
+
+// findPartyIdx returns the index of the party with the given ID, or -1.
+func findPartyIdx(parties []Party, id string) int {
+	for i, p := range parties {
+		if p.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// activeRoutingOrder returns the lowest RoutingOrder that has at least
+// one unsigned required SIGNER (or paired-required WITNESS). Returns
+// (-1, false) if every required party has signed.
+func activeRoutingOrder(parties []Party) (int, bool) {
+	min := 0
+	found := false
+	for _, p := range parties {
+		if !isRequiredForSigning(p) {
+			continue
+		}
+		if !p.SignedAt.IsZero() {
+			continue
+		}
+		if !found || p.RoutingOrder < min {
+			min = p.RoutingOrder
+			found = true
+		}
+	}
+	return min, found
+}
+
+// partyInActiveSet returns true if the party belongs to the current
+// active routing-order group.
+func partyInActiveSet(parties []Party, p *Party) bool {
+	active, ok := activeRoutingOrder(parties)
+	if !ok {
+		return false
+	}
+	return p.RoutingOrder == active
+}
+
+// allRequiredSigned returns true when every required signing party
+// (SIGNER required==true, plus paired WITNESS) has SignedAt set.
+func allRequiredSigned(parties []Party) bool {
+	for _, p := range parties {
+		if !isRequiredForSigning(p) {
+			continue
+		}
+		if p.SignedAt.IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+// isRequiredForSigning returns true if the party must sign for the
+// contract to advance to SIGNED. Required SIGNERs and paired WITNESSes
+// both count.
+func isRequiredForSigning(p Party) bool {
+	switch {
+	case p.Role == RoleSigner && p.Required:
+		return true
+	case p.Role == RoleWitness && p.PairedWith != nil:
+		// Paired witnesses are always required (they sign in tandem
+		// with their signer; the pair counts as one obligation).
+		return true
+	}
+	return false
+}
+
+// -- defensive copies -----------------------------------------------------
+
+func cloneParties(in []Party) []Party {
+	if in == nil {
+		return nil
+	}
+	out := make([]Party, len(in))
+	for i, p := range in {
+		out[i] = p
+		if p.PairedWith != nil {
+			s := *p.PairedWith
+			out[i].PairedWith = &s
+		}
+		if p.Attestation != nil {
+			a := *p.Attestation
+			out[i].Attestation = &a
+		}
+		if p.Metadata != nil {
+			m := make(map[string]any, len(p.Metadata))
+			for k, v := range p.Metadata {
+				m[k] = v
+			}
+			out[i].Metadata = m
+		}
+	}
+	return out
+}
+
+func cloneDocuments(in []DocumentRef) []DocumentRef {
+	if in == nil {
+		return nil
+	}
+	out := make([]DocumentRef, len(in))
+	for i, d := range in {
+		out[i] = d
+		if d.Metadata != nil {
+			m := make(map[string]any, len(d.Metadata))
+			for k, v := range d.Metadata {
+				m[k] = v
+			}
+			out[i].Metadata = m
+		}
+	}
+	return out
+}
+
+func cloneMetadata(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
Implements the contract workflow engine designed in [wondertwin-docs/research/contracts/engine-design.md](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/research/contracts/engine-design.md). Public, MIT, lives at `twinkit/contract` alongside `ledger` and `events`.

## What's in v0.1

- **Canonical state machine.** `DRAFT → SENT → PARTIALLY_SIGNED → SIGNED → EXECUTED` plus `DECLINED` / `VOIDED` / `EXPIRED` off-paths.
- **Party model with routing-order semantics.** Equal `RoutingOrder` = parallel; ascending = sequential. Active-set rule: lowest order with at least one unsigned required party.
- **Witness counter-signatory pairing** via `Party.PairedWith`. Pair signs in same routing slot and counts as one required signature for the `SIGNED` trigger. (Per the §1.5 design decision — first-class in v0.1.)
- **Append-only audit log per contract**, monotonic `Sequence`.
- **Post-execution observer.** `Hooks.OnExecuted` gates `SIGNED → EXECUTED`. Hook error halts at `SIGNED`; `Execute()` exposed for manual recovery (covered by test).
- **Composition over inheritance.** Storage delegates to per-twin `StateStore` (`MemoryStore` reference impl included). No engine-side document bytes (DocumentRef stays opaque). Events/webhooks composed at the twin layer.

## What's NOT in v0.1 (per design doc §1.5)

- Pre-signature approval chain. `StatusPendingApproval` is a reserved enum value. `SubmitForApproval` and `Approve` return `ErrApprovalChainNotImplemented` and will be shaped by the first CLM consumer in v0.2.
- Webhook bridge (`bridge.go` analog). Twins compose via `Hooks.OnStateTransition` for v0.1; a `bridge.go` helper that wires the canonical events to `twinkit/webhook` can land in a follow-up.
- Conformance suite. Lands as a follow-up PR (it's a separate deliverable per the design doc §14).

## Deviation from the design doc

The design doc lists `WithRand(*sim.Rand)` as an Engine option for ID generation. **Implemented as counter-based IDs + `state.Clock` for timestamps**, matching the existing `ledger` and `events` engines. Counter+clock is sufficient for v0.1 determinism; `WithRand` can be added later if a use case appears (e.g., randomized cert-serial generation in a future Attestation enrichment).

## Files (1,483 LoC)

| File | LoC | Purpose |
|---|---|---|
| `interface.go` | 164 | Public types: `Contract`, `Party`, `Status`, `RoleType`, `Attestation`, `AuditEntry`, `DocumentRef`, `StateStore` |
| `errors.go` | 36 | Sentinel errors |
| `hooks.go` | 52 | `Hooks` interface + `NoOpHooks` |
| `engine.go` | 459 | `Engine`, options, `Create` / `Update` / `Send` / `RecordSignature` / `Execute` / `Decline` / `Void` / `Expire` / `Get` / `List` |
| `parties.go` | 184 | Routing-order helpers, witness-pairing validation, deep-copy helpers |
| `memory_store.go` | 82 | Reference in-memory `StateStore` |
| `engine_test.go` | 506 | 22 tests |

## Verification

- `go build ./...` ✅
- `go vet ./twinkit/contract/...` ✅
- `go test ./twinkit/contract/... -count=1` — **22 / 22 pass**
- `go test ./... -short` — `twinkit/admin` has one pre-existing failure on main (`TestHandleListQuirksNilStore`) unrelated to this change; verified by running on clean main.

## Test coverage

Happy paths (sequential + parallel signers), routing-order enforcement, witness pairing (3 validation cases), already-signed rejection, role-cannot-sign rejection, decline/void/expire transitions, hook error halting at SIGNED + manual recovery, validate-create blocking persist, audit-log monotonic sequence, determinism (two identical runs → identical contracts), store-load returns copy.