### PR TITLE
feat(mcp): wt_trial + wt_subscribe MCP tools (cleanup item 3)

### DIFF
--- a/internal/mcp/tools_discovery.go
+++ b/internal/mcp/tools_discovery.go
@@ -118,47 +118,8 @@ func discoveryTools(pc *platform.Client, cfg *config.Config) []toolEntry {
 				return errorResult(fmt.Sprintf("twin %q not found", p.TwinName))
 			},
 		},
-		{
-			Tool: Tool{
-				Name:        "wt_subscribe",
-				Description: "Subscribe to a twin. The backend determines the outcome: already entitled, subscribed, trial started, or upgrade required. Returns structured JSON.",
-				InputSchema: json.RawMessage(`{
-					"type": "object",
-					"properties": {
-						"twin_name": {"type": "string", "description": "Name of the twin to subscribe to"}
-					},
-					"required": ["twin_name"]
-				}`),
-			},
-			Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
-				var p struct {
-					TwinName string `json:"twin_name"`
-				}
-				if len(params) > 0 {
-					json.Unmarshal(params, &p)
-				}
-				if p.TwinName == "" {
-					return errorResult("twin_name is required")
-				}
-
-				if cfg.APIKey == "" || cfg.OrgID == "" {
-					return jsonResult(map[string]any{
-						"action":     "signup_required",
-						"signup_url": fmt.Sprintf("https://app.wondertwin.ai/signup?ref=mcp&twin=%s", p.TwinName),
-						"message":    "Not authenticated. Sign up or run wt login --org.",
-					})
-				}
-
-				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-				defer cancel()
-
-				resp, err := pc.Subscribe(ctx, cfg.OrgID, p.TwinName)
-				if err != nil {
-					return errorResult(fmt.Sprintf("subscribe failed: %v", err))
-				}
-				return jsonResult(resp)
-			},
-		},
+		trialTool(pc, cfg),
+		subscribeTool(pc, cfg),
 		{
 			Tool: Tool{
 				Name:        "wt_request",

--- a/internal/mcp/tools_subscribe.go
+++ b/internal/mcp/tools_subscribe.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+// subscribeTool is the wt_subscribe MCP tool entry — repurposed from
+// its previous per-twin shape to the plan-relationship-change verb
+// per adr-license-delivery-via-mcp §4.
+//
+// The distinction from wt_install is meaningful:
+//   - wt_install delivers a SPECIFIC twin to the local runtime. The
+//     agent's primary action; runs many times per session.
+//   - wt_subscribe changes the ORG's BILLING RELATIONSHIP with
+//     WonderTwin (trial -> paid; paid -> larger plan; etc.). Rare;
+//     typically once per customer lifecycle, driven proactively by
+//     an agent client offering a "manage plan" affordance.
+//
+// V1 implementation is client-side URL construction only — the agent
+// surfaces the plan-management URL to the user, who handles the
+// actual plan change in the web app. A future PR adds the wondertwin-
+// app /v1/accounts/{id}/mcp/subscribe endpoint with smarter branching
+// (subscribed when the requested plan is granted; already_entitled
+// when already on it; upgrade_required when manual intervention
+// needed; setup_required when card collection is needed).
+//
+// The previous per-twin behavior (route to legacy /v1/orgs/{id}/subscribe
+// endpoint) is fully superseded by wt_install. No tool slot is being
+// taken away from agents — the wt_subscribe name now has the
+// semantics the ADR pinned, and the per-twin install path lives at
+// wt_install where it belongs.
+//
+// Note: the unused pc parameter is preserved for when the server
+// endpoint lands. Marked _ for now to satisfy the linter.
+func subscribeTool(_ *platform.Client, cfg *config.Config) toolEntry {
+	return toolEntry{
+		Tool: Tool{
+			Name: "wt_subscribe",
+			Description: "Change the organization's WonderTwin plan or billing " +
+				"relationship — trial-to-paid, paid-to-larger-plan, etc. NOT for " +
+				"adding a specific twin (use wt_install for that). Surfaces a " +
+				"plan-management URL the user opens in their browser. Returns the " +
+				"structured envelope.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"target_plan": {
+						"type": "string",
+						"description": "Optional plan hint (e.g. pro, enterprise). The web app handles the actual plan change; this is informational telemetry."
+					},
+					"agent_client_id": {
+						"type": "string",
+						"description": "MCP client identifier for telemetry (e.g. claude-code, cursor)"
+					}
+				}
+			}`),
+		},
+		Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+			var p struct {
+				TargetPlan    string `json:"target_plan"`
+				AgentClientID string `json:"agent_client_id"`
+			}
+			if len(params) > 0 {
+				if err := json.Unmarshal(params, &p); err != nil {
+					return errorResult(fmt.Sprintf("decode params: %v", err))
+				}
+			}
+
+			if cfg.APIKey == "" || cfg.OrgID == "" {
+				// Day Zero: no account at all. Plan changes are
+				// nonsensical here — there's no plan to change. Route
+				// to signup with action=subscribe so the web app's
+				// post-signup flow can land them on the plan page.
+				signupURL := "https://app.wondertwin.ai/signup?ref=mcp&action=subscribe"
+				if p.AgentClientID != "" {
+					signupURL += "&agent_client=" + p.AgentClientID
+				}
+				return jsonResult(map[string]any{
+					"outcome": string(platform.OutcomeSetupRequired),
+					"twin_id": "*",
+					"client_facing_message": "You'll need a WonderTwin account before you can manage a plan. " +
+						"Opening the signup page.",
+					"schema_version": 1,
+					"outcome_detail": map[string]string{
+						"setup_url":   signupURL,
+						"reason_code": "no_account",
+					},
+				})
+			}
+
+			// Authenticated: open the plan-management page where the
+			// web app handles the actual relationship change. Per the
+			// ADR, plan changes are rare and human-driven for V1; the
+			// server-side endpoint that returns subscribed /
+			// already_entitled / upgrade_required directly is deferred.
+			planURL := "https://app.wondertwin.ai/" + cfg.OrgID + "/admin/plan"
+			if p.TargetPlan != "" {
+				planURL += "?target_plan=" + p.TargetPlan
+			}
+			msg := "Opening the plan-management page so you can change your WonderTwin plan."
+			if p.TargetPlan != "" {
+				msg = "Opening the plan-management page so you can change your WonderTwin plan to " + p.TargetPlan + "."
+			}
+			return jsonResult(map[string]any{
+				"outcome":               string(platform.OutcomeSetupRequired),
+				"twin_id":               "*",
+				"client_facing_message": msg,
+				"schema_version":        1,
+				"outcome_detail": map[string]string{
+					"setup_url":   planURL,
+					"reason_code": "plan_change_requires_browser",
+				},
+			})
+		},
+	}
+}

--- a/internal/mcp/tools_subscribe_test.go
+++ b/internal/mcp/tools_subscribe_test.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+func runSubscribeTool(t *testing.T, cfg *config.Config, params map[string]string) ToolResult {
+	t.Helper()
+	pc := platform.New("http://unused", "")
+	entry := subscribeTool(pc, cfg)
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return entry.Handler(nil, nil, raw)
+}
+
+func TestSubscribeTool_DayZeroRoutesToSignup(t *testing.T) {
+	t.Parallel()
+	res := runSubscribeTool(t, &config.Config{}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("outcome: want setup_required, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["reason_code"] != "no_account" {
+		t.Errorf("reason_code: want no_account on Day Zero, got %v", detail["reason_code"])
+	}
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "/signup") || !strings.Contains(url, "action=subscribe") {
+		t.Errorf("Day-Zero subscribe URL should be /signup?action=subscribe, got %s", url)
+	}
+}
+
+func TestSubscribeTool_AuthenticatedReturnsPlanPage(t *testing.T) {
+	t.Parallel()
+	res := runSubscribeTool(t, &config.Config{APIKey: "k", OrgID: "org_t"}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("outcome: want setup_required, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["reason_code"] != "plan_change_requires_browser" {
+		t.Errorf("reason_code: want plan_change_requires_browser, got %v", detail["reason_code"])
+	}
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "/org_t/admin/plan") {
+		t.Errorf("authenticated subscribe URL should target /{org}/admin/plan, got %s", url)
+	}
+}
+
+func TestSubscribeTool_TargetPlanPropagatesToURL(t *testing.T) {
+	t.Parallel()
+	res := runSubscribeTool(t, &config.Config{APIKey: "k", OrgID: "org_t"},
+		map[string]string{"target_plan": "enterprise"})
+	got := unmarshalResult(t, res)
+	detail, _ := got["outcome_detail"].(map[string]any)
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "target_plan=enterprise") {
+		t.Errorf("target_plan should propagate to URL, got %s", url)
+	}
+	msg, _ := got["client_facing_message"].(string)
+	if !strings.Contains(msg, "enterprise") {
+		t.Errorf("client_facing_message should mention target plan, got %s", msg)
+	}
+}
+
+func TestSubscribeTool_AgentClientIDPropagatesOnDayZero(t *testing.T) {
+	t.Parallel()
+	res := runSubscribeTool(t, &config.Config{},
+		map[string]string{"agent_client_id": "cursor"})
+	got := unmarshalResult(t, res)
+	detail, _ := got["outcome_detail"].(map[string]any)
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "agent_client=cursor") {
+		t.Errorf("agent_client_id should propagate to signup URL, got %s", url)
+	}
+}
+
+func TestSubscribeTool_NoTwinIDRequired(t *testing.T) {
+	t.Parallel()
+	// Previous wt_subscribe required twin_name. The refactored ADR
+	// version is org-scoped, no twin parameter.
+	res := runSubscribeTool(t, &config.Config{APIKey: "k", OrgID: "org_t"}, nil)
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("no-param call should succeed; got outcome=%v", got["outcome"])
+	}
+}
+
+func TestSubscribeTool_EnvelopeShape(t *testing.T) {
+	t.Parallel()
+	res := runSubscribeTool(t, &config.Config{APIKey: "k", OrgID: "org_t"}, nil)
+	got := unmarshalResult(t, res)
+	for _, key := range []string{"outcome", "twin_id", "outcome_detail", "client_facing_message", "schema_version"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("envelope missing required field %q", key)
+		}
+	}
+	if got["twin_id"] != "*" {
+		t.Errorf("twin_id: want '*' for org-scoped tool, got %v", got["twin_id"])
+	}
+}

--- a/internal/mcp/tools_trial.go
+++ b/internal/mcp/tools_trial.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+// trialTool is the wt_trial MCP tool entry — surfaces the free-trial
+// affordance to brand-new users. Distinct from wt_install (day-to-day
+// twin delivery) and wt_subscribe (plan-relationship changes) per
+// adr-license-delivery-via-mcp §4.
+//
+// **Product rule: one trial per account, ever.** Once an account has
+// had a trial (whether expired without conversion or cancelled
+// mid-trial), no new trial can be started — the customer must
+// subscribe to regain Pro functionality. The tool reflects that:
+//
+//   - Day Zero (no account). Returns setup_required with a signup
+//     URL. The signup flow itself activates the account's one-and-
+//     only free trial. Tool message says so explicitly so agents
+//     surface "your free trial starts when you finish signup."
+//
+//   - Authenticated. The CLI cannot determine trial-eligibility
+//     locally (server holds the state). Routes the user to the
+//     plan-management page where the web app decides what's
+//     actually available — trial active, trial expired (and so
+//     must subscribe), already on paid plan. The tool MUST NOT
+//     claim "you can start a trial" for authenticated users; that
+//     determination belongs server-side and is gated by the
+//     one-trial-per-account rule.
+//
+// V1 implementation is client-side URL construction only. The web
+// app handles eligibility, card collection, and trial activation.
+// When the wondertwin-app /v1/accounts/{id}/mcp/trial endpoint lands
+// (separate PR pending Clerk JWT verifier), this tool will call
+// through for the smarter branching: trial_started ONLY for accounts
+// that have never had a trial; trial_already_active when in-progress;
+// upgrade_required (with the subscribe URL) when the trial is used
+// and the customer needs to subscribe to get Pro back.
+//
+// Returns the standard MCP envelope per mcp-subscribe-outcome-v1.json.
+// Agents read env.Outcome and surface env.ClientFacingMessage verbatim.
+func trialTool(_ *platform.Client, cfg *config.Config) toolEntry {
+	return toolEntry{
+		Tool: Tool{
+			Name: "wt_trial",
+			Description: "Surface the free-trial signup affordance to the user. " +
+				"For Day-Zero users (no account), returns a signup URL — the " +
+				"account's one-and-only free trial activates as part of signup. " +
+				"For authenticated users, routes to the plan-management page; " +
+				"the web app determines eligibility (one trial per account; " +
+				"expired trials require subscribing, not re-trialing). Returns " +
+				"the structured envelope.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"agent_client_id": {
+						"type": "string",
+						"description": "MCP client identifier for telemetry (e.g. claude-code, cursor)"
+					}
+				}
+			}`),
+		},
+		Handler: func(_ *manifest.Manifest, _ *client.AdminClient, params json.RawMessage) ToolResult {
+			var p struct {
+				AgentClientID string `json:"agent_client_id"`
+			}
+			if len(params) > 0 {
+				if err := json.Unmarshal(params, &p); err != nil {
+					return errorResult(fmt.Sprintf("decode params: %v", err))
+				}
+			}
+
+			signupURL := "https://app.wondertwin.ai/signup?ref=mcp&action=trial"
+			if p.AgentClientID != "" {
+				signupURL += "&agent_client=" + p.AgentClientID
+			}
+
+			if cfg.APIKey == "" || cfg.OrgID == "" {
+				return jsonResult(map[string]any{
+					"outcome": string(platform.OutcomeSetupRequired),
+					"twin_id": "*",
+					"client_facing_message": "Open the signup page to create your WonderTwin account. " +
+						"Your one free trial activates as part of signup — you only get one, so " +
+						"there's nothing extra to do beyond signing up.",
+					"schema_version": 1,
+					"outcome_detail": map[string]string{
+						"setup_url":   signupURL,
+						"reason_code": "no_account",
+					},
+				})
+			}
+
+			// Authenticated. The CLI cannot determine trial-eligibility
+			// locally — server holds the state — and per the one-trial-
+			// per-account rule, we MUST NOT imply they can start a new
+			// trial. Route to the plan-management page where the web app
+			// shows the right action: trial-active timer, or
+			// subscribe-to-Pro if the trial has ended, or already-on-paid
+			// plan management.
+			//
+			// reason_code='plan_management' (not 'already_authenticated')
+			// so the agent's client_facing_message doesn't accidentally
+			// suggest "you can start a trial."
+			planURL := "https://app.wondertwin.ai/" + cfg.OrgID + "/admin/plan"
+			return jsonResult(map[string]any{
+				"outcome": string(platform.OutcomeSetupRequired),
+				"twin_id": "*",
+				"client_facing_message": "You're signed in. Opening the plan page — the web app will " +
+					"show your current trial / plan status. (Trials are one per account; if yours " +
+					"has ended, you'll subscribe to Pro from this page.)",
+				"schema_version": 1,
+				"outcome_detail": map[string]string{
+					"setup_url":   planURL,
+					"reason_code": "plan_management",
+				},
+			})
+		},
+	}
+}

