### PR TITLE
fix: SBOM not listed explicitly in gh release create

### DIFF
--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -99,9 +99,11 @@ jobs:
           TWIN: ${{ inputs.twin }}
           VERSION: ${{ inputs.version }}
         run: |
+          # The SBOM (twin-<name>-<version>.cdx.json) is already matched
+          # by the dist/twin-${TWIN}-* glob; do not list it explicitly or
+          # gh will try to upload it twice and 422 on the second attempt.
           gh release create "twin-${TWIN}-v${VERSION}" \
             dist/twin-${TWIN}-* dist/checksums.txt \
-            "dist/twin-${TWIN}-${VERSION}.cdx.json" \
             --repo wondertwin-ai/registry \
             --title "twin-${TWIN} v${VERSION}" \
             --notes "Twin release for ${TWIN} v${VERSION}. SBOM: twin-${TWIN}-${VERSION}.cdx.json (CycloneDX JSON)."


### PR DESCRIPTION
fix: SBOM not listed explicitly in gh release create

The dist/twin-${TWIN}-* glob already matches the SBOM filename
(twin-<name>-<version>.cdx.json). Listing it again as an explicit
positional argument caused gh to upload it twice and 422 on the
second attempt with "ReleaseAsset.name already exists".

Caught by the third release run (twin-measure v0.1.0, run
25568127830 on wondertwin-pro). The release shell-handle 319631456
was already auto-cleaned by gh on the partial failure, so no orphan
state to clean up.
