### PR TITLE
auth: enforce 0600/0700 on ~/.wondertwin/config.json + perm-check on load (Stream E-cli)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+func runtimeIsWindows() bool { return runtime.GOOS == "windows" }
 
 // DefaultConfigDir is the directory under the user's home for CLI state.
 const DefaultConfigDir = ".wondertwin"
@@ -86,7 +89,27 @@ func Load() (*Config, error) {
 
 // LoadFrom reads and parses a config from the given path.
 // If isJSON is true, the file is parsed as JSON; otherwise as YAML.
+//
+// LoadFrom refuses to read a config file whose Unix permissions are
+// world- or group-readable (anything beyond 0600). The file holds an
+// API key and the license; a misconfigured umask or a recursive chmod
+// can leak credentials to any other user on the box. The CLI fails
+// loud with a chmod hint rather than silently loading.
+//
+// Per-platform note: Windows does not honor Unix mode bits in any
+// meaningful way; the check is skipped there.
 func LoadFrom(path string, isJSON bool) (*Config, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultConfig(), nil
+		}
+		return nil, fmt.Errorf("stat config %s: %w", path, err)
+	}
+	if err := checkConfigPerms(path, info); err != nil {
+		return nil, err
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -119,15 +142,27 @@ func LoadFrom(path string, isJSON bool) (*Config, error) {
 	return &cfg, nil
 }
 
-// Save writes the config to ~/.wondertwin/config.json.
+// Save writes the config to ~/.wondertwin/config.json with 0600
+// permissions inside a 0700 directory. If the directory already
+// exists with looser permissions (e.g., a prior CLI version wrote it
+// 0755), Save tightens it. Symmetric with LoadFrom's perm-check —
+// the two together close the credential-leak window.
 func Save(cfg *Config) error {
 	dir, err := configDir()
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
+	}
+	// MkdirAll respects existing permissions; explicitly drop them
+	// to 0700 in case a prior version of the CLI created the dir
+	// with 0755. Skipped on Windows where Unix mode bits are inert.
+	if !runtimeIsWindows() {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("tightening config dir perms: %w", err)
+		}
 	}
 
 	path := filepath.Join(dir, DefaultConfigFile)
@@ -138,7 +173,17 @@ func Save(cfg *Config) error {
 	}
 	data = append(data, '\n')
 
-	return os.WriteFile(path, data, 0o600)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	// Likewise, tighten the file in case it pre-existed with a
+	// looser mode that WriteFile preserved.
+	if !runtimeIsWindows() {
+		if err := os.Chmod(path, 0o600); err != nil {
+			return fmt.Errorf("tightening config file perms: %w", err)
+		}
+	}
+	return nil
 }
 
 // ParseLicenseKey parses a license key of the format wt_{tier}_{org}_{random}_{check}.
@@ -224,6 +269,43 @@ func TierName(tier string) string {
 	default:
 		return "free"
 	}
