### PR TITLE
feat(cli): wt verify CI gate + .wondertwin/project.json reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ bin/
 .wt/
 dist/
 wondertwin.json
-wt
+/wt
 .claude/
 twin-posthog/seed.json
 twin-posthog/demo.sh

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -13,6 +13,7 @@
 //	wt install                    Install all twins from wondertwin.yaml
 //	wt install <twin>@<version>   Install a specific twin at a version
 //	wt ci                         Install twins from lock file (frozen)
+//	wt verify                     Assert lockfile twins are covered by org entitlements
 //	wt auth login                 Activate a license key
 //	wt auth status                Show current license tier
 //	wt auth logout                Clear license key
@@ -122,6 +123,8 @@ func main() {
 		err = cmdInstall(manifestPath, args)
 	case "ci":
 		err = cmdCI(manifestPath)
+	case "verify":
+		err = cmdVerify(args)
 	case "login":
 		err = cmdLogin(args)
 	case "catalog":
@@ -197,6 +200,7 @@ Commands:
   install                    Install all twins from manifest
   install <twin>@<version>   Install a specific twin at a version
   ci                         Install twins from lock file (frozen, reproducible)
+  verify                     Assert lockfile twins are covered by org entitlements (CI gate)
   auth login                 Activate a license key
   auth status                Show current license tier and org
   auth logout                Clear license key
@@ -1441,6 +1445,7 @@ func cmdAuthStatus() error {
 		fmt.Printf("Org ID:  %s\n", cfg.OrgID)
 		maskedKey := cfg.APIKey[:8] + "..." + cfg.APIKey[len(cfg.APIKey)-4:]
 		fmt.Printf("API Key: %s\n", maskedKey)
+		printProjectMismatchWarning(cfg.OrgID)
 		return nil
 	}
 

--- a/cmd/wt/verify.go
+++ b/cmd/wt/verify.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/lockfile"
+	"github.com/wondertwin-ai/wondertwin/internal/platform"
+	"github.com/wondertwin-ai/wondertwin/internal/project"
+)
+
+// Exit codes for `wt verify`, per adr-ci-twin-verification.
+//
+//	0 — every twin in the lock file is covered by the asserted org's
+//	    entitlements.
+//	1 — one or more twins are missing entitlements (the conversion
+//	    signal — CI fails and the human is told to subscribe).
+//	2 — usage / configuration error (no lockfile, no account, network
+//	    failure). Distinct from 1 so CI dashboards can tell "missing
+//	    coverage" apart from "tool didn't run."
+const (
+	verifyExitOK         = 0
+	verifyExitNotCovered = 1
+	verifyExitUsage      = 2
+)
+
+// cmdVerify implements `wt verify` — the CI gate that asserts every
+// twin in wondertwin-lock.json is covered by the entitlements of the
+// account-of-record. The account is resolved from (in order):
+//
+//  1. --org / --account flag
+//  2. WONDERTWIN_ACCOUNT_ID env (CI-friendly override)
+//  3. .wondertwin/project.json#account_id (committed, walks up)
+//  4. ~/.wondertwin/config.yaml's org_id (developer fallback)
+//
+// Per adr-ci-twin-verification we want the gate to be loud-but-fair:
+// missing entitlements get printed with a human-readable next step.
+func cmdVerify(args []string) error {
+	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	orgOverride := fs.String("org", "", "override account_id (e.g. for CI)")
+	accountAlias := fs.String("account", "", "alias for --org")
+	dir := fs.String("dir", "", "directory containing wondertwin-lock.json (default: cwd)")
+	if err := fs.Parse(args); err != nil {
+		// Treat flag-parse errors as usage failures (exit 2).
+		os.Exit(verifyExitUsage)
+	}
+
+	workDir := *dir
+	if workDir == "" {
+		var err error
+		workDir, err = os.Getwd()
+		if err != nil {
+			os.Exit(verifyExitUsage)
+		}
+	}
+
+	// 1. Lockfile is the source of truth for what to check.
+	if !lockfile.Exists(workDir) {
+		fmt.Fprintf(os.Stderr, "wt verify: no %s found in %s\n", lockfile.Filename, workDir)
+		fmt.Fprintln(os.Stderr, "Run `wt install` first to produce a lock file.")
+		os.Exit(verifyExitUsage)
+	}
+	lf, err := lockfile.Load(workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wt verify: reading %s: %v\n", lockfile.Filename, err)
+		os.Exit(verifyExitUsage)
+	}
+	twins := sortedTwinNames(lf)
+
+	// 2. Resolve account.
+	accountID, source, err := resolveAccountID(*orgOverride, *accountAlias, workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wt verify: %v\n", err)
+		os.Exit(verifyExitUsage)
+	}
+
+	// 3. Need an API key to call the server.
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wt verify: loading config: %v\n", err)
+		os.Exit(verifyExitUsage)
+	}
+	apiKey := cfg.APIKey
+	if k := os.Getenv("WONDERTWIN_API_KEY"); k != "" {
+		apiKey = k
+	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "wt verify: no API key configured")
+		fmt.Fprintln(os.Stderr, "Set WONDERTWIN_API_KEY (CI) or run `wt login` (local).")
+		os.Exit(verifyExitUsage)
+	}
+
+	// 4. Call the server.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := platform.New(platformBaseURL(), apiKey)
+	resp, err := client.EntitlementsCover(ctx, accountID, twins)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wt verify: %v\n", err)
+		os.Exit(verifyExitUsage)
+	}
+
+	// 5. Report.
+	fmt.Printf("Verifying %d twins against account %s (%s)\n",
+		len(twins), accountID, source)
+	fmt.Println()
+
+	if len(resp.Missing) == 0 {
+		fmt.Printf("  All %d twins covered.\n", len(resp.Covered))
+		return nil
+	}
+
+	fmt.Printf("  %d twin(s) NOT covered:\n", len(resp.Missing))
+	for _, m := range resp.Missing {
+		fmt.Printf("    - %-24s %s\n", m.TwinName, humanReason(m.ReasonCode))
+	}
+	fmt.Println()
+	fmt.Println("To resolve:")
+	fmt.Println("  • Run `wt subscribe <twin>` to add the missing entitlements, or")
+	fmt.Println("  • Remove unused twins from wondertwin.yaml and rerun `wt install`.")
+	os.Exit(verifyExitNotCovered)
+	return nil
+}
+
+// resolveAccountID picks the account_id and returns (id, source-label, err).
+// The source label is printed back to the user so they can tell at a
+// glance which input won — useful when CI overrides a project.json.
+func resolveAccountID(orgFlag, accountFlag, workDir string) (id, source string, err error) {
+	if orgFlag != "" {
+		return orgFlag, "--org flag", nil
+	}
+	if accountFlag != "" {
+		return accountFlag, "--account flag", nil
+	}
+	if env := os.Getenv("WONDERTWIN_ACCOUNT_ID"); env != "" {
+		return env, "WONDERTWIN_ACCOUNT_ID env", nil
+	}
+	p, perr := project.Find(workDir)
+	if perr != nil {
+		return "", "", fmt.Errorf("reading project.json: %w", perr)
+	}
+	if p != nil {
+		return p.AccountID, ".wondertwin/project.json", nil
+	}
+	// Developer fallback.
+	cfg, cerr := config.Load()
+	if cerr == nil && cfg.OrgID != "" {
+		return cfg.OrgID, "~/.wondertwin/config.yaml", nil
+	}
+	return "", "", fmt.Errorf("no account_id configured (set --org, WONDERTWIN_ACCOUNT_ID, or commit .wondertwin/project.json)")
+}
+
+// printProjectMismatchWarning emits a soft warning to stderr when the
+// signed-in account_id doesn't match the .wondertwin/project.json
+// committed in the current directory tree.
+//
+// This is the "you're about to push code that CI is going to reject"
+// hint — strictly informational, never an error, since the developer
+// may legitimately be testing locally against their own account
+// before opening a PR (the friction-as-conversion path from
+// adr-ci-twin-verification).
+func printProjectMismatchWarning(localOrgID string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	p, err := project.Find(cwd)
+	if err != nil || p == nil {
+		return
+	}
+	if p.AccountID == localOrgID {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\nNote: .wondertwin/project.json#account_id is %s\n", p.AccountID)
+	fmt.Fprintf(os.Stderr, "      Local login is %s. `wt verify` will assert against %s.\n",
+		localOrgID, p.AccountID)
+}
+
+func sortedTwinNames(lf *lockfile.LockFile) []string {
+	names := make([]string, 0, len(lf.Twins))
+	for n := range lf.Twins {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// humanReason turns a wire-level reason_code into a one-line
+// explanation. Unknown codes pass through verbatim — forward-compat
+// per the same ADR pattern as install outcomes (clients should never
+// hide a server message even if they don't recognize the code).
+func humanReason(code string) string {
+	switch code {
+	case "not_entitled":
+		return "not entitled — run `wt subscribe`"
+	case "entitlement_lapsed":
+		return "entitlement lapsed — renew via `wt subscribe`"
+	case "entitlement_cancelled":
+		return "entitlement cancelled — run `wt subscribe` to re-add"
+	case "entitlement_unknown_status":
+		return "entitlement in unknown state — contact support"
+	default:
+		return code
+	}
+}

--- a/cmd/wt/verify_test.go
+++ b/cmd/wt/verify_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveAccountID_FlagWinsOverEverything(t *testing.T) {
+	t.Setenv("WONDERTWIN_ACCOUNT_ID", "from-env")
+	id, src, err := resolveAccountID("from-flag", "", t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveAccountID: %v", err)
+	}
+	if id != "from-flag" || !strings.Contains(src, "--org") {
+		t.Errorf("got id=%q src=%q", id, src)
+	}
+}
+
+func TestResolveAccountID_AccountAliasIsHonored(t *testing.T) {
+	id, src, err := resolveAccountID("", "from-account", t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveAccountID: %v", err)
+	}
+	if id != "from-account" || !strings.Contains(src, "--account") {
+		t.Errorf("got id=%q src=%q", id, src)
+	}
+}
+
+func TestResolveAccountID_EnvBeatsProjectJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectJSON(t, dir, `{"account_id": "from-project"}`)
+	t.Setenv("WONDERTWIN_ACCOUNT_ID", "from-env")
+	id, src, err := resolveAccountID("", "", dir)
+	if err != nil {
+		t.Fatalf("resolveAccountID: %v", err)
+	}
+	if id != "from-env" || !strings.Contains(src, "WONDERTWIN_ACCOUNT_ID") {
+		t.Errorf("got id=%q src=%q", id, src)
+	}
+}
+
+func TestResolveAccountID_ReadsProjectJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectJSON(t, dir, `{"account_id": "from-project"}`)
+	t.Setenv("WONDERTWIN_ACCOUNT_ID", "")
+	id, src, err := resolveAccountID("", "", dir)
+	if err != nil {
+		t.Fatalf("resolveAccountID: %v", err)
+	}
+	if id != "from-project" || !strings.Contains(src, "project.json") {
+		t.Errorf("got id=%q src=%q", id, src)
+	}
+}
+
+func TestHumanReason_KnownCodes(t *testing.T) {
+	cases := map[string]string{
+		"not_entitled":               "subscribe",
+		"entitlement_lapsed":         "renew",
+		"entitlement_cancelled":      "subscribe",
+		"entitlement_unknown_status": "support",
+	}
+	for code, want := range cases {
+		got := humanReason(code)
+		if !strings.Contains(got, want) {
+			t.Errorf("humanReason(%q) = %q, want it to contain %q", code, got, want)
+		}
+	}
+}
+
+func TestHumanReason_UnknownPassesThroughVerbatim(t *testing.T) {
+	// Forward-compat: server may add codes we don't know yet.
+	got := humanReason("future_unknown_code")
+	if got != "future_unknown_code" {
+		t.Errorf("unknown reason should pass through verbatim, got %q", got)
+	}
+}
+
+func writeProjectJSON(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".wondertwin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".wondertwin", "project.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/internal/platform/entitlements_cover.go
+++ b/internal/platform/entitlements_cover.go
@@ -1,0 +1,92 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// MissingTwin mirrors the server-side billing.MissingTwin (which
+// itself comes from subscriptions.MissingTwin). Wire shape matches.
+// ReasonCode is one of: not_entitled, entitlement_lapsed,
+// entitlement_cancelled, entitlement_unknown_status.
+type MissingTwin struct {
+	TwinName   string `json:"twin_name"`
+	ReasonCode string `json:"reason_code"`
+}
+
+// EntitlementsCoverResponse is the typed return from
+// /v1/accounts/{id}/entitlements/cover. Covered is the list of twin
+// names that are entitled (active / trial / cooling_off / pending);
+// Missing is the per-twin reason record for the rest.
+type EntitlementsCoverResponse struct {
+	Covered []string      `json:"covered"`
+	Missing []MissingTwin `json:"missing"`
+}
+
+// EntitlementsCover queries the server's coverage view for a list of
+// twin names against the given account. Backbone of the `wt verify`
+// CI gate per adr-ci-twin-verification.
+//
+// Returns a Go error only for transport-layer failures (network,
+// non-200 HTTP, malformed JSON). Empty input returns the empty
+// envelope (no server call) — CI tooling with an empty lockfile
+// shouldn't pay for a round-trip.
+func (c *Client) EntitlementsCover(ctx context.Context, accountID string, twins []string) (*EntitlementsCoverResponse, error) {
+	if accountID == "" {
+		return nil, fmt.Errorf("entitlements-cover: accountID is required")
+	}
+	cleaned := dedupeNonEmpty(twins)
+	if len(cleaned) == 0 {
+		return &EntitlementsCoverResponse{Covered: []string{}, Missing: []MissingTwin{}}, nil
+	}
+
+	q := url.Values{}
+	q.Set("twins", strings.Join(cleaned, ","))
+	endpoint := fmt.Sprintf("%s/v1/accounts/%s/entitlements/cover?%s",
+		c.baseURL, url.PathEscape(accountID), q.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("entitlements-cover: create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("entitlements-cover: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("entitlements-cover: HTTP %d: %s", resp.StatusCode, body)
+	}
+	var out EntitlementsCoverResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("entitlements-cover: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// dedupeNonEmpty drops empty strings and duplicates while preserving
+// order. The server is defensive about both, but it's cheap to do
+// here and keeps the URL clean.
+func dedupeNonEmpty(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/platform/entitlements_cover_test.go
+++ b/internal/platform/entitlements_cover_test.go
@@ -1,0 +1,134 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestEntitlementsCover_HappyPath(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/accounts/org_t/entitlements/cover" {
+			t.Errorf("path: got %s", r.URL.Path)
+		}
+		want := "stripe,hubspot"
+		if got := r.URL.Query().Get("twins"); got != want {
+			t.Errorf("twins query: want %q, got %q", want, got)
+		}
+		_ = json.NewEncoder(w).Encode(EntitlementsCoverResponse{
+			Covered: []string{"hubspot", "stripe"},
+			Missing: []MissingTwin{},
+		})
+	})
+
+	got, err := client.EntitlementsCover(context.Background(), "org_t",
+		[]string{"stripe", "hubspot"})
+	if err != nil {
+		t.Fatalf("EntitlementsCover: %v", err)
+	}
+	if len(got.Covered) != 2 || got.Covered[0] != "hubspot" {
+		t.Errorf("covered: got %+v", got.Covered)
+	}
+}
+
+func TestEntitlementsCover_MissingDecodesReasonCodes(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(EntitlementsCoverResponse{
+			Covered: []string{"stripe"},
+			Missing: []MissingTwin{
+				{TwinName: "hubspot", ReasonCode: "not_entitled"},
+				{TwinName: "linear", ReasonCode: "entitlement_cancelled"},
+			},
+		})
+	})
+	got, err := client.EntitlementsCover(context.Background(), "org_t",
+		[]string{"stripe", "hubspot", "linear"})
+	if err != nil {
+		t.Fatalf("EntitlementsCover: %v", err)
+	}
+	if len(got.Missing) != 2 {
+		t.Fatalf("missing count: got %d", len(got.Missing))
+	}
+	if got.Missing[0].ReasonCode != "not_entitled" {
+		t.Errorf("first reason: %s", got.Missing[0].ReasonCode)
+	}
+}
+
+func TestEntitlementsCover_DedupesAndStripsEmpty(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("twins")
+		// Order preserved, dedup'd, no empties.
+		if got != "stripe,hubspot" {
+			t.Errorf("twins query: got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(EntitlementsCoverResponse{
+			Covered: []string{}, Missing: []MissingTwin{},
+		})
+	})
+	_, err := client.EntitlementsCover(context.Background(), "org_t",
+		[]string{"stripe", "", "stripe", " hubspot ", "  "})
+	if err != nil {
+		t.Fatalf("EntitlementsCover: %v", err)
+	}
+}
+
+func TestEntitlementsCover_EmptyTwinsListSkipsServerCall(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called for empty twins list")
+	})
+	got, err := client.EntitlementsCover(context.Background(), "org_t", nil)
+	if err != nil {
+		t.Fatalf("empty input: %v", err)
+	}
+	if len(got.Covered) != 0 || len(got.Missing) != 0 {
+		t.Errorf("empty input: want empty response, got %+v", got)
+	}
+}
+
+func TestEntitlementsCover_HTTP5xxBubbles(t *testing.T) {
+	t.Parallel()
+	_, client := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	_, err := client.EntitlementsCover(context.Background(), "org_t",
+		[]string{"stripe"})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("want HTTP 500 error, got %v", err)
+	}
+}
+
+func TestEntitlementsCover_MissingAccountIDIsClientError(t *testing.T) {
+	t.Parallel()
+	client := New("http://unused", "key")
+	_, err := client.EntitlementsCover(context.Background(), "",
+		[]string{"stripe"})
+	if err == nil || !strings.Contains(err.Error(), "accountID") {
+		t.Errorf("want accountID error, got %v", err)
+	}
+}
+
+func TestEntitlementsCover_AccountIDIsURLEscaped(t *testing.T) {
+	t.Parallel()
+	var seenPath string
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.EscapedPath()
+		_ = json.NewEncoder(w).Encode(EntitlementsCoverResponse{})
+	})
+	// account_id with a space (artificial; the real ones don't, but
+	// the path escaping is defensive).
+	_, err := client.EntitlementsCover(context.Background(),
+		"org with space", []string{"stripe"})
+	if err != nil {
+		t.Fatalf("EntitlementsCover: %v", err)
+	}
+	if !strings.Contains(seenPath, url.PathEscape("org with space")) {
+		t.Errorf("account_id not URL-escaped in path: %s", seenPath)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,109 @@
+// Package project loads the project-scope assertion file
+// `.wondertwin/project.json`. Per adr-ci-twin-verification, this file
+// is the auditable, in-repo declaration of which WonderTwin org a
+// codebase belongs to — `wt verify` and `wt status` use it to bridge
+// between local working state and the org's entitlements API.
+//
+// The file is intentionally narrow: one field today (account_id),
+// room to grow without breaking existing readers. Linters / CI
+// tooling can require the file's presence on repos that need verify;
+// developers experimenting locally without one are unaffected
+// (everything is permissive when project.json is absent).
+package project
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Filename is the relative path of the project scope file inside a
+// repo. Lives under .wondertwin/ alongside future per-project state
+// (cache directories, captured fixtures, etc.).
+const Filename = ".wondertwin/project.json"
+
+// Project is the decoded contents of .wondertwin/project.json.
+// AccountID is the WonderTwin org account ID this codebase belongs
+// to. SourcePath is the absolute path the file was loaded from
+// (informational, used in warning messages).
+type Project struct {
+	AccountID  string `json:"account_id"`
+	SourcePath string `json:"-"`
+}
+
+// Find walks up from startDir looking for the project file. Returns
+// the parsed Project, or (nil, nil) when no file is found — that's a
+// valid state (developer running outside a project-scoped repo);
+// the caller decides whether absence is fatal.
+//
+// The walk stops at the filesystem root or at any directory
+// containing a .git subdirectory — repo boundaries are natural stops
+// because finding a project.json above a repo boundary would be
+// misleading. Errors reading or parsing the file when it IS found
+// are surfaced.
+func Find(startDir string) (*Project, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", startDir, err)
+	}
+
+	for {
+		candidate := filepath.Join(dir, Filename)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return load(candidate)
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("stat %s: %w", candidate, err)
+		}
+
+		// Stop at the repo root (any directory containing .git, file
+		// or dir — covers worktrees and git submodules).
+		if _, gitErr := os.Stat(filepath.Join(dir, ".git")); gitErr == nil {
+			return nil, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root; no project.json on the way up.
+			return nil, nil
+		}
+		dir = parent
+	}
+}
+
+// LoadFile reads and parses the project file at the explicit path.
+// Used by tests and by callers that don't want the auto-walking
+// behavior. Returns (nil, nil) for a missing file so callers can
+// branch on absence cleanly.
+func LoadFile(path string) (*Project, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory, not a file", path)
+	}
+	return load(path)
+}
+
+func load(path string) (*Project, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var p Project
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if p.AccountID == "" {
+		return nil, fmt.Errorf("%s: account_id is required", path)
+	}
+	p.SourcePath = path
+	return &p, nil
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,137 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFind_NoFileReturnsNilNil(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Mark as repo root so Find stops here.
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir"), 0o600); err != nil {
+		t.Fatalf("seed .git: %v", err)
+	}
+	p, err := Find(dir)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p != nil {
+		t.Errorf("want nil project, got %+v", p)
+	}
+}
+
+func TestFind_LoadsFromCurrentDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteProject(t, dir, `{"account_id": "org_acme"}`)
+	p, err := Find(dir)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p == nil || p.AccountID != "org_acme" {
+		t.Errorf("project: got %+v", p)
+	}
+	if !strings.HasSuffix(p.SourcePath, Filename) {
+		t.Errorf("SourcePath should point at the file, got %s", p.SourcePath)
+	}
+}
+
+func TestFind_WalksUpToParentDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWriteProject(t, root, `{"account_id": "org_root"}`)
+	sub := filepath.Join(root, "nested", "deeper")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	p, err := Find(sub)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p == nil || p.AccountID != "org_root" {
+		t.Errorf("walk-up: got %+v", p)
+	}
+}
+
+func TestFind_StopsAtGitRepoRoot(t *testing.T) {
+	t.Parallel()
+	// project.json above the repo root must NOT be picked up — the
+	// .git boundary stops the walk.
+	outside := t.TempDir()
+	mustWriteProject(t, outside, `{"account_id": "org_outside"}`)
+	repo := filepath.Join(outside, "myrepo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	p, err := Find(repo)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p != nil {
+		t.Errorf("walked past .git boundary; got %+v", p)
+	}
+}
+
+func TestFind_RepoRootProjectStillLoads(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	mustWriteProject(t, repo, `{"account_id": "org_repo"}`)
+	p, err := Find(repo)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p == nil || p.AccountID != "org_repo" {
+		t.Errorf("want project at repo root, got %+v", p)
+	}
+}
+
+func TestLoadFile_MissingReturnsNilNil(t *testing.T) {
+	t.Parallel()
+	p, err := LoadFile(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Errorf("missing file: want nil err, got %v", err)
+	}
+	if p != nil {
+		t.Errorf("missing file: want nil project, got %+v", p)
+	}
+}
+
+func TestLoadFile_MalformedJSONErrors(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "project.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := LoadFile(path)
+	if err == nil {
+		t.Fatal("want error on malformed JSON")
+	}
+}
+
+func TestLoadFile_MissingAccountIDErrors(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "project.json")
+	if err := os.WriteFile(path, []byte(`{"unrelated": "field"}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "account_id") {
+		t.Errorf("want account_id required error, got %v", err)
+	}
+}
+
+func mustWriteProject(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".wondertwin"), 0o755); err != nil {
+		t.Fatalf("mkdir .wondertwin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, Filename), []byte(body), 0o600); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Runtime side of [adr-ci-twin-verification](../wondertwin-docs/adrs/adr-ci-twin-verification.md). Server side merged in wondertwin-app PR #105.

- `internal/project` — reads `.wondertwin/project.json`, walks up to the `.git` boundary (worktree- and submodule-safe). Holds `account_id` + source path. Missing file is a valid state.
- `internal/platform.Client.EntitlementsCover` — wraps `GET /v1/accounts/{id}/entitlements/cover?twins=...`. Empty input short-circuits; account_id path-escaped defensively.
- `wt verify` — reads `wondertwin-lock.json`, resolves account from `--org` / `--account` flag → `WONDERTWIN_ACCOUNT_ID` env → `.wondertwin/project.json` → `~/.wondertwin/config.yaml`, calls cover, prints covered vs missing with human-readable reasons.
  - **Exit 0** — all covered
  - **Exit 1** — one or more missing (the CI conversion signal)
  - **Exit 2** — usage / config error
- `wt auth status` — soft warning when local `org_id` ≠ committed `project.json#account_id`, so devs see "this would fail CI" before pushing.
- `.gitignore` — anchor `wt` → `/wt` so the pattern targets the root-level compiled binary, not the `cmd/wt/` source directory (which had been silently swallowing new files in that package).

Forward-compat: unknown reason codes pass through verbatim, same pattern as install outcomes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all green)
- [x] `go vet ./...`
- [x] Lint clean for new packages (preexisting gosec hit on `cmdLogs` `tail -f` is unrelated)
- [ ] Smoke: `wt verify` against staging with seeded lockfile (post-merge in QA env)
- [ ] Follow-up PR: GitHub Action repo (`wondertwin-ai/verify-action`) wrapping this for one-line CI integration