### PR TITLE
feat(twin-posthog): handle posthog-js gzip-js compression

### DIFF
--- a/twin-posthog/internal/api/decompress.go
+++ b/twin-posthog/internal/api/decompress.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// readCaptureBody reads a PostHog capture body, transparently handling the
+// compression and form-wrapping variants emitted by posthog-js and other SDKs.
+//
+// Supported shapes:
+//   - Raw JSON
+//   - Form-encoded "data=<value>" (value may itself be base64+gzip)
+//   - ?compression=gzip-js or ?compression=gzip — body (or "data" field) is gzip bytes
+//   - ?compression=base64 — body (or "data" field) is base64-encoded JSON
+//   - Content-Encoding: gzip — body is gzipped
+func readCaptureBody(r *http.Request) ([]byte, error) {
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	ct := r.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, "application/x-www-form-urlencoded") ||
+		(len(raw) >= 5 && bytes.HasPrefix(raw, []byte("data="))) {
+		if values, perr := url.ParseQuery(string(raw)); perr == nil {
+			if d := values.Get("data"); d != "" {
+				raw = []byte(d)
+			}
+		}
+	}
+
+	compression := r.URL.Query().Get("compression")
+	if compression == "" && strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {
+		compression = "gzip"
+	}
+
+	switch compression {
+	case "gzip", "gzip-js":
+		// posthog-js sends raw gzip bytes; the form-wrapped path may have
+		// surfaced a base64-encoded gzip payload — try that first.
+		if decoded, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(string(raw))); derr == nil && looksLikeGzip(decoded) {
+			raw = decoded
+		}
+		gz, gerr := gzip.NewReader(bytes.NewReader(raw))
+		if gerr != nil {
+			return nil, fmt.Errorf("gzip reader: %w", gerr)
+		}
+		defer gz.Close()
+		out, rerr := io.ReadAll(gz)
+		if rerr != nil {
+			return nil, fmt.Errorf("gzip read: %w", rerr)
+		}
+		return out, nil
+	case "base64":
+		decoded, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(string(raw)))
+		if derr != nil {
+			return nil, fmt.Errorf("base64 decode: %w", derr)
+		}
+		return decoded, nil
+	default:
+		return raw, nil
+	}
+}
+
+func looksLikeGzip(b []byte) bool {
+	return len(b) >= 2 && b[0] == 0x1f && b[1] == 0x8b
+}