+}
+
+// checkConfigPerms returns an error if the config file or its parent
+// directory permit access outside the owner. The directory check
+// catches the "world-readable ~/.wondertwin" footgun even when the
+// file itself is 0600 (since a path-traversal-via-readable-dir is
+// the same disclosure).
+//
+// On Windows we skip — `runtime.GOOS == "windows"` doesn't expose
+// meaningful Unix mode bits and the check is noise there.
+func checkConfigPerms(path string, info os.FileInfo) error {
+	if runtimeIsWindows() {
+		return nil
+	}
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return fmt.Errorf(
+			"config file %s has insecure permissions %#o; run `chmod 600 %s` and retry",
+			path, mode, path,
+		)
+	}
+
+	dir := filepath.Dir(path)
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		// If the directory is unreadable we can't continue anyway —
+		// the file read would already have failed before this point.
+		return nil
+	}
+	dirMode := dirInfo.Mode().Perm()
+	if dirMode&0o077 != 0 {
+		return fmt.Errorf(
+			"config directory %s has insecure permissions %#o; run `chmod 700 %s` and retry",
+			dir, dirMode, dir,
+		)
+	}
+	return nil
 }
 
 func defaultConfig() *Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,11 +3,17 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestLoadFromYAML(t *testing.T) {
 	dir := t.TempDir()
+	// t.TempDir() returns a 0755 dir on most platforms; tighten so
+	// the per-load perm-check passes for valid-shape tests.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	path := filepath.Join(dir, "config.yaml")
 	content := `
 license_key: "wt_com_acme_abcdef_7b"
@@ -15,7 +21,7 @@ registries:
   public:
     url: https://example.com/registry.yaml
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,6 +39,9 @@ registries:
 
 func TestLoadFromJSON(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	path := filepath.Join(dir, "config.json")
 	content := `{
   "license_key": "wt_com_acme_abcdef_7b",
@@ -42,7 +51,7 @@ func TestLoadFromJSON(t *testing.T) {
     }
   }
 }`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,16 +85,19 @@ func TestLoadPrefersJSONOverYAML(t *testing.T) {
 	// and using LoadFrom to test each format. The preference logic is in
 	// resolveConfigPath which we test indirectly.
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 
 	yamlPath := filepath.Join(dir, "config.yaml")
 	yamlContent := `license_key: "yaml-key"`
-	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	jsonPath := filepath.Join(dir, "config.json")
 	jsonContent := `{"license_key": "json-key"}`
-	if err := os.WriteFile(jsonPath, []byte(jsonContent), 0o644); err != nil {
+	if err := os.WriteFile(jsonPath, []byte(jsonContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -173,6 +185,9 @@ func TestOrgContext(t *testing.T) {
 
 func TestOrgContextRoundTrip(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	path := filepath.Join(dir, "config.json")
 	content := `{
   "license_key": "",
@@ -180,7 +195,7 @@ func TestOrgContextRoundTrip(t *testing.T) {
   "org_id": "org-123",
   "api_key": "wt_live_abc123"
 }`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -211,5 +226,89 @@ func TestParseLicenseKey(t *testing.T) {
 	}
 	if info.Org != "acme" {
 		t.Errorf("expected org acme, got %q", info.Org)
+	}
+}
+
+// TestLoadFrom_RejectsWorldReadableFile pins the Stream-E-cli
+// guarantee: a credentials file whose mode permits group/world reads
+// is refused with a clear chmod hint, not silently loaded.
+func TestLoadFrom_RejectsWorldReadableFile(t *testing.T) {
+	if runtimeIsWindows() {
+		t.Skip("Unix mode bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"license_key":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFrom(path, true)
+	if err == nil {
+		t.Fatal("expected LoadFrom to refuse 0644 config file")
+	}
+	if !strings.Contains(err.Error(), "chmod 600") {
+		t.Fatalf("expected chmod hint, got %v", err)
+	}
+}
+
+// TestLoadFrom_RejectsWorldReadableDir checks the directory mode
+// independently — a 0600 file inside a 0755 directory still leaks
+// the file's existence (and is suspect).
+func TestLoadFrom_RejectsWorldReadableDir(t *testing.T) {
+	if runtimeIsWindows() {
+		t.Skip("Unix mode bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"license_key":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFrom(path, true)
+	if err == nil {
+		t.Fatal("expected LoadFrom to refuse 0755 config dir")
+	}
+	if !strings.Contains(err.Error(), "chmod 700") {
+		t.Fatalf("expected chmod hint, got %v", err)
+	}
+}
+
+// TestSave_TightensExistingDirPerms covers the upgrade path: a prior
+// CLI version created ~/.wondertwin with 0755; Save must tighten it
+// to 0700 in place so the next Load passes its perm check.
+func TestSave_TightensExistingDirPerms(t *testing.T) {
+	if runtimeIsWindows() {
+		t.Skip("Unix mode bits don't apply on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, DefaultConfigDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{LicenseKey: "test"}
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("expected dir mode 0700 after Save, got %#o", mode)
+	}
+
+	fileInfo, err := os.Stat(filepath.Join(dir, DefaultConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := fileInfo.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("expected file mode 0600 after Save, got %#o", mode)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,6 +14,19 @@ import (
 )
 
 // Server is an MCP server that exposes twin management tools over JSON-RPC 2.0 on stdio.
+//
+// Security model: this server runs as a local stdio subprocess
+// launched by the agent client (Claude Code, Cursor, etc.). It is
+// single-tenant and single-process; there is no network surface and
+// the agent client cannot inject credentials. Upstream calls to
+// wondertwin-app authenticate using cfg.APIKey loaded from
+// ~/.wondertwin/config.json (whose permissions are enforced by the
+// config package's perm-check at load time). No request from the
+// agent is ever interpreted as an auth claim — the agent supplies
+// tool-call arguments, never authentication context.
+//
+// This invariant is verified by `grep -r 'Authorization\|Bearer\|
+// Cookie' internal/mcp/` returning no matches (see issue #259).
 type Server struct {
 	manifest *manifest.Manifest
 	client   *client.AdminClient


### PR DESCRIPTION
Closes #259. Stream E-cli of the customer-launch auth implementation (umbrella: WonderTwin-AI/wondertwin-docs#100).

## What changed

Three discrete tightenings on the local credential store that every CLI + MCP-driven flow depends on:

### 1. \`config.LoadFrom\` rejects insecure permissions

The file holds the API key + license; a misconfigured umask or a recursive \`chmod -R\` leaks credentials to any other user on the box. \`LoadFrom\` now stats the file before reading and refuses if:
- The file mode allows group/world access (anything beyond \`0600\`)
- The parent directory mode allows group/world access (anything beyond \`0700\`)

Both errors print a clear hint:

\`\`\`
config file /Users/x/.wondertwin/config.json has insecure permissions 0644; run \`chmod 600 /Users/x/.wondertwin/config.json\` and retry
\`\`\`

Windows is exempted (Unix mode bits are inert there).

### 2. \`config.Save\` creates + tightens to \`0700/0600\`

\`os.MkdirAll\` was creating the dir at \`0755\`. Now it creates at \`0700\` and explicitly \`Chmod\`s both the dir and the file after write — covers the upgrade case where a prior CLI version left the dir loose.

Symmetric with the load-time check; the two together close the window.

### 3. MCP server invariant documented

Audited \`internal/mcp/\` with \`grep -rn 'Authorization\\|Bearer\\|Cookie'\` — no matches. The stdio JSON-RPC server never interprets agent input as an authentication claim; upstream auth uses \`cfg.APIKey\` from the now-locked-down config file. Added a security-model comment on \`Server\` to pin the invariant for future contributors.

## Out of scope (per the issue)

- Replacing the byte-sum checksum in \`ParseLicenseKey\` with a real signature — separate license-format work tracked in the broader punchlist.
- Keychain / OS-secret-store integration — v1 stays file-based.
- Device-pairing flow for API-key delivery — Stream E-web (#69).

## Tests

- \`TestLoadFrom_RejectsWorldReadableFile\` — 0644 file rejected with chmod 600 hint
- \`TestLoadFrom_RejectsWorldReadableDir\` — 0755 dir rejected even with 0600 file
- \`TestSave_TightensExistingDirPerms\` — upgrade path: pre-existing 0755 dir gets tightened to 0700 in place
- Existing tests updated to 0600 fixtures + 0700 TempDirs so they pass the new check

\`go build ./... && go test ./... && go vet ./...\` clean.

## Test plan

- [x] \`chmod 644 ~/.wondertwin/config.json && wt auth status\` → refuses with clear chmod hint
- [x] \`chmod 755 ~/.wondertwin && wt auth status\` → refuses with clear chmod hint
- [x] Fresh install with \`wt auth login\` creates dir at 0700 and file at 0600
- [x] Existing 0755 dir from prior CLI → next Save tightens it to 0700
- [x] \`grep -rn 'Authorization\\|Bearer\\|Cookie' internal/mcp/\` returns nothing

Tracker: WonderTwin-AI/wondertwin-docs#100