--- a/internal/mcp/tools_trial_test.go
+++ b/internal/mcp/tools_trial_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+func runTrialTool(t *testing.T, cfg *config.Config, params map[string]string) ToolResult {
+	t.Helper()
+	pc := platform.New("http://unused", "")
+	entry := trialTool(pc, cfg)
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return entry.Handler(nil, nil, raw)
+}
+
+func TestTrialTool_DayZeroReturnsSetupRequiredWithSignupURL(t *testing.T) {
+	t.Parallel()
+	res := runTrialTool(t, &config.Config{}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("outcome: want setup_required, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["reason_code"] != "no_account" {
+		t.Errorf("reason_code: want no_account, got %v", detail["reason_code"])
+	}
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "/signup") || !strings.Contains(url, "action=trial") {
+		t.Errorf("setup_url should be signup with action=trial, got %s", url)
+	}
+}
+
+func TestTrialTool_AuthenticatedRoutesToPlanPageWithoutTrialClaim(t *testing.T) {
+	t.Parallel()
+	// Per the one-trial-per-account rule: authenticated users routing
+	// through wt_trial must NOT be told "you can start a trial." The
+	// envelope routes them to the plan page where the web app
+	// determines what's actually available (trial active, expired,
+	// already on paid plan).
+	res := runTrialTool(t, &config.Config{APIKey: "k", OrgID: "org_t"}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("outcome: want setup_required, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["reason_code"] != "plan_management" {
+		t.Errorf("reason_code: want plan_management, got %v", detail["reason_code"])
+	}
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "/admin/plan") {
+		t.Errorf("authenticated wt_trial URL should target /admin/plan, got %s", url)
+	}
+	if !strings.Contains(url, "/org_t/") {
+		t.Errorf("setup_url should be scoped to the org, got %s", url)
+	}
+	// The URL must NOT carry action=trial — that would claim the
+	// user can start one, which violates one-trial-per-account.
+	if strings.Contains(url, "action=trial") {
+		t.Errorf("authenticated URL must NOT carry action=trial (claims new trial possible), got %s", url)
+	}
+	// Client-facing message must not promise a trial restart.
+	msg, _ := got["client_facing_message"].(string)
+	if !strings.Contains(strings.ToLower(msg), "one per account") {
+		t.Errorf("message should explain one-per-account so agent surfaces it accurately, got %q", msg)
+	}
+}
+
+func TestTrialTool_DayZeroMessageMentionsAutomaticTrial(t *testing.T) {
+	t.Parallel()
+	res := runTrialTool(t, &config.Config{}, map[string]string{})
+	got := unmarshalResult(t, res)
+	msg, _ := got["client_facing_message"].(string)
+	if !strings.Contains(strings.ToLower(msg), "one free trial") {
+		t.Errorf("Day-Zero message should mention the one-free-trial framing, got %q", msg)
+	}
+}
+
+func TestTrialTool_AgentClientIDPropagatesToURL(t *testing.T) {
+	t.Parallel()
+	res := runTrialTool(t, &config.Config{},
+		map[string]string{"agent_client_id": "claude-code"})
+	got := unmarshalResult(t, res)
+	detail, _ := got["outcome_detail"].(map[string]any)
+	url, _ := detail["setup_url"].(string)
+	if !strings.Contains(url, "agent_client=claude-code") {
+		t.Errorf("agent_client_id should propagate to signup URL, got %s", url)
+	}
+}
+
+func TestTrialTool_EnvelopeSchemaVersionIs1(t *testing.T) {
+	t.Parallel()
+	res := runTrialTool(t, &config.Config{}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if v, _ := got["schema_version"].(float64); v != 1 {
+		t.Errorf("schema_version: want 1, got %v", got["schema_version"])
+	}
+	if got["client_facing_message"] == nil || got["client_facing_message"] == "" {
+		t.Errorf("client_facing_message must be populated for forward-compat")
+	}
+}
+
+func TestTrialTool_TwinIDIsWildcard(t *testing.T) {
+	t.Parallel()
+	// wt_trial isn't twin-specific; the envelope's twin_id field
+	// is '*' by convention per mcp-subscribe-outcome-v1.json.
+	res := runTrialTool(t, &config.Config{}, map[string]string{})
+	got := unmarshalResult(t, res)
+	if got["twin_id"] != "*" {
+		t.Errorf("twin_id: want '*' for non-twin-specific tool, got %v", got["twin_id"])
+	}
+}


### PR DESCRIPTION
## Summary

Third of the four critical capability items from the post-platform cleanup queue. Closes the Day-Zero MCP gap that was deferred when \`wt_install\` shipped in [PR #256](https://github.com/WonderTwin-AI/wondertwin/pull/256).

Adds \`wt_trial\` (new tool) and refactors \`wt_subscribe\` (existing slot, new ADR semantics). Both are client-side URL builders that return MCP envelopes per \`mcp-subscribe-outcome-v1.json\` — server endpoints are deferred to follow-on PRs once the Clerk JWT verifier lands per \`adr-mcp-runtime-auth\`.

## Pinned by

- [adr-license-delivery-via-mcp §4](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/adr/adr-license-delivery-via-mcp.md) — the three-tool split (\`wt_install\` / \`wt_trial\` / \`wt_subscribe\`)
- Memory rule \`project-one-trial-per-account\` — one free trial per account, ever; expired trials require subscribing

## Changes (2 atomic commits)

**\`tools_trial.go\` + tests (7 tests)** — new tool
- Day Zero: signup URL; the signup flow activates the one-and-only free trial
- Authenticated: routes to \`/admin/plan\` where the web app shows the right action (trial active, expired, on paid plan). Reason code \`plan_management\` (not \`already_authenticated\`) so the surfaced message doesn't accidentally suggest "you can start a trial"
- URL must NOT carry \`action=trial\` for authenticated users — explicitly tested
- Client-facing message mentions one-per-account so agents surface it accurately

**\`tools_subscribe.go\` + tests (6 tests)** — repurposed slot
- Previous per-twin shape (route to legacy \`/v1/orgs/{id}/subscribe\`) fully superseded by \`wt_install\`
- New semantics: org's billing-relationship-change verb. trial→paid, paid→larger plan, etc.
- Day Zero: signup with \`action=subscribe\`
- Authenticated: \`/admin/plan\` with optional \`target_plan\` hint
- Drops the \`pc.Subscribe\` call site; \`tools_discovery.go\` wires the two new tools

## Tests

13 new tests, all passing. Full suite: \`go build ./... && go test ./... && go vet ./... && go mod tidy\` clean.

## What's deliberately not in this PR

- **Server-side \`/v1/accounts/{id}/mcp/trial\` and \`/mcp/subscribe\` endpoints** — deferred until the Clerk verifier lands. The web app currently handles eligibility, card collection, plan changes; the CLI just surfaces the right URL.
- **Smarter outcome branching** (\`trial_started\` vs \`trial_already_active\` vs \`upgrade_required\`) — requires server-side state. Today both tools return \`setup_required\` with the appropriate URL; the web app decides the next step.
- **\`wt_trial --upgrade-on-expiry\` and similar agent-driven plan workflows** — out of scope; agents drive these by calling \`wt_subscribe\` separately.

## Test plan
- [ ] CI green
- [ ] Reviewer sanity-check: authenticated wt_trial NEVER claims a new trial is possible (no \`action=trial\` URL; message explains one-per-account)
- [ ] Reviewer sanity-check: wt_subscribe drops the legacy \`pc.Subscribe\` call cleanly (no other callers)