### PR TITLE
add(twinkit/contract): dedicated terminal hooks

### DIFF
--- a/twinkit/contract/engine.go
+++ b/twinkit/contract/engine.go
@@ -353,6 +353,9 @@ func (e *Engine) Decline(ctx context.Context, id, partyID, reason string) (*Cont
 	if err := e.store.Save(c); err != nil {
 		return nil, fmt.Errorf("save: %w", err)
 	}
+	if err := e.hooks.OnDeclined(ctx, c, partyID, reason); err != nil {
+		return c, fmt.Errorf("hook OnDeclined: %w", err)
+	}
 	return c, nil
 }
 
@@ -378,6 +381,9 @@ func (e *Engine) Void(ctx context.Context, id, reason string) (*Contract, error)
 	if err := e.store.Save(c); err != nil {
 		return nil, fmt.Errorf("save: %w", err)
 	}
+	if err := e.hooks.OnVoided(ctx, c, reason); err != nil {
+		return c, fmt.Errorf("hook OnVoided: %w", err)
+	}
 	return c, nil
 }
 
@@ -402,6 +408,9 @@ func (e *Engine) Expire(ctx context.Context, id string) (*Contract, error) {
 	if err := e.store.Save(c); err != nil {
 		return nil, fmt.Errorf("save: %w", err)
 	}
+	if err := e.hooks.OnExpired(ctx, c); err != nil {
+		return c, fmt.Errorf("hook OnExpired: %w", err)
+	}
 	return c, nil
 }
 
