### PR TITLE
fix(installer): bound network downloads with io.LimitReader (F-008)

### DIFF
--- a/internal/registry/install_integration_test.go
+++ b/internal/registry/install_integration_test.go
@@ -3,10 +3,12 @@ package registry
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -164,4 +166,40 @@ func TestIntegrationFetchRegistryFromServer(t *testing.T) {
 	if ver.APIVersion != "2024-12-18" {
 		t.Errorf("api_version = %q, want %q", ver.APIVersion, "2024-12-18")
 	}
+}
+
+// TestInstallFromURL_RejectsOversizedBody asserts that a server streaming a
+// body larger than maxTwinBinarySize is rejected without OOMing the process.
+// Regression test for F-008: bound network downloads with io.LimitReader.
+// Removing the LimitReader wrapper and size check in installer.go would cause
+// this test to allocate >256 MiB and silently succeed instead of erroring.
+func TestInstallFromURL_RejectsOversizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		src := io.LimitReader(zeroReader{}, maxTwinBinarySize+1)
+		if _, err := io.Copy(w, src); err != nil {
+			t.Logf("server copy: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("oversized", "0.0.1", srv.URL+"/twin-oversized", "", dir)
+	if err == nil {
+		t.Fatal("InstallFromURL accepted an oversized body; expected error")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("expected size-exceeded error, got: %v", err)
+	}
+}
+
+// zeroReader emits an unbounded stream of zero bytes. Used only by the
+// oversized-body regression test.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -14,6 +14,14 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/config"
 )
 
+// maxTwinBinarySize bounds in-memory reads of twin binaries during install.
+// 256 MiB is well above any plausible twin (current binaries are <30 MiB)
+// and well below memory-exhaustion territory on developer machines. A
+// malicious or misconfigured registry that streams past this cap is
+// treated as a download failure rather than allowed to OOM the CLI before
+// checksum verification runs.
+const maxTwinBinarySize = 256 << 20 // 256 MiB
+
 // Install downloads a twin binary for the current platform, verifies its
 // checksum, and saves it to binaryDir. It also writes a .version sidecar file.
 func Install(twinName string, resolvedVersion string, ver Version, binaryDir string) error {
@@ -45,10 +53,14 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
 	}
 
-	// Read entire binary into memory for checksum verification
-	data, err := io.ReadAll(resp.Body)
+	// Read entire binary into memory for checksum verification, bounded
+	// by maxTwinBinarySize so a runaway server cannot OOM the CLI.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxTwinBinarySize+1))
 	if err != nil {
 		return fmt.Errorf("reading binary data: %w", err)
+	}
+	if int64(len(data)) > maxTwinBinarySize {
+		return fmt.Errorf("binary exceeds maximum size of %d bytes", maxTwinBinarySize)
 	}
 
 	// Verify checksum
@@ -131,9 +143,13 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	// Bounded read — see Install() for rationale.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxTwinBinarySize+1))
 	if err != nil {
 		return fmt.Errorf("reading binary data: %w", err)
+	}
+	if int64(len(data)) > maxTwinBinarySize {
+		return fmt.Errorf("binary exceeds maximum size of %d bytes", maxTwinBinarySize)
 	}
 
 	// Verify checksum if provided


### PR DESCRIPTION
## Summary

The two `io.ReadAll(resp.Body)` calls in `registry.Install` and `registry.InstallFromURL` were unbounded. A malicious or buggy registry that streams a `content-length=10GB` body OOMs the `wt` CLI **before checksum verification runs** — a supply-chain attack surface.

Wraps both reads with `io.LimitReader(resp.Body, maxTwinBinarySize+1)` and rejects on overflow. **256 MiB cap** (current twin binaries are <30 MiB). In-repo precedent for the pattern already exists at `scenario/v2/runner.go:194`.

## What changed

- `internal/registry/installer.go`
  - New package-level constant `maxTwinBinarySize = 256 << 20`
  - `Install()` and `InstallFromURL()` now use `io.LimitReader` + overflow check
- `internal/registry/install_integration_test.go`
  - New regression test `TestInstallFromURL_RejectsOversizedBody` — streams 256 MiB+1 bytes from an `httptest` server, asserts the install errors with `"exceeds maximum size"`
  - New helper `zeroReader` (test-only) for unbounded streaming without paying the memory cost the fix prevents

## Verification gates run pre-submit (gates 1–2 of 4)

1. ✅ **Build + test + vet.** `go build ./...`, `go vet ./...`, `go test ./internal/registry/...` all clean. Full short suite: 28 packages pass, 0 failures.
2. ✅ **Regression test fails without the fix.** Verified rigorously: when only the runtime size checks are removed (constant kept), the test fails on `"InstallFromURL accepted an oversized body; expected error"` — proving it catches the actual behavioural regression, not just a missing symbol.

Gates 3 (re-scan) and 4 (fresh-eyes re-discovery) belong to **verify** and must run in a fresh Claude session per the harness grader-isolation rule. Do not verify in the session that authored this PR.

## Context

This is the first end-to-end exercise of the WonderTwin security-harness loop. Full proposal and rationale: [`wondertwin-docs/security/harness/patches/F-008.md`](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/security/harness/patches/F-008.md). Registry entry: [`wondertwin-docs/security/known-findings.yaml`](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/security/known-findings.yaml) (search F-008).

## Out of scope (deliberately)

- JSON-body `io.ReadAll` sites in `internal/platform/client.go` (8 sites) and `internal/content/client.go` — tracked separately as **F-031** in the registry. Different cap (64 KiB is reasonable for JSON error envelopes vs. 256 MiB for binaries) and a wider call-site sweep needed.
- **F-007** (checksum required, not optional) — bounding the body does not address checksum bypass. Will be patched independently.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/registry/...` clean
- [x] `go test ./... -short` clean (28 packages pass)
- [x] Regression test verified to fail without the fix
- [ ] After merge: fresh Claude session runs verify (gates 3 + 4) per harness rules