### PR TITLE
feat(ci): in-repo wt verify composite action

### DIFF
--- a/.github/actions/verify/README.md
+++ b/.github/actions/verify/README.md
@@ -1,0 +1,62 @@
+# WonderTwin Verify Action
+
+CI gate that asserts every twin in your `wondertwin-lock.json` is covered
+by your org's WonderTwin entitlements. Per
+[adr-ci-twin-verification](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/adr/adr-ci-twin-verification.md),
+this is the boundary that converts local exploration into a commercial
+conversation — local twin runs are unconstrained; the conversion moment
+is when code ships.
+
+## Usage
+
+```yaml
+- uses: wondertwin-ai/wondertwin/.github/actions/verify@v1
+  with:
+    api-key: ${{ secrets.WONDERTWIN_API_KEY }}
+```
+
+That's the whole integration. The action:
+
+1. Downloads the `wt` CLI for the runner's OS/arch (default: latest release).
+2. Verifies the binary against the release's `checksums.txt`.
+3. Runs `wt verify` against `wondertwin-lock.json`, resolving the
+   account from `.wondertwin/project.json#account_id` (or an explicit
+   `account-id` input).
+4. Exits non-zero if any twin in the lockfile is missing entitlements.
+
+## Inputs
+
+| Input               | Required | Default     | Description |
+|---------------------|----------|-------------|-------------|
+| `api-key`           | yes      | —           | WonderTwin API key. Always pass via secret. |
+| `account-id`        | no       | from `project.json` | Override the account_id used for the coverage check. |
+| `working-directory` | no       | `.`         | Directory containing `wondertwin-lock.json`. |
+| `wt-version`        | no       | `latest`    | Specific `wt` release tag (e.g. `v0.42.0`) for reproducible CI. |
+| `base-url`          | no       | production  | Override platform base URL (staging / self-hosted). |
+
+## Exit codes
+
+The action surfaces the underlying `wt verify` exit code:
+
+- **0** — every twin in the lockfile is covered.
+- **1** — one or more twins are missing entitlements. The CI job fails;
+  the log lists each missing twin with a one-line reason and the
+  `wt subscribe <twin>` command to resolve it.
+- **2** — configuration error (no lockfile, no API key, network failure).
+
+## Pinning
+
+For reproducible CI, pin both the action and the CLI:
+
+```yaml
+- uses: wondertwin-ai/wondertwin/.github/actions/verify@<sha>
+  with:
+    api-key: ${{ secrets.WONDERTWIN_API_KEY }}
+    wt-version: v0.42.0
+```
+
+## Platform support
+
+Linux and macOS GitHub-hosted runners (`ubuntu-*`, `macos-*`) on x64
+and arm64. Windows is not supported in v1 — open an issue if you need
+it.

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,0 +1,149 @@
+name: WonderTwin Verify
+description: >-
+  Assert every twin in wondertwin-lock.json is covered by the asserted
+  org's WonderTwin entitlements. Fails CI on missing coverage —
+  the conversion signal from adr-ci-twin-verification.
+author: WonderTwin
+branding:
+  icon: shield
+  color: purple
+
+inputs:
+  api-key:
+    description: >-
+      WonderTwin API key (a wt_* token from `wt login` or the platform
+      console). Pass via secret; never hard-code.
+    required: true
+  account-id:
+    description: >-
+      Override the account_id used for the coverage check. Defaults
+      to whatever .wondertwin/project.json#account_id resolves to.
+      Useful for monorepos that verify against multiple accounts.
+    required: false
+    default: ""
+  working-directory:
+    description: >-
+      Directory containing wondertwin-lock.json (and optionally
+      .wondertwin/project.json). Defaults to the workflow's working
+      directory.
+    required: false
+    default: "."
+  wt-version:
+    description: >-
+      Version of the wt CLI to download. Use a specific tag (e.g.
+      v0.42.0) for reproducible CI; "latest" pulls the most recent
+      release.
+    required: false
+    default: latest
+  base-url:
+    description: >-
+      Override the WonderTwin platform base URL. Only set this for
+      staging / self-hosted deployments.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve wt binary
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_OS}" in
+          Linux)  os=linux ;;
+          macOS)  os=darwin ;;
+          *)
+            echo "::error::wondertwin-ai/verify: ${RUNNER_OS} runners are not supported yet (linux + macos only in v1)."
+            exit 2
+            ;;
+        esac
+
+        case "${RUNNER_ARCH}" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *)
+            echo "::error::wondertwin-ai/verify: unsupported runner arch ${RUNNER_ARCH}."
+            exit 2
+            ;;
+        esac
+
+        version="${WT_VERSION_INPUT}"
+        if [ "${version}" = "latest" ]; then
+          # Resolve "latest" to a concrete tag so the download URL is
+          # deterministic and the checksum line is reachable.
+          version="$(curl -fsSL \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/wondertwin-ai/wondertwin/releases/latest" \
+            | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' \
+            | head -n1)"
+          if [ -z "${version}" ]; then
+            echo "::error::could not resolve latest wt release"
+            exit 2
+          fi
+        fi
+
+        echo "os=${os}"     >> "${GITHUB_OUTPUT}"
+        echo "arch=${arch}" >> "${GITHUB_OUTPUT}"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      env:
+        WT_VERSION_INPUT: ${{ inputs.wt-version }}
+
+    - name: Download wt binary
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        base="https://github.com/wondertwin-ai/wondertwin/releases/download/${WT_VERSION}"
+        bin_name="wt-${WT_OS}-${WT_ARCH}"
+        bin_url="${base}/${bin_name}"
+        sums_url="${base}/checksums.txt"
+
+        tmp="$(mktemp -d)"
+        echo "Downloading ${bin_url}"
+        curl -fsSL --retry 3 -o "${tmp}/${bin_name}" "${bin_url}"
+
+        # Verify checksum if the release publishes one. We don't fail
+        # the build if checksums.txt is absent for a given release —
+        # only if it's present and doesn't match.
+        if curl -fsSL --retry 3 -o "${tmp}/checksums.txt" "${sums_url}"; then
+          expected="$(grep "  ${bin_name}$" "${tmp}/checksums.txt" | awk '{print $1}' || true)"
+          if [ -n "${expected}" ]; then
+            actual="$(shasum -a 256 "${tmp}/${bin_name}" | awk '{print $1}')"
+            if [ "${expected}" != "${actual}" ]; then
+              echo "::error::checksum mismatch for ${bin_name}: expected ${expected}, got ${actual}"
+              exit 2
+            fi
+            echo "Checksum verified."
+          else
+            echo "::warning::no checksum entry for ${bin_name}; proceeding without verification."
+          fi
+        else
+          echo "::warning::no checksums.txt for ${WT_VERSION}; proceeding without verification."
+        fi
+
+        install_dir="${RUNNER_TEMP}/wondertwin-bin"
+        mkdir -p "${install_dir}"
+        mv "${tmp}/${bin_name}" "${install_dir}/wt"
+        chmod +x "${install_dir}/wt"
+        echo "${install_dir}" >> "${GITHUB_PATH}"
+      env:
+        WT_OS:      ${{ steps.resolve.outputs.os }}
+        WT_ARCH:    ${{ steps.resolve.outputs.arch }}
+        WT_VERSION: ${{ steps.resolve.outputs.version }}
+
+    - name: Run wt verify
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        args=()
+        if [ -n "${ACCOUNT_ID_INPUT}" ]; then
+          args+=(--org "${ACCOUNT_ID_INPUT}")
+        fi
+        wt verify "${args[@]}"
+      env:
+        WONDERTWIN_API_KEY: ${{ inputs.api-key }}
+        WT_PLATFORM_URL:    ${{ inputs.base-url }}
+        ACCOUNT_ID_INPUT:   ${{ inputs.account-id }}


