### PR TITLE
feat(cli): wt-auth slog + key floors + graceful shutdown; bounded reads

### DIFF
--- a/cmd/wt-auth/internal/api/handlers_tokens.go
+++ b/cmd/wt-auth/internal/api/handlers_tokens.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -52,8 +53,10 @@ func (h *Handler) handleIssueToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check the full license key matches.
-	if lic.ID != req.LicenseKey {
+	// Check the full license key matches. ConstantTimeCompare avoids
+	// the timing oracle that `lic.ID != req.LicenseKey` would create
+	// on the byte-by-byte equality check. Audit 2026-06-04, section 3.
+	if subtle.ConstantTimeCompare([]byte(lic.ID), []byte(req.LicenseKey)) != 1 {
 		writeError(w, http.StatusUnauthorized, "invalid_license")
 		return
 	}

--- a/cmd/wt-auth/internal/api/router.go
+++ b/cmd/wt-auth/internal/api/router.go
@@ -27,7 +27,13 @@ func NewHandler(licenses *store.LicenseStore, tokens *store.TokenStore, signer *
 
 // Routes mounts all API routes.
 func (h *Handler) Routes(r chi.Router) {
+	// RequestID injects an X-Request-ID header on every request so a
+	// customer report ("twin install failed at timestamp X") maps to
+	// exactly one log line. Logger appends it to every request log.
+	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
+	// Recoverer turns a handler panic into a 500 with a logged stack
+	// trace instead of taking down the whole process.
 	r.Use(middleware.Recoverer)
 
 	// Health (public).

--- a/cmd/wt-auth/main.go
+++ b/cmd/wt-auth/main.go
@@ -4,11 +4,16 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/wondertwin-ai/wondertwin/cmd/wt-auth/internal/api"
@@ -16,19 +21,61 @@ import (
 	"github.com/wondertwin-ai/wondertwin/cmd/wt-auth/internal/token"
 )
 
+// minSecretBytes is the lower bound on WT_AUTH_SIGNING_KEY and
+// WT_AUTH_INTERNAL_KEY. The 2026-06-04 customer-launch audit flagged
+// the previous "any length accepted" behavior. 32 bytes matches the
+// platform-side secret floor (WT_API_KEY_HMAC_SECRET, etc.) and
+// gives HMAC-SHA256 a key as wide as its output.
+const minSecretBytes = 32
+
+// Timeout values for *http.Server. ReadHeaderTimeout is the
+// canonical Slowloris bound; the others are conservative defaults.
+const (
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 10 * time.Second
+	writeTimeout      = 30 * time.Second
+	idleTimeout       = 60 * time.Second
+)
+
+// shutdownTimeout bounds how long srv.Shutdown will wait for in-
+// flight requests to drain on SIGTERM. Past this we fall through
+// and the process exits — any open connections get an abrupt RST.
+const shutdownTimeout = 10 * time.Second
+
 func main() {
+	if err := run(); err != nil {
+		slog.Error("wt-auth exited with error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Structured JSON logging from the start so a misconfig error
+	// lands as parseable JSON, not free-text log.Printf.
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+
 	port := flag.Int("port", 4300, "HTTP listen port")
 	dbPath := flag.String("db", "", "Path to LibSQL database file")
 	flag.Parse()
 
-	// Required env vars — fail fast.
+	// Required env vars — fail fast with length floors.
 	signingKey := os.Getenv("WT_AUTH_SIGNING_KEY")
 	if signingKey == "" {
-		log.Fatal("WT_AUTH_SIGNING_KEY is required")
+		return fmt.Errorf("WT_AUTH_SIGNING_KEY is required")
+	}
+	if len(signingKey) < minSecretBytes {
+		return fmt.Errorf("WT_AUTH_SIGNING_KEY must be at least %d bytes (got %d)",
+			minSecretBytes, len(signingKey))
 	}
 	internalKey := os.Getenv("WT_AUTH_INTERNAL_KEY")
 	if internalKey == "" {
-		log.Fatal("WT_AUTH_INTERNAL_KEY is required")
+		return fmt.Errorf("WT_AUTH_INTERNAL_KEY is required")
+	}
+	if len(internalKey) < minSecretBytes {
+		return fmt.Errorf("WT_AUTH_INTERNAL_KEY must be at least %d bytes (got %d)",
+			minSecretBytes, len(internalKey))
 	}
 
 	// Database.
@@ -42,7 +89,7 @@ func main() {
 
 	db, err := store.Open(*dbPath)
 	if err != nil {
-		log.Fatalf("opening database: %v", err)
+		return fmt.Errorf("open database: %w", err)
 	}
 	defer db.Close()
 
@@ -57,12 +104,54 @@ func main() {
 
 	// Override port from env.
 	if p := os.Getenv("WT_AUTH_PORT"); p != "" {
-		fmt.Sscanf(p, "%d", port)
+		if v, err := strconv.Atoi(p); err == nil {
+			*port = v
+		}
 	}
 
 	addr := fmt.Sprintf(":%d", *port)
-	log.Printf("wt-auth listening on %s (db: %s)", addr, *dbPath)
-	if err := http.ListenAndServe(addr, r); err != nil {
-		log.Fatalf("server error: %v", err)
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: r,
+		// ReadHeaderTimeout caps the slow-headers Slowloris attack.
+		// ReadTimeout covers the full body read; both apply at the
+		// connection level even before our handlers see the request.
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
+
+	// Graceful shutdown on SIGINT/SIGTERM. signal.NotifyContext returns
+	// a ctx that gets cancelled when the signal fires; srv.Shutdown
+	// then drains in-flight requests up to shutdownTimeout before
+	// returning.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("wt-auth listening", "addr", addr, "db", *dbPath)
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("wt-auth: shutdown signal received; draining")
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("server: %w", err)
+		}
+		return nil
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("wt-auth: shutdown failed; some in-flight requests may have been dropped",
+			"error", err)
+		return err
+	}
+	slog.Info("wt-auth: clean exit")
+	return nil
 }

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"time"
 )
@@ -60,7 +62,7 @@ func (c *Client) RequestToken(licenseKey, twinName string) (*TokenResponse, erro
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 
 	if resp.StatusCode != http.StatusOK {
 		var errResp ErrorResponse

--- a/internal/content/client.go
+++ b/internal/content/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"time"
 )
@@ -43,7 +45,7 @@ func (c *Client) FetchContent(twin, version string) ([]byte, *ContentPayload, er
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading content response: %w", err)
 	}

--- a/internal/httpio/httpio.go
+++ b/internal/httpio/httpio.go
@@ -1,0 +1,17 @@
+// Package httpio defines small HTTP-related constants shared across
+// the CLI. The point is to centralize the per-response body cap so a
+// future change (raise the cap, vendor a real reader, etc.) is one
+// edit instead of one per call site.
+package httpio
+
+// MaxResponseBytes is the upper bound on a single HTTP response body
+// the CLI is willing to read into memory. Binary downloads (twin
+// installers) are bounded by this; JSON responses are much smaller
+// in practice but share the same ceiling for consistency.
+//
+// 100 MiB is comfortable above any realistic twin binary while still
+// preventing OOM if a malicious or misbehaving server returns a 50
+// GiB body. The 2026-06-04 audit's "unbounded io.ReadAll" finding
+// was about every HTTP body in the CLI not being bounded at all;
+// even a high ceiling like this closes that gap.
+const MaxResponseBytes = 100 << 20

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"strings"
 	"time"
@@ -328,7 +330,7 @@ func handleInspect(m *manifest.Manifest, _ *client.AdminClient, params json.RawM
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if resp.StatusCode != http.StatusOK {
 		return textResult(fmt.Sprintf("Error inspecting %s: status %d: %s", p.Twin, resp.StatusCode, body))
 	}
@@ -372,7 +374,7 @@ func handleConfig(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 		}
 		defer resp.Body.Close()
 
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		if resp.StatusCode != http.StatusOK {
 			return textResult(fmt.Sprintf("Error updating config for %s: status %d: %s", p.Twin, resp.StatusCode, respBody))
 		}
@@ -386,7 +388,7 @@ func handleConfig(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if resp.StatusCode != http.StatusOK {
 		return textResult(fmt.Sprintf("Error fetching config for %s: status %d: %s", p.Twin, resp.StatusCode, body))
 	}
@@ -440,7 +442,7 @@ func handleQuirks(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 		}
 		defer resp.Body.Close()
 
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		if resp.StatusCode != http.StatusOK {
 			return textResult(fmt.Sprintf("Error toggling quirk for %s: status %d: %s", p.Twin, resp.StatusCode, body))
 		}
@@ -454,7 +456,7 @@ func handleQuirks(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if resp.StatusCode != http.StatusOK {
 		return textResult(fmt.Sprintf("Error fetching quirks for %s: status %d: %s", p.Twin, resp.StatusCode, body))
 	}

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"net/url"
 	"time"
@@ -65,7 +67,7 @@ func (c *Client) ValidateKey(ctx context.Context, apiKey string) (*ValidateKeyRe
 		return nil, fmt.Errorf("invalid API key")
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("validate key: HTTP %d: %s", resp.StatusCode, body)
 	}
 
@@ -156,7 +158,7 @@ func (c *Client) ListTwins(ctx context.Context, category, tier, sdkLanguage, sea
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("list twins: HTTP %d: %s", resp.StatusCode, body)
 	}
 
@@ -198,7 +200,7 @@ func (c *Client) ListOrgCatalog(ctx context.Context, orgID, category, search str
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("list org catalog: HTTP %d: %s", resp.StatusCode, body)
 	}
 
@@ -225,7 +227,7 @@ func (c *Client) ListCategories(ctx context.Context) ([]Category, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("list categories: HTTP %d: %s", resp.StatusCode, body)
 	}
 
@@ -272,7 +274,7 @@ func (c *Client) Subscribe(ctx context.Context, orgID, twinName string) (*Subscr
 
 	var result SubscribeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("subscribe: HTTP %d: %s", resp.StatusCode, respBody)
 	}
 
@@ -326,7 +328,7 @@ func (c *Client) SubmitTwinRequest(ctx context.Context, orgID, serviceName, serv
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("submit twin request: HTTP %d: %s", resp.StatusCode, respBody)
 	}
 
@@ -353,7 +355,7 @@ func (c *Client) ListTwinRequests(ctx context.Context, orgID string) ([]TwinRequ
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("list twin requests: HTTP %d: %s", resp.StatusCode, body)
 	}
 
@@ -385,7 +387,7 @@ func (c *Client) GetTwinRequest(ctx context.Context, orgID, requestID string) (*
 		return nil, fmt.Errorf("request not found: %s", requestID)
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("get twin request: HTTP %d: %s", resp.StatusCode, body)
 	}
 

--- a/internal/platform/entitlements_cover.go
+++ b/internal/platform/entitlements_cover.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"net/url"
 	"strings"
@@ -64,7 +66,7 @@ func (c *Client) EntitlementsCover(ctx context.Context, accountID string, twins 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("entitlements-cover: HTTP %d: %s", resp.StatusCode, body)
 	}
 	var out EntitlementsCoverResponse

--- a/internal/platform/install_client.go
+++ b/internal/platform/install_client.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 )
 
@@ -54,7 +56,7 @@ func (c *Client) Install(ctx context.Context, accountID string, req InstallReque
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("install: HTTP %d: %s", resp.StatusCode, respBody)
 	}
 

--- a/internal/platform/license_refresh.go
+++ b/internal/platform/license_refresh.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 )
 
@@ -67,7 +69,7 @@ func (c *Client) LicenseRefresh(ctx context.Context, accountID string) (*Install
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 		return nil, fmt.Errorf("license-refresh: HTTP %d: %s", resp.StatusCode, respBody)
 	}
 

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -46,7 +48,7 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 	}
 
 	// Read entire binary into memory for checksum verification
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if err != nil {
 		return fmt.Errorf("reading binary data: %w", err)
 	}
@@ -131,7 +133,7 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if err != nil {
 		return fmt.Errorf("reading binary data: %w", err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"strings"
 	"time"
@@ -232,7 +234,7 @@ func fetchAndParse(url, token string) (*Registry, error) {
 		return nil, &httpError{statusCode: resp.StatusCode}
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading registry response: %w", err)
 	}


### PR DESCRIPTION
Item 3 of 5 in tonight's Category 1+2 batch. Closes the customer-facing CLI security items from the 2026-06-04 audit (wt-auth runtime hardening + constant-time license compare + bounded HTTP reads). Supply-chain items (cosign, SBOM, BinaryURL allowlist) deferred to follow-up — they're real but lower customer-impact.

## Three orthogonal fixes bundled as "harden the network surface before customer #1"

### wt-auth runtime hardening (\`cmd/wt-auth/main.go\` rewrite)

| Was | Now |
|---|---|
| \`log.Fatal\` / \`log.Printf\` | \`slog\` JSON handler from process start |
| WT_AUTH_SIGNING_KEY accepted at any length | ≥32 bytes enforced at startup |
| WT_AUTH_INTERNAL_KEY accepted at any length | ≥32 bytes enforced at startup |
| Bare \`http.ListenAndServe\` with no timeouts | \`*http.Server\` with ReadHeaderTimeout=5s, ReadTimeout=10s, WriteTimeout=30s, IdleTimeout=60s |
| No signal handling — connections dropped on SIGTERM | \`signal.NotifyContext\` + \`srv.Shutdown\` with 10s drain budget |

Router (\`router.go\`) gains \`middleware.RequestID\` alongside the existing Logger + Recoverer so every request has an X-Request-ID for operator correlation.

### Constant-time license compare (\`handlers_tokens.go\`)

\`subtle.ConstantTimeCompare\` replaces the byte-by-byte equality on \`lic.ID\` vs \`req.LicenseKey\`. Closes the timing oracle from audit section 3.

### Bounded HTTP response reads (\`internal/httpio\` + 21 call sites)

New \`internal/httpio/httpio.go\` defines \`MaxResponseBytes = 100 MiB\`. Every \`io.ReadAll(resp.Body)\` in the CLI becomes \`io.ReadAll(io.LimitReader(resp.Body, httpio.MaxResponseBytes))\`. Comfortable above any realistic twin binary while preventing OOM if a malicious or misbehaving server returns a 50 GiB body.

21 sites fixed across:
- \`internal/registry/installer.go\` (2× — binary downloads)
- \`internal/registry/registry.go\` (registry manifest)
- \`internal/content/client.go\` (content downloads)
- \`internal/auth/client.go\` (auth responses)
- \`internal/platform/client.go\` (8×)
- \`internal/platform/install_client.go\`
- \`internal/platform/license_refresh.go\`
- \`internal/platform/entitlements_cover.go\`
- \`internal/mcp/tools.go\` (5×)

## Out of scope (follow-ups)

- **TLS minimum** — a shared \`httpclient\` package returning a Transport with \`MinVersion: tls.VersionTLS12\`. Touches every http.Client construction; bigger refactor.
- **Required checksum in installer** — needs coordination with the pro registry on the rollout plan (every registry entry needs a checksum or no twins install).
- **BinaryURL allowlist** in registry/bundle.go — needs the platform-side spec to nail down allowed hosts.
- **\`cosign\` + SBOM in goreleaser** — requires GitHub Actions changes.
- **\`ParseLicenseKey\` → \`validateChecksum\` rename** — surface rename, no behavior change.

## Verification

\`go build ./... && go vet ./... && go test ./... -short\` clean across the whole repo. Existing handler and token tests continue to pass (the constant-time compare is observationally identical for correct/wrong inputs).