### PR TITLE
feat(mcp): wt_license_refresh tool + auto-trigger on stale local (cleanup item 4, runtime)

### DIFF
--- a/internal/mcp/tools_discovery.go
+++ b/internal/mcp/tools_discovery.go
@@ -32,6 +32,7 @@ func errorResult(msg string) ToolResult {
 func discoveryTools(pc *platform.Client, cfg *config.Config) []toolEntry {
 	return []toolEntry{
 		installTool(pc, cfg),
+		licenseRefreshTool(pc, cfg),
 		{
 			Tool: Tool{
 				Name:        "wt_catalog",

--- a/internal/mcp/tools_install.go
+++ b/internal/mcp/tools_install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/wondertwin-ai/wondertwin/internal/client"
@@ -125,6 +126,15 @@ func installTool(pc *platform.Client, cfg *config.Config) toolEntry {
 					})
 				}
 			}
+
+			// Refresh-on-MCP-call hygiene per adr-license-delivery-via-mcp §3.
+			// For install responses the local license is already up-to-date
+			// after commitBundleIfPresent so this is normally a no-op, but
+			// it exercises the same path that future non-install MCP tools
+			// (subscribe-status polling, etc.) will use. Best-effort: any
+			// failure is logged, not surfaced — the original install's
+			// outcome stands.
+			refreshLicenseIfStale(ctx, pc, cfg, env, slog.Default())
 
 			return jsonResult(env)
 		},

--- a/internal/mcp/tools_license_refresh.go
+++ b/internal/mcp/tools_license_refresh.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/client"
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/manifest"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+	"github.com/wondertwin-ai/wondertwin/internal/registry"
+)
+
+// licenseRefreshTool is the wt_license_refresh MCP tool entry per
+// adr-license-delivery-via-mcp §3 (refresh-on-MCP-call freshness).
+//
+// Typical use: the runtime calls this in-band after receiving an
+// MCP response whose mcp_metadata.license_current_issued_at is
+// newer than its local license.json's IssuedAt — see
+// refreshLicenseIfStale below. Agents rarely invoke it directly,
+// but the tool is exposed so:
+//
+//   - An agent client can offer a manual "refresh license" affordance
+//     for the rare case the user wants to force a sync.
+//   - Diagnostics workflows can call it without going through a
+//     specific install.
+//
+// V1 implementation phones home unconditionally — the server returns
+// the freshly-issued license, runtime writes it atomically. The
+// no-op-on-already-current optimization (server says "you're already
+// at IssuedAt X, here's a no-op response") is deferred; for V1 we
+// always pay the IssueLicense cost server-side. Cheap enough.
+func licenseRefreshTool(pc *platform.Client, cfg *config.Config) toolEntry {
+	return toolEntry{
+		Tool: Tool{
+			Name: "wt_license_refresh",
+			Description: "Force-refresh the local WonderTwin license to match " +
+				"the server's current view of the org's entitlements. Normally " +
+				"the runtime calls this automatically when it detects a stale " +
+				"local license (via mcp_metadata.license_current_issued_at on " +
+				"prior responses). Returns the structured envelope.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {}
+			}`),
+		},
+		Handler: func(_ *manifest.Manifest, _ *client.AdminClient, _ json.RawMessage) ToolResult {
+			if cfg.APIKey == "" || cfg.OrgID == "" {
+				return jsonResult(map[string]any{
+					"outcome":               string(platform.OutcomeSetupRequired),
+					"twin_id":               "*",
+					"client_facing_message": "You're not signed in. Open the WonderTwin signup page first, then try again.",
+					"schema_version":        1,
+					"outcome_detail": map[string]string{
+						"setup_url":   "https://app.wondertwin.ai/signup?ref=mcp",
+						"reason_code": "no_account",
+					},
+				})
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			env, err := pc.LicenseRefresh(ctx, cfg.OrgID)
+			if err != nil {
+				return errorResult(fmt.Sprintf("license-refresh: %v", err))
+			}
+
+			if env.Outcome == platform.OutcomeLicenseRefreshed {
+				if err := commitLicenseIfPresent(env); err != nil {
+					return jsonResult(map[string]any{
+						"outcome":               string(platform.OutcomePolicyError),
+						"twin_id":               "*",
+						"client_facing_message": fmt.Sprintf("Server refreshed the license but the local commit failed: %v.", err),
+						"schema_version":        1,
+						"outcome_detail": map[string]string{
+							"error_code":    "license_commit_failed",
+							"error_message": err.Error(),
+						},
+					})
+				}
+			}
+
+			return jsonResult(env)
+		},
+	}
+}
+
+// commitLicenseIfPresent atomic-writes the license file from a
+// license-refresh envelope's bundle. Sister to commitBundleIfPresent
+// in tools_install.go but license-only (no binary). Returns an error
+// if the bundle is missing or malformed — that's a server-contract
+// violation, not a normal branch.
+//
+// licenseCommitter is the indirection layer that tests swap out; in
+// production it writes to ~/.wondertwin/license.json via the registry
+// helper. Mirrors the bundleCommitter pattern from tools_install.go.
+func commitLicenseIfPresent(env *platform.InstallEnvelope) error {
+	detail, err := platform.DecodeLicenseRefreshedDetail(env)
+	if err != nil {
+		return fmt.Errorf("decode license-refreshed detail: %w", err)
+	}
+	if detail == nil || detail.LicenseBundle == nil {
+		return fmt.Errorf("license-refreshed outcome has no license_bundle")
+	}
+	return licenseCommitter(detail.LicenseBundle)
+}
+
+// licenseCommitter is the package-level commit function. Production
+// uses commitLicenseToHome (writes ~/.wondertwin/license.json); tests
+// override to write to t.TempDir() without depending on the user's
+// HOME. Mirrors bundleCommitter in tools_install.go.
+var licenseCommitter = commitLicenseToHome
+
+func commitLicenseToHome(bundle *platform.LicenseBundle) error {
+	licensePath := registry.ExpandPath("~/.wondertwin/license.json")
+	return registry.WriteLicenseFromB64(licensePath, bundle.LicenseFileB64)
+}
+
+// refreshLicenseIfStale checks the MCP envelope's metadata against
+// the local license file and triggers a wt_license_refresh in-band
+// if the server's IssuedAt is newer.
+//
+// Called by other MCP tool handlers (today: wt_install) after a
+// successful response. The freshness check is best-effort — any
+// error reading the local file, parsing the metadata timestamp, or
+// performing the refresh is logged but not surfaced to the caller.
+// The original MCP call's outcome stands; the refresh is purely
+// background hygiene.
+//
+// Production wires this in main.go. Today the only tool that
+// produces install-bearing responses with mcp_metadata is wt_install,
+// so wt_install is the only call site. As more tools land
+// (wt_trial / wt_subscribe / etc. with server endpoints), they'll
+// pick up the same helper.
+func refreshLicenseIfStale(ctx context.Context, pc *platform.Client, cfg *config.Config, env *platform.InstallEnvelope, logger *slog.Logger) {
+	if env == nil || env.MCPMetadata == nil || env.MCPMetadata.LicenseCurrentIssuedAt == "" {
+		return
+	}
+	if cfg.APIKey == "" || cfg.OrgID == "" {
+		return // unauthenticated; can't refresh anyway
+	}
+
+	local, err := registry.ReadLocalLicenseInfo(registry.ExpandPath("~/.wondertwin/license.json"))
+	if err != nil {
+		logger.WarnContext(ctx, "license-refresh: read local license failed",
+			"err", err)
+		return
+	}
+	if !registry.IsLocalLicenseStale(local, env.MCPMetadata.LicenseCurrentIssuedAt) {
+		return
+	}
+
+	refreshEnv, err := pc.LicenseRefresh(ctx, cfg.OrgID)
+	if err != nil {
+		logger.WarnContext(ctx, "license-refresh: in-band refresh failed",
+			"err", err, "server_issued_at", env.MCPMetadata.LicenseCurrentIssuedAt)
+		return
+	}
+	if refreshEnv.Outcome != platform.OutcomeLicenseRefreshed {
+		logger.WarnContext(ctx, "license-refresh: server returned non-success outcome",
+			"outcome", refreshEnv.Outcome,
+			"message", refreshEnv.ClientFacingMessage)
+		return
+	}
+	if err := commitLicenseIfPresent(refreshEnv); err != nil {
+		logger.WarnContext(ctx, "license-refresh: commit failed",
+			"err", err)
+	}
+}
+

--- a/internal/mcp/tools_license_refresh_test.go
+++ b/internal/mcp/tools_license_refresh_test.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+)
+
+// licenseCommitRecorder is the test-mode replacement for the
+// commitLicenseToHome production licenseCommitter. Mirrors the
+// bundleCommitRecorder pattern from tools_install_test.go.
+type licenseCommitRecorder struct {
+	mu     sync.Mutex
+	called int
+	bundle *platform.LicenseBundle
+	err    error
+}
+
+func (r *licenseCommitRecorder) commit(bundle *platform.LicenseBundle) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.called++
+	r.bundle = bundle
+	return r.err
+}
+
+// captureLicenseCommitter swaps the package-level licenseCommitter
+// for a recording fake. Returns the recorder + a cleanup func that
+// t.Cleanup restores.
+func captureLicenseCommitter(t *testing.T) *licenseCommitRecorder {
+	t.Helper()
+	rec := &licenseCommitRecorder{}
+	prev := licenseCommitter
+	licenseCommitter = rec.commit
+	t.Cleanup(func() { licenseCommitter = prev })
+	return rec
+}
+
+// licenseEnvelopeResp returns an httptest server that responds at
+// the license-refresh endpoint with the given envelope.
+func licenseEnvelopeResp(t *testing.T, env platform.InstallEnvelope) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(env)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runRefreshTool(t *testing.T, srv *httptest.Server, cfg *config.Config) ToolResult {
+	t.Helper()
+	pc := platform.New(srv.URL, "test-key")
+	entry := licenseRefreshTool(pc, cfg)
+	return entry.Handler(nil, nil, nil)
+}
+
+func sampleLicenseBundle(t *testing.T) platform.LicenseBundle {
+	t.Helper()
+	return platform.LicenseBundle{
+		LicenseFileB64:  base64.StdEncoding.EncodeToString([]byte(`{"format":"v2","account_id":"org_t","issued_at":"2026-06-01T12:00:00Z"}`)),
+		LicenseIssuedAt: "2026-06-01T12:00:00Z",
+		LicenseNotAfter: "2026-07-01T12:00:00Z",
+	}
+}
+
+func TestLicenseRefreshTool_UnauthenticatedReturnsSetupRequired(t *testing.T) {
+	t.Parallel()
+	srv := licenseEnvelopeResp(t, platform.InstallEnvelope{})
+	res := runRefreshTool(t, srv, &config.Config{})
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeSetupRequired) {
+		t.Errorf("outcome: want setup_required, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["reason_code"] != "no_account" {
+		t.Errorf("reason_code: want no_account, got %v", detail["reason_code"])
+	}
+}
+
+func TestLicenseRefreshTool_HappyPathCommitsBundle(t *testing.T) {
+	// Not Parallel: mutates package-level licenseCommitter
+	bundle := sampleLicenseBundle(t)
+	srv := licenseEnvelopeResp(t, platform.InstallEnvelope{
+		Outcome:             platform.OutcomeLicenseRefreshed,
+		TwinID:              "*",
+		ClientFacingMessage: "License refreshed.",
+		SchemaVersion:       1,
+		OutcomeDetail: map[string]any{
+			"license_bundle": map[string]any{
+				"license_file":      bundle.LicenseFileB64,
+				"license_issued_at": bundle.LicenseIssuedAt,
+				"license_not_after": bundle.LicenseNotAfter,
+			},
+		},
+	})
+	rec := captureLicenseCommitter(t)
+	res := runRefreshTool(t, srv, &config.Config{APIKey: "k", OrgID: "org_t"})
+
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomeLicenseRefreshed) {
+		t.Errorf("outcome: want license_refreshed, got %v", got["outcome"])
+	}
+	if rec.called != 1 {
+		t.Errorf("commit calls: want 1, got %d", rec.called)
+	}
+	if rec.bundle == nil || rec.bundle.LicenseIssuedAt != bundle.LicenseIssuedAt {
+		t.Errorf("committed bundle IssuedAt: got %v", rec.bundle)
+	}
+}
+
+func TestLicenseRefreshTool_PolicyErrorDoesNotCommit(t *testing.T) {
+	// Not Parallel: mutates package-level licenseCommitter
+	srv := licenseEnvelopeResp(t, platform.InstallEnvelope{
+		Outcome:             platform.OutcomePolicyError,
+		TwinID:              "*",
+		ClientFacingMessage: "License refresh failed: no_active_entitlements.",
+		SchemaVersion:       1,
+		OutcomeDetail: map[string]any{
+			"error_code":    "no_active_entitlements",
+			"error_message": "no active entitlements",
+		},
+	})
+	rec := captureLicenseCommitter(t)
+	res := runRefreshTool(t, srv, &config.Config{APIKey: "k", OrgID: "org_t"})
+
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomePolicyError) {
+		t.Errorf("outcome: want policy_error, got %v", got["outcome"])
+	}
+	if rec.called != 0 {
+		t.Errorf("policy_error should not commit; got %d calls", rec.called)
+	}
+}
+
+func TestLicenseRefreshTool_CommitFailureReturnsPolicyError(t *testing.T) {
+	// Not Parallel: mutates package-level licenseCommitter
+	bundle := sampleLicenseBundle(t)
+	srv := licenseEnvelopeResp(t, platform.InstallEnvelope{
+		Outcome:             platform.OutcomeLicenseRefreshed,
+		TwinID:              "*",
+		ClientFacingMessage: "License refreshed.",
+		SchemaVersion:       1,
+		OutcomeDetail: map[string]any{
+			"license_bundle": map[string]any{
+				"license_file":      bundle.LicenseFileB64,
+				"license_issued_at": bundle.LicenseIssuedAt,
+				"license_not_after": bundle.LicenseNotAfter,
+			},
+		},
+	})
+	rec := captureLicenseCommitter(t)
+	rec.err = errors.New("disk full")
+	res := runRefreshTool(t, srv, &config.Config{APIKey: "k", OrgID: "org_t"})
+
+	got := unmarshalResult(t, res)
+	if got["outcome"] != string(platform.OutcomePolicyError) {
+		t.Errorf("outcome: want policy_error on commit failure, got %v", got["outcome"])
+	}
+	detail, _ := got["outcome_detail"].(map[string]any)
+	if detail["error_code"] != "license_commit_failed" {
+		t.Errorf("error_code: want license_commit_failed, got %v", detail["error_code"])
+	}
+}
+
+func TestLicenseRefreshTool_HTTP5xxBubblesAsError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	pc := platform.New(srv.URL, "test-key")
+	entry := licenseRefreshTool(pc, &config.Config{APIKey: "k", OrgID: "org_t"})
+	res := entry.Handler(nil, nil, nil)
+	got := unmarshalResult(t, res)
+	if got["error"] == nil {
+		t.Errorf("want error on HTTP 500, got %+v", got)
+	} else if !strings.Contains(got["error"].(string), "license-refresh") {
+		t.Errorf("error should mention license-refresh, got %v", got["error"])
+	}
+}
+
+// --- refreshLicenseIfStale tests ---
+
+func TestRefreshLicenseIfStale_NoMetadataIsNoOp(t *testing.T) {
+	t.Parallel()
+	// Server should never be called.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called when no metadata")
+	}))
+	defer srv.Close()
+	pc := platform.New(srv.URL, "test-key")
+	refreshLicenseIfStale(context.Background(), pc,
+		&config.Config{APIKey: "k", OrgID: "org_t"},
+		&platform.InstallEnvelope{Outcome: platform.OutcomeInstalled},
+		slog.Default())
+}
+
+func TestRefreshLicenseIfStale_UnauthenticatedIsNoOp(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called when unauthenticated")
+	}))
+	defer srv.Close()
+	pc := platform.New(srv.URL, "test-key")
+	env := &platform.InstallEnvelope{
+		MCPMetadata: &platform.EnvelopeMeta{
+			LicenseCurrentIssuedAt: "2099-01-01T00:00:00Z",
+		},
+	}
+	refreshLicenseIfStale(context.Background(), pc, &config.Config{}, env, slog.Default())
+}

--- a/internal/platform/license_refresh.go
+++ b/internal/platform/license_refresh.go
@@ -1,0 +1,98 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// LicenseBundle is the license-only payload returned by the
+// /v1/accounts/{id}/mcp/license-refresh endpoint. Distinct from
+// InstallBundle (which carries the binary too) because refresh
+// leaves the binary alone — only ~/.wondertwin/license.json is
+// atomic-replaced per adr-license-delivery-via-mcp §3.
+//
+// Field names match the server-side billing.LicenseBundle and the
+// schema's installBundle subset for runtime code reuse.
+type LicenseBundle struct {
+	LicenseFileB64  string `json:"license_file"`
+	LicenseIssuedAt string `json:"license_issued_at"`
+	LicenseNotAfter string `json:"license_not_after"`
+}
+
+// LicenseRefreshedDetail is OutcomeDetail when outcome=license_refreshed.
+// JSON-decode into this when env.Outcome is OutcomeLicenseRefreshed.
+type LicenseRefreshedDetail struct {
+	LicenseBundle *LicenseBundle `json:"license_bundle"`
+}
+
+// OutcomeLicenseRefreshed is the InstallOutcome value for a
+// successful license-only refresh. Adds to the existing enum and is
+// forward-compat per adr-mcp-subscribe-outcomes §4 — older clients
+// degrade to policy_error and surface client_facing_message verbatim,
+// which is safe because "license refreshed" is informational.
+const OutcomeLicenseRefreshed InstallOutcome = "license_refreshed"
+
+// LicenseRefresh calls POST /v1/accounts/{accountID}/mcp/license-refresh
+// on wondertwin-app. Returns the full envelope so the caller can
+// branch on env.Outcome (license_refreshed on success; policy_error
+// on no-active-entitlements / issuer failure / etc.).
+//
+// Returns a Go error only for transport-layer failures. Every
+// expected outcome, including policy_error, comes back as a 200
+// with a populated envelope.
+func (c *Client) LicenseRefresh(ctx context.Context, accountID string) (*InstallEnvelope, error) {
+	if accountID == "" {
+		return nil, fmt.Errorf("license-refresh: accountID is required")
+	}
+
+	// Empty POST body — refresh takes no inputs beyond the
+	// path-scoped accountID and the auth context.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/v1/accounts/%s/mcp/license-refresh", c.baseURL, accountID),
+		bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return nil, fmt.Errorf("license-refresh: create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("license-refresh: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("license-refresh: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var env InstallEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("license-refresh: decode response: %w", err)
+	}
+	return &env, nil
+}
+
+// DecodeLicenseRefreshedDetail re-decodes env.OutcomeDetail (the raw
+// any from JSON) into a typed LicenseRefreshedDetail. Returns
+// (nil, nil) if the outcome isn't license_refreshed so callers can
+// branch cleanly.
+func DecodeLicenseRefreshedDetail(env *InstallEnvelope) (*LicenseRefreshedDetail, error) {
+	if env == nil || env.Outcome != OutcomeLicenseRefreshed {
+		return nil, nil
+	}
+	raw, err := json.Marshal(env.OutcomeDetail)
+	if err != nil {
+		return nil, fmt.Errorf("decode license-refreshed detail: re-marshal: %w", err)
+	}
+	var detail LicenseRefreshedDetail
+	if err := json.Unmarshal(raw, &detail); err != nil {
+		return nil, fmt.Errorf("decode license-refreshed detail: %w", err)
+	}
+	return &detail, nil
+}

--- a/internal/platform/license_refresh_test.go
+++ b/internal/platform/license_refresh_test.go
@@ -1,0 +1,148 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLicenseRefresh_HappyPathDecodesEnvelope(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/accounts/org_t/mcp/license-refresh" {
+			t.Errorf("path: got %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "test-api-key" {
+			t.Errorf("auth header missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(InstallEnvelope{
+			Outcome:             OutcomeLicenseRefreshed,
+			TwinID:              "*",
+			ClientFacingMessage: "License refreshed (3 entitlements).",
+			SchemaVersion:       1,
+			OutcomeDetail: map[string]any{
+				"license_bundle": map[string]any{
+					"license_file":      "eyJmb28iOiJiYXIifQ==",
+					"license_issued_at": "2026-06-01T12:00:00Z",
+					"license_not_after": "2026-07-01T12:00:00Z",
+				},
+			},
+			MCPMetadata: &EnvelopeMeta{
+				LicenseCurrentIssuedAt: "2026-06-01T12:00:00Z",
+			},
+		})
+	})
+
+	env, err := client.LicenseRefresh(context.Background(), "org_t")
+	if err != nil {
+		t.Fatalf("LicenseRefresh: %v", err)
+	}
+	if env.Outcome != OutcomeLicenseRefreshed {
+		t.Errorf("outcome: want license_refreshed, got %s", env.Outcome)
+	}
+	detail, err := DecodeLicenseRefreshedDetail(env)
+	if err != nil {
+		t.Fatalf("DecodeLicenseRefreshedDetail: %v", err)
+	}
+	if detail == nil || detail.LicenseBundle == nil {
+		t.Fatalf("detail/bundle nil: %+v", detail)
+	}
+	if detail.LicenseBundle.LicenseFileB64 != "eyJmb28iOiJiYXIifQ==" {
+		t.Errorf("license_file: got %q", detail.LicenseBundle.LicenseFileB64)
+	}
+	if detail.LicenseBundle.LicenseIssuedAt != "2026-06-01T12:00:00Z" {
+		t.Errorf("license_issued_at: got %q", detail.LicenseBundle.LicenseIssuedAt)
+	}
+	if env.MCPMetadata == nil || env.MCPMetadata.LicenseCurrentIssuedAt != "2026-06-01T12:00:00Z" {
+		t.Errorf("metadata IssuedAt not propagated: %+v", env.MCPMetadata)
+	}
+}
+
+func TestLicenseRefresh_PolicyErrorOutcomeReturnsEnvelopeNotGoError(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(InstallEnvelope{
+			Outcome:             OutcomePolicyError,
+			TwinID:              "*",
+			ClientFacingMessage: "License refresh failed: no_active_entitlements.",
+			SchemaVersion:       1,
+			OutcomeDetail: map[string]any{
+				"error_code":    "no_active_entitlements",
+				"error_message": "no active entitlements to issue a license for",
+			},
+		})
+	})
+
+	env, err := client.LicenseRefresh(context.Background(), "org_t")
+	if err != nil {
+		t.Fatalf("policy_error should come back as envelope, not Go error; got %v", err)
+	}
+	if env.Outcome != OutcomePolicyError {
+		t.Errorf("outcome: want policy_error, got %s", env.Outcome)
+	}
+}
+
+func TestLicenseRefresh_HTTP5xxBubblesAsError(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	_, err := client.LicenseRefresh(context.Background(), "org_t")
+	if err == nil {
+		t.Fatal("want error on 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("want HTTP 500 in error, got %v", err)
+	}
+}
+
+func TestLicenseRefresh_MissingAccountIDIsClientError(t *testing.T) {
+	t.Parallel()
+	client := New("http://unused", "key")
+	_, err := client.LicenseRefresh(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "accountID") {
+		t.Errorf("want accountID-required error, got %v", err)
+	}
+}
+
+func TestDecodeLicenseRefreshedDetail_NonMatchingOutcomeReturnsNil(t *testing.T) {
+	t.Parallel()
+	env := &InstallEnvelope{Outcome: OutcomeInstalled}
+	d, err := DecodeLicenseRefreshedDetail(env)
+	if err != nil || d != nil {
+		t.Errorf("non-matching outcome: want (nil, nil), got (%v, %v)", d, err)
+	}
+
+	d, err = DecodeLicenseRefreshedDetail(nil)
+	if err != nil || d != nil {
+		t.Errorf("nil envelope: want (nil, nil), got (%v, %v)", d, err)
+	}
+}
+
+func TestLicenseRefresh_PostsEmptyJSONBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		if string(body) != "{}" {
+			t.Errorf("body: want '{}', got %q", string(body))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type: got %s", r.Header.Get("Content-Type"))
+		}
+		_ = json.NewEncoder(w).Encode(InstallEnvelope{
+			Outcome: OutcomeLicenseRefreshed, TwinID: "*", SchemaVersion: 1,
+			ClientFacingMessage: "ok",
+		})
+	}))
+	defer srv.Close()
+	client := New(srv.URL, "key")
+	_, err := client.LicenseRefresh(context.Background(), "org_t")
+	if err != nil {
+		t.Fatalf("LicenseRefresh: %v", err)
+	}
+}

--- a/internal/registry/license_load.go
+++ b/internal/registry/license_load.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// WriteLicenseFromB64 decodes a base64-encoded license file and
+// atomic-writes it to path. Sister to CommitInstallBundle's license
+// branch, but standalone — for the refresh-on-MCP-call path where
+// only the license is being updated (no binary).
+//
+// Uses the same temp-then-rename strategy as writeLicenseAtomic so a
+// partial write never bricks the runtime: the runtime continues
+// running against the prior license until the rename commits.
+func WriteLicenseFromB64(path, licenseB64 string) error {
+	licenseBytes, err := base64.StdEncoding.DecodeString(licenseB64)
+	if err != nil {
+		return fmt.Errorf("decode license: %w", err)
+	}
+	return writeLicenseAtomic(path, licenseBytes)
+}
+
+// LocalLicenseInfo is the subset of the offline license file the
+// runtime needs for freshness comparison. Decoded from
+// ~/.wondertwin/license.json (or wherever Path points) — minimal
+// shape so the runtime doesn't have to depend on the full
+// twinkit-pro/license types (which live in a separate module under
+// the BSL license boundary).
+type LocalLicenseInfo struct {
+	AccountID string    `json:"account_id"`
+	IssuedAt  time.Time `json:"issued_at"`
+	NotAfter  time.Time `json:"not_after"`
+}
+
+// ReadLocalLicenseInfo reads the license file at path (typically
+// ~/.wondertwin/license.json) and decodes the IssuedAt /
+// AccountID / NotAfter fields. Used for the refresh-on-MCP-call
+// freshness comparison per adr-license-delivery-via-mcp §3:
+// runtime compares the local IssuedAt against the
+// mcp_metadata.license_current_issued_at on each MCP response and
+// triggers wt_license_refresh when newer server-side.
+//
+// Returns (nil, nil) when the file doesn't exist — that's a valid
+// state (fresh install before first wt_install) and the caller
+// treats it as "no comparison possible; skip the freshness check."
+// Other errors (malformed JSON, permission denied) bubble up.
+func ReadLocalLicenseInfo(path string) (*LocalLicenseInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read license file: %w", err)
+	}
+	var info LocalLicenseInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("decode license file: %w", err)
+	}
+	return &info, nil
+}
+
+// IsLocalLicenseStale reports whether the server's most-recent
+// license issued_at is newer than what the runtime has locally.
+// Returns false when the local license is missing (no comparison
+// possible) or when the server's value is empty/malformed (don't
+// trigger refresh on a server that didn't tell us its state).
+//
+// The comparison is at second-level granularity since license
+// IssuedAt is written with second-level precision; sub-second
+// differences would always show stale otherwise.
+func IsLocalLicenseStale(local *LocalLicenseInfo, serverIssuedAt string) bool {
+	if local == nil || serverIssuedAt == "" {
+		return false
+	}
+	server, err := time.Parse(time.RFC3339, serverIssuedAt)
+	if err != nil {
+		return false
+	}
+	return server.Truncate(time.Second).After(local.IssuedAt.Truncate(time.Second))
+}

--- a/internal/registry/license_load_test.go
+++ b/internal/registry/license_load_test.go
@@ -1,0 +1,117 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadLocalLicenseInfo_MissingFileReturnsNilNil(t *testing.T) {
+	t.Parallel()
+	info, err := ReadLocalLicenseInfo(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Errorf("missing file: want nil err, got %v", err)
+	}
+	if info != nil {
+		t.Errorf("missing file: want nil info, got %+v", info)
+	}
+}
+
+func TestReadLocalLicenseInfo_HappyPathDecodes(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "license.json")
+	body := `{
+		"format_version": "2.0",
+		"account_id": "org_t",
+		"issued_at": "2026-06-01T12:00:00Z",
+		"not_after": "2026-07-01T12:00:00Z",
+		"signature": "abc"
+	}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	info, err := ReadLocalLicenseInfo(path)
+	if err != nil {
+		t.Fatalf("ReadLocalLicenseInfo: %v", err)
+	}
+	if info.AccountID != "org_t" {
+		t.Errorf("account_id: got %q", info.AccountID)
+	}
+	want := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	if !info.IssuedAt.Equal(want) {
+		t.Errorf("issued_at: want %v, got %v", want, info.IssuedAt)
+	}
+}
+
+func TestReadLocalLicenseInfo_MalformedJSONErrors(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "license.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := ReadLocalLicenseInfo(path)
+	if err == nil {
+		t.Fatal("want error on malformed JSON")
+	}
+}
+
+func TestIsLocalLicenseStale_NilLocalReturnsFalse(t *testing.T) {
+	t.Parallel()
+	if IsLocalLicenseStale(nil, "2026-06-01T12:00:00Z") {
+		t.Errorf("nil local should never be stale (no comparison possible)")
+	}
+}
+
+func TestIsLocalLicenseStale_EmptyServerValueReturnsFalse(t *testing.T) {
+	t.Parallel()
+	local := &LocalLicenseInfo{IssuedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)}
+	if IsLocalLicenseStale(local, "") {
+		t.Errorf("empty server value: don't trigger refresh")
+	}
+}
+
+func TestIsLocalLicenseStale_MalformedServerValueReturnsFalse(t *testing.T) {
+	t.Parallel()
+	local := &LocalLicenseInfo{IssuedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)}
+	if IsLocalLicenseStale(local, "not-a-timestamp") {
+		t.Errorf("malformed server value: should be conservative and not trigger refresh")
+	}
+}
+
+func TestIsLocalLicenseStale_ServerNewerReturnsTrue(t *testing.T) {
+	t.Parallel()
+	local := &LocalLicenseInfo{IssuedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)}
+	if !IsLocalLicenseStale(local, "2026-06-01T12:00:00Z") {
+		t.Errorf("server newer: want stale")
+	}
+}
+
+func TestIsLocalLicenseStale_ServerSameReturnsFalse(t *testing.T) {
+	t.Parallel()
+	local := &LocalLicenseInfo{IssuedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)}
+	if IsLocalLicenseStale(local, "2026-06-01T12:00:00Z") {
+		t.Errorf("server equal to local: don't trigger refresh")
+	}
+}
+
+func TestIsLocalLicenseStale_ServerOlderReturnsFalse(t *testing.T) {
+	t.Parallel()
+	local := &LocalLicenseInfo{IssuedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)}
+	if IsLocalLicenseStale(local, "2026-05-01T12:00:00Z") {
+		t.Errorf("server older: don't trigger refresh (the runtime has the newer license)")
+	}
+}
+
+func TestIsLocalLicenseStale_SubSecondDifferenceReturnsFalse(t *testing.T) {
+	t.Parallel()
+	// Server reports 100ms after local. Should NOT be stale —
+	// we truncate to second-level granularity to avoid false positives
+	// from server-time vs local-time-of-write drift.
+	local := &LocalLicenseInfo{
+		IssuedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+	if IsLocalLicenseStale(local, "2026-06-01T12:00:00.100Z") {
+		t.Errorf("sub-second diff: don't trigger refresh (truncation defense)")
+	}
+}


### PR DESCRIPTION
## Summary

Runtime side of cleanup item 4 (refresh-on-MCP-call freshness). Pairs with the server endpoint that landed in [wondertwin-app PR #95](https://github.com/WonderTwin-AI/wondertwin-app/pull/95).

With both merged, the runtime can detect a stale local license (because the server's \`mcp_metadata.license_current_issued_at\` is newer than the local file's \`issued_at\`) and refresh in-band — no polling thread, no missed entitlement changes between installs.

## Pinned by

[adr-license-delivery-via-mcp §3](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/adr/adr-license-delivery-via-mcp.md) — freshness via refresh-on-MCP-call, not polling.

## Changes (3 atomic commits)

**\`platform/license_refresh.go\` + 6 tests** — \`Client.LicenseRefresh\` + \`LicenseBundle\` wire type + decoder helper
- Mirrors the server endpoint; envelope shape shared with InstallEnvelope
- \`OutcomeLicenseRefreshed\` added to enum (forward-compat per adr-mcp-subscribe-outcomes §4)

**\`registry/license_load.go\` + 10 tests** — three small helpers
- \`ReadLocalLicenseInfo(path)\` — minimal-shape decoder for ~/.wondertwin/license.json
- \`IsLocalLicenseStale(local, serverIssuedAt)\` — second-level-granularity comparison with safe-degradation on every edge (nil local, empty/malformed server, equal, older). No false positives from sub-second time skew.
- \`WriteLicenseFromB64(path, b64)\` — base64-decode + atomic temp-then-rename

**\`mcp/tools_license_refresh.go\` + 7 tests** — \`wt_license_refresh\` tool + \`refreshLicenseIfStale\` helper
- New MCP tool: phones home → atomic-writes ~/.wondertwin/license.json. Unauthenticated → \`setup_required\`. policy_error from server passes through. Local commit failure synthesizes \`policy_error\` with \`license_commit_failed\`.
- \`licenseCommitter\` package-level var for test swappability (mirrors \`bundleCommitter\` from PR #256)
- \`refreshLicenseIfStale\` hooked into \`wt_install\`'s response path. For install responses the local file is already up-to-date after \`commitBundleIfPresent\` so this is a no-op in practice — but exercises the same code path future non-install MCP tools (subscribe-status polling, queue list refresh, etc.) will use uniformly.
- \`discoveryTools\` registers \`wt_license_refresh\` alongside the existing slots

## Tests

23 new tests, all passing. Full suite: \`go build ./... && go test ./... && go vet ./... && go mod tidy\` clean across the runtime + all 11 twins.

## What's deliberately not in this PR

- **Server endpoint** — landed in wondertwin-app PR #95
- **Populating mcp_metadata on non-install MCP tools** — wt_install is the only tool producing install-bearing responses today. As wt_trial / wt_subscribe / queue-status server endpoints land, they'll pick up the same metadata pattern.
- **Background refresh thread** — the ADR's no-polling decision holds. The trigger is in-band after every MCP call.

## Test plan
- [ ] CI green
- [ ] Reviewer sanity-check: \`IsLocalLicenseStale\` returns false on every safe-degradation case (no false positives from server-time / local-time skew, no triggers when server claims older-than-local)
- [ ] Reviewer sanity-check: refresh-after-install no-op assertion holds (commit-then-compare against the same IssuedAt → no second refresh call)