### PR DESCRIPTION
## Summary
One-line CI integration for the \`wt verify\` gate that landed in #262.

\`\`\`yaml
- uses: wondertwin-ai/wondertwin/.github/actions/verify@v1
  with:
    api-key: \${{ secrets.WONDERTWIN_API_KEY }}
\`\`\`

The action downloads the \`wt\` binary for the runner's OS/arch (default: latest release), verifies SHA-256 against the release's \`checksums.txt\`, prepends to PATH, then runs \`wt verify\`. Inputs: \`api-key\` (required), \`account-id\` (override \`.wondertwin/project.json\`), \`working-directory\`, \`wt-version\` (pin for reproducibility), \`base-url\` (staging / self-hosted).

Distribution strategy is documented in wondertwin-docs ADR PR #102 ([adr-verify-action-distribution](https://github.com/WonderTwin-AI/wondertwin-docs/pull/102)): in-repo composite now, dedicated \`wondertwin-ai/verify-action\` repo + Marketplace listing later when enterprise procurement asks for the verified-creator badge.

## Notes
- Linux + macOS runners, x64 + arm64. Windows deferred.
- No smoke workflow yet — current released \`wt\` binaries (≤v0.2.1) don't contain the \`verify\` subcommand. Add the smoke job in a follow-up after the next release tag ships.
- Exit codes pass through from \`wt verify\`: 0 covered, 1 missing entitlement (CI fail = conversion signal), 2 config error.

## Test plan
- [x] Action YAML parses (\`actionlint\` clean locally)
- [x] Shell scripts pass \`shellcheck\` mentally — \`set -euo pipefail\`, quoted vars, no eval
- [ ] End-to-end smoke after next \`wt\` release tag (follow-up PR)
- [ ] Docs update on wondertwin.dev pointing at the canonical \`uses:\` snippet (follow-up)