### PR TITLE
chore: bump Go stdlib to clear OSV-2026 stdlib advisories

### DIFF
--- a/docs/TWIN_TEMPLATE/go.mod
+++ b/docs/TWIN_TEMPLATE/go.mod
@@ -1,6 +1,6 @@
 module github.com/wondertwin-ai/wondertwin/twin-TEMPLATE
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wondertwin-ai/wondertwin
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/twinkit/go.mod
+++ b/twinkit/go.mod
@@ -1,5 +1,5 @@
 module github.com/wondertwin-ai/wondertwin/twinkit
 
-go 1.26.2
+go 1.26.3
 
 require github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Summary

Mirror of `wondertwin-pro#156`, applied to the community repo. Bump every `go.mod`'s `go` directive from `1.26.2` to `1.26.3` to pull in the patched Go stdlib.

## Why

OSV-Scanner is currently flagging 24 findings on every PR build (8 advisories × 3 go.mod files) — visible on PR #251's Dependency vulnerability scan check. This is the same GO-2026 stdlib bundle PR #156 cleared in `wondertwin-pro`.

## Files touched

- `go.mod` — top-level
- `twinkit/go.mod`
- `docs/TWIN_TEMPLATE/go.mod`

`require` blocks untouched. No `go mod tidy` churn beyond the directive bump.

## Advisories cleared

- GO-2026-4918, 4971, 4976, 4977, 4980, 4981, 4982, 4986

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (24 packages green)
- [ ] OSV-Scanner gate green on this PR