@@ -417,13 +426,19 @@ func (e *Engine) List(_ context.Context) ([]*Contract, error) {
 
 // -- internal -------------------------------------------------------------
 
-// transition records a state change and invokes OnStateTransition. The
-// caller updates timestamps before this is called. Audit entry is
-// emitted; hook errors are non-fatal but surfaced.
+// transition records a state change and invokes OnStateTransition for
+// non-terminal targets. Terminal targets (EXECUTED, DECLINED, VOIDED,
+// EXPIRED) route to their dedicated terminal hook fired by the caller —
+// OnStateTransition is intentionally suppressed so consumers don't have
+// to special-case terminal statuses inside a generic transition
+// handler. The caller updates timestamps before this is called.
 func (e *Engine) transition(ctx context.Context, c *Contract, to Status, evt AuditEventType, partyID, msg string) error {
 	from := c.Status
 	c.Status = to
 	e.appendAudit(c, evt, partyID, from, to, msg, nil)
+	if isTerminal(to) {
+		return nil
+	}
 	if err := e.hooks.OnStateTransition(ctx, c, from, to); err != nil {
 		return fmt.Errorf("hook OnStateTransition %s→%s: %w", from, to, err)
 	}

--- a/twinkit/contract/engine_test.go
+++ b/twinkit/contract/engine_test.go
@@ -340,6 +340,9 @@ type recordingHooks struct {
 	executed       int
 	sigRecorded    int
 	transitions    []string // "FROM->TO"
+	declined       int
+	voided         int
+	expired        int
 	executeErr     error
 	validateErr    error
 }
@@ -359,6 +362,18 @@ func (r *recordingHooks) OnStateTransition(_ context.Context, _ *Contract, from,
 	r.transitions = append(r.transitions, string(from)+"->"+string(to))
 	return nil
 }
+func (r *recordingHooks) OnDeclined(_ context.Context, _ *Contract, _, _ string) error {
+	r.declined++
+	return nil
+}
+func (r *recordingHooks) OnVoided(_ context.Context, _ *Contract, _ string) error {
+	r.voided++
+	return nil
+}
+func (r *recordingHooks) OnExpired(_ context.Context, _ *Contract) error {
+	r.expired++
+	return nil
+}
 
 func TestHooks_OnExecutedFires(t *testing.T) {
 	clk := state.NewClock()
@@ -375,7 +390,8 @@ func TestHooks_OnExecutedFires(t *testing.T) {
 	if h.sigRecorded != 2 {
 		t.Errorf("OnSignatureRecorded called %d times, want 2", h.sigRecorded)
 	}
-	wantTransitions := []string{"DRAFT->SENT", "SENT->PARTIALLY_SIGNED", "PARTIALLY_SIGNED->SIGNED", "SIGNED->EXECUTED"}
+	// SIGNED->EXECUTED routes to OnExecuted, not OnStateTransition.
+	wantTransitions := []string{"DRAFT->SENT", "SENT->PARTIALLY_SIGNED", "PARTIALLY_SIGNED->SIGNED"}
 	if got := h.transitions; !equalStrings(got, wantTransitions) {
 		t.Errorf("transitions = %v, want %v", got, wantTransitions)
 	}
@@ -407,6 +423,71 @@ func TestHooks_OnExecutedErrorHaltsAtSigned(t *testing.T) {
 	if got2.Status != StatusExecuted {
 		t.Errorf("status after recovery = %s, want EXECUTED", got2.Status)
 	}
+}
+
+// TestHooks_TerminalRouting verifies that transitions into terminal
+// states route to dedicated terminal hooks (OnExecuted, OnDeclined,
+// OnVoided, OnExpired) and do NOT also fire OnStateTransition. This is
+// the contract surfaced in Hooks doc and reproduced from issue #249.
+func TestHooks_TerminalRouting(t *testing.T) {
+	t.Run("decline", func(t *testing.T) {
+		clk := state.NewClock()
+		clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+		h := &recordingHooks{}
+		eng := NewEngine(WithStore(NewMemoryStore()), WithClock(clk), WithHooks(h))
+		c, _ := eng.Create(context.Background(), twoSignerInput())
+		_, _ = eng.Send(context.Background(), c.ID)
+		if _, err := eng.Decline(context.Background(), c.ID, "p1", "nope"); err != nil {
+			t.Fatalf("Decline: %v", err)
+		}
+		if h.declined != 1 {
+			t.Errorf("OnDeclined called %d times, want 1", h.declined)
+		}
+		for _, tr := range h.transitions {
+			if tr == "SENT->DECLINED" || tr == "PARTIALLY_SIGNED->DECLINED" {
+				t.Errorf("OnStateTransition fired for terminal: %s", tr)
+			}
+		}
+	})
+
+	t.Run("void", func(t *testing.T) {
+		clk := state.NewClock()
+		clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+		h := &recordingHooks{}
+		eng := NewEngine(WithStore(NewMemoryStore()), WithClock(clk), WithHooks(h))
+		c, _ := eng.Create(context.Background(), twoSignerInput())
+		if _, err := eng.Void(context.Background(), c.ID, "rescinded"); err != nil {
+			t.Fatalf("Void: %v", err)
+		}
+		if h.voided != 1 {
+			t.Errorf("OnVoided called %d times, want 1", h.voided)
+		}
+		for _, tr := range h.transitions {
+			if tr == "DRAFT->VOIDED" {
+				t.Errorf("OnStateTransition fired for terminal: %s", tr)
+			}
+		}
+	})
+
+	t.Run("expire", func(t *testing.T) {
+		clk := state.NewClock()
+		clk.Pin(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+		h := &recordingHooks{}
+		eng := NewEngine(WithStore(NewMemoryStore()), WithClock(clk), WithHooks(h))
+		c, _ := eng.Create(context.Background(), twoSignerInput())
+		_, _ = eng.Send(context.Background(), c.ID)
+		if _, err := eng.Expire(context.Background(), c.ID); err != nil {
+			t.Fatalf("Expire: %v", err)
+		}
+		if h.expired != 1 {
+			t.Errorf("OnExpired called %d times, want 1", h.expired)
+		}
+		for _, tr := range h.transitions {
+			if tr == "SENT->EXPIRED" {
+				t.Errorf("OnStateTransition fired for terminal: %s", tr)
+			}
+		}
+	})
 }
 
 func TestHooks_ValidateCreateBlocksPersist(t *testing.T) {

--- a/twinkit/contract/hooks.go
+++ b/twinkit/contract/hooks.go
@@ -8,6 +8,22 @@ import "context"
 //
 // All methods receive a snapshot of the contract at the point of the
 // callback. Mutations to the snapshot are not persisted.
+//
+// Callback partitioning. The engine routes transitions to two distinct
+// observer surfaces so consumers don't have to special-case terminal
+// states inside a generic transition handler:
+//
+//   - OnStateTransition fires for every NON-terminal transition
+//     (DRAFT→SENT, SENT→PARTIALLY_SIGNED, PARTIALLY_SIGNED→SIGNED, …).
+//     This is the place to emit "contract.updated"-style change events.
+//
+//   - OnExecuted, OnDeclined, OnVoided, OnExpired fire for the four
+//     terminal transitions. Each is the canonical site for the
+//     side-effects specific to that terminal state (downstream
+//     materialisation on EXECUTED, refund/cleanup on VOIDED, etc.).
+//
+// A single state change invokes EITHER OnStateTransition OR exactly one
+// terminal hook — never both.
 type Hooks interface {
 	// ValidateCreate is called before a contract is persisted. Returning
 	// a non-nil error aborts the Create.
@@ -17,9 +33,12 @@ type Hooks interface {
 	// engine has already merged the mutation into the snapshot.
 	ValidateMutation(ctx context.Context, c *Contract) error
 
-	// OnStateTransition is called after a contract transitions state and
-	// is persisted. Errors are logged via the bridge but do not roll
-	// back the transition.
+	// OnStateTransition is called after a contract transitions to a
+	// non-terminal state and is persisted. It does NOT fire for
+	// transitions into EXECUTED, DECLINED, VOIDED, or EXPIRED — those
+	// route to their dedicated terminal hooks (OnExecuted, OnDeclined,
+	// OnVoided, OnExpired). Errors halt the transition and surface to
+	// the caller.
 	OnStateTransition(ctx context.Context, c *Contract, from, to Status) error
 
 	// OnSignatureRecorded is called after a signature is recorded.
@@ -34,14 +53,34 @@ type Hooks interface {
 	// Returning a non-nil error halts the transition: the contract stays
 	// at SIGNED and the error is surfaced to the caller of
 	// RecordSignature/Execute. The twin is responsible for retry/repair.
+	//
+	// OnStateTransition does NOT also fire for SIGNED → EXECUTED.
 	OnExecuted(ctx context.Context, c *Contract) error
+
+	// OnDeclined is called after a contract transitions to DECLINED and
+	// is persisted. Use this hook to emit decline-specific side effects
+	// (notifications, audit forwarding) without having to special-case
+	// the status inside OnStateTransition. Errors are surfaced to the
+	// caller of Decline; the contract has already moved to DECLINED.
+	OnDeclined(ctx context.Context, c *Contract, partyID, reason string) error
+
+	// OnVoided is called after a contract transitions to VOIDED and is
+	// persisted. Use this hook for cancellation-specific side effects
+	// (refunds, downstream tear-down). Errors are surfaced to the caller
+	// of Void; the contract has already moved to VOIDED.
+	OnVoided(ctx context.Context, c *Contract, reason string) error
+
+	// OnExpired is called after a contract transitions to EXPIRED and is
+	// persisted. Errors are surfaced to the caller of Expire; the
+	// contract has already moved to EXPIRED.
+	OnExpired(ctx context.Context, c *Contract) error
 }
 
 // NoOpHooks is a default no-op implementation. Embed this in a twin's
 // hook implementation to override only the methods that matter.
 type NoOpHooks struct{}
 
-func (NoOpHooks) ValidateCreate(_ context.Context, _ *Contract) error  { return nil }
+func (NoOpHooks) ValidateCreate(_ context.Context, _ *Contract) error   { return nil }
 func (NoOpHooks) ValidateMutation(_ context.Context, _ *Contract) error { return nil }
 func (NoOpHooks) OnStateTransition(_ context.Context, _ *Contract, _, _ Status) error {
 	return nil
@@ -49,4 +88,7 @@ func (NoOpHooks) OnStateTransition(_ context.Context, _ *Contract, _, _ Status) 
 func (NoOpHooks) OnSignatureRecorded(_ context.Context, _ *Contract, _ *Party) error {
 	return nil
 }
-func (NoOpHooks) OnExecuted(_ context.Context, _ *Contract) error { return nil }
+func (NoOpHooks) OnExecuted(_ context.Context, _ *Contract) error              { return nil }
+func (NoOpHooks) OnDeclined(_ context.Context, _ *Contract, _, _ string) error { return nil }
+func (NoOpHooks) OnVoided(_ context.Context, _ *Contract, _ string) error      { return nil }
+func (NoOpHooks) OnExpired(_ context.Context, _ *Contract) error               { return nil }


### PR DESCRIPTION
## Summary
- `OnStateTransition` no longer fires for transitions into terminal states (EXECUTED, DECLINED, VOIDED, EXPIRED). Each terminal status routes to a dedicated observer hook so consumers don't have to special-case terminal statuses.
- Adds `OnDeclined`, `OnVoided`, `OnExpired` to `Hooks` (`OnExecuted` already existed). `NoOpHooks` provides defaults.
- Updates `Hooks` docstrings and adds `TestHooks_TerminalRouting` covering decline/void/expire routing.

Implements Option A from #249. Closes #249.

After merge, twin-measure (wondertwin-pro PR #149) can drop the `case StatusExecuted: return nil` special-case in `hooks_contract.go` and either embed `contractlib.NoOpHooks` or implement the three new methods.

## Test plan
- [x] `go test ./contract/...` passes (including new `TestHooks_TerminalRouting`)
- [x] `go vet ./contract/...` clean
- [x] Updated `TestHooks_OnExecutedFires` no longer expects `SIGNED->EXECUTED` in the transition list
- [ ] Verify downstream twin-measure consumer once they update to the new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)