--- a/twin-posthog/internal/api/decompress_test.go
+++ b/twin-posthog/internal/api/decompress_test.go
@@ -1,0 +1,178 @@
+package api_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(b); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func postRaw(t *testing.T, base, path, contentType string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, base+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return resp
+}
+
+func readJSON(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("decode response %q: %v", body, err)
+	}
+	return m
+}
+
+// TestCaptureGzipJS verifies posthog-js's ?compression=gzip-js path: raw gzip
+// bytes in the body, JSON inside.
+func TestCaptureGzipJS(t *testing.T) {
+	srv, tc := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "gzip_event",
+		"distinct_id": "user_gz",
+	})
+
+	resp := postRaw(t, srv.URL, "/capture?compression=gzip-js", "text/plain", gzipBytes(t, payload))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	m := readJSON(t, resp)
+	if m["status"] != float64(1) {
+		t.Errorf("expected status=1, got %v", m["status"])
+	}
+
+	r := tc.Get("/admin/events?event=gzip_event")
+	r.AssertStatus(200)
+	events := r.JSONMap()["events"].([]any)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+}
+
+// TestBatchGzipJS exercises the /batch endpoint with gzip-js compression.
+func TestBatchGzipJS(t *testing.T) {
+	srv, tc := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key": "phc_test_key",
+		"batch": []map[string]any{
+			{"event": "gz_batch_a", "distinct_id": "u1"},
+			{"event": "gz_batch_b", "distinct_id": "u2"},
+		},
+	})
+
+	resp := postRaw(t, srv.URL, "/batch?compression=gzip-js", "text/plain", gzipBytes(t, payload))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	r := tc.Get("/admin/events?event=gz_batch_a")
+	r.AssertStatus(200)
+	if len(r.JSONMap()["events"].([]any)) != 1 {
+		t.Errorf("missing gz_batch_a event")
+	}
+}
+
+// TestCaptureContentEncodingGzip verifies the Content-Encoding: gzip fallback
+// path (no ?compression query param).
+func TestCaptureContentEncodingGzip(t *testing.T) {
+	srv, _ := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "ce_gzip",
+		"distinct_id": "u",
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/capture", bytes.NewReader(gzipBytes(t, payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestCaptureBase64 verifies the ?compression=base64 path.
+func TestCaptureBase64(t *testing.T) {
+	srv, _ := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "b64_event",
+		"distinct_id": "u",
+	})
+	encoded := base64.StdEncoding.EncodeToString(payload)
+
+	resp := postRaw(t, srv.URL, "/capture?compression=base64", "text/plain", []byte(encoded))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestCaptureFormDataWrapper verifies the legacy "data=<payload>" form-encoded
+// shape that posthog-js falls back to for the /e endpoint.
+func TestCaptureFormDataWrapper(t *testing.T) {
+	srv, _ := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "form_event",
+		"distinct_id": "u",
+	})
+	form := "data=" + url.QueryEscape(string(payload))
+
+	resp := postRaw(t, srv.URL, "/e", "application/x-www-form-urlencoded", []byte(form))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestCaptureFormDataGzipBase64 covers the data=<base64-of-gzip-bytes> shape.
+func TestCaptureFormDataGzipBase64(t *testing.T) {
+	srv, _ := setupPostHog(t)
+
+	payload, _ := json.Marshal(map[string]any{
+		"api_key":     "phc_test_key",
+		"event":       "form_gz_event",
+		"distinct_id": "u",
+	})
+	b64 := base64.StdEncoding.EncodeToString(gzipBytes(t, payload))
+	form := "data=" + url.QueryEscape(b64)
+
+	resp := postRaw(t, srv.URL, "/e?compression=gzip-js", "application/x-www-form-urlencoded", []byte(form))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}

--- a/twin-posthog/internal/api/handlers_capture.go
+++ b/twin-posthog/internal/api/handlers_capture.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -35,8 +36,16 @@ type decideRequest struct {
 
 // CaptureEvent handles POST /capture, POST /e
 func (h *Handler) CaptureEvent(w http.ResponseWriter, r *http.Request) {
+	body, err := readCaptureBody(r)
+	if err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "Invalid request body: " + err.Error(),
+		})
+		return
+	}
 	var req captureRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
 		twincore.JSON(w, http.StatusBadRequest, map[string]any{
 			"status": 0,
 			"error":  "Invalid request body: " + err.Error(),
@@ -73,8 +82,16 @@ func (h *Handler) CaptureEvent(w http.ResponseWriter, r *http.Request) {
 
 // BatchCapture handles POST /batch
 func (h *Handler) BatchCapture(w http.ResponseWriter, r *http.Request) {
+	body, err := readCaptureBody(r)
+	if err != nil {
+		twincore.JSON(w, http.StatusBadRequest, map[string]any{
+			"status": 0,
+			"error":  "Invalid request body: " + err.Error(),
+		})
+		return
+	}
 	var req batchRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
 		twincore.JSON(w, http.StatusBadRequest, map[string]any{
 			"status": 0,
 			"error":  "Invalid request body: " + err.Error(),


### PR DESCRIPTION
## Summary
- posthog-js sends capture/batch payloads as raw gzip bytes with `?compression=gzip-js`; the twin was rejecting those as invalid JSON.
- New `readCaptureBody` helper transparently decodes the full set of shapes the SDK emits: `gzip-js`, `Content-Encoding: gzip`, `compression=base64`, and the legacy form-encoded `data=<payload>` wrapper (including `data=<base64-of-gzip>`).
- Wired into `/capture`, `/e`, and `/batch` handlers.

## Test plan
- [x] `go test ./twin-posthog/...` passes
- [x] New tests cover gzip-js (capture + batch), `Content-Encoding: gzip`, `compression=base64`, form `data=`, and form `data=<base64-of-gzip>`