### PR TITLE
fix: OSV scanner uses --sbom flag, not sbom subcommand

### DIFF
--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -90,7 +90,7 @@ jobs:
           # Final release gate: a release with known stdlib/dep CVEs in
           # its SBOM fails here, forcing an explicit fix-or-allowlist.
           go install github.com/google/osv-scanner/cmd/osv-scanner@v1.9.2
-          osv-scanner sbom "dist/twin-${TWIN}-${VERSION}.cdx.json"
+          osv-scanner --sbom="dist/twin-${TWIN}-${VERSION}.cdx.json"
 
       - name: Create release
         working-directory: wondertwin


### PR DESCRIPTION
## Summary

The "Verify SBOM is OSV-clean" step in the new release pipeline was using `osv-scanner sbom <file>`, which doesn't exist in osv-scanner v1.9.x — the CLI interpreted "sbom" as a positional path argument and failed with `Failed to walk sbom: lstat sbom: no such file or directory`.

Correct invocation is `osv-scanner --sbom=<file>`.

## How it surfaced

First run through the new pipeline (twin-measure v0.1.0, [run 25566795701](https://github.com/WonderTwin-AI/wondertwin-pro/actions/runs/25566795701)). The build, SBOM generation, and everything before this step worked fine — the syntax error was masked because the OSV scanner step never appeared in any prior PR test (the pipeline only runs on `workflow_dispatch`).

## Test plan

- [ ] Merge this PR
- [ ] Re-run `Release Commercial Twin` for measure v0.1.0
- [ ] Verify the OSV step succeeds and the rest of the pipeline completes
