### PR TITLE
fix(go.mod): bump go directive 1.26.3 -> 1.26.4 (stdlib CVEs, unblocks CI)

### DIFF
--- a/docs/TWIN_TEMPLATE/go.mod
+++ b/docs/TWIN_TEMPLATE/go.mod
@@ -1,6 +1,6 @@
 module github.com/wondertwin-ai/wondertwin/twin-TEMPLATE
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wondertwin-ai/wondertwin
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/twinkit/go.mod
+++ b/twinkit/go.mod
@@ -1,5 +1,5 @@
 module github.com/wondertwin-ai/wondertwin/twinkit
 
-go 1.26.3
+go 1.26.4
 
 require github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Summary

Three Go stdlib CVEs are fixed in 1.26.4. All three go.mod files (`./`, `twinkit/`, `docs/TWIN_TEMPLATE/`) still declare `go 1.26.3`, so OSV-Scanner flags them on **every PR** — main and every in-flight PR (#265, #266) is red on the "Dependency vulnerability scan" check.

| CVE | Fixed in |
|---|---|
| [GO-2026-5037](https://osv.dev/GO-2026-5037) | 1.26.4 |
| [GO-2026-5038](https://osv.dev/GO-2026-5038) | 1.26.4 |
| [GO-2026-5039](https://osv.dev/GO-2026-5039) | 1.26.4 |

3 files × 3 CVEs = 9 reported vulnerabilities, all the same root cause.

## What changed

```diff
- go 1.26.3
+ go 1.26.4
```

In all three files. No library deps touched — the fix is entirely in the stdlib.

## Why one PR, not bundled into #266

Toolchain hygiene is its own concern. Bundling it into the F-008 fix would obscure the review and make rollback of either independently messier. Discovering this finding via #266's failed CI is exactly the kind of thing the harness should surface as its own registry entry (will track as **F-032** in a follow-up docs PR).

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./internal/registry/...` ✅
- Local toolchain: `go version go1.26.4 darwin/arm64`
- CI uses `go-version-file: go.mod` so the runner will pull 1.26.4 automatically

## After this merges

- #265 and #266 will need a rebase to pick up the bump (or just retry CI — main will be green and PRs should auto-merge main).

## Test plan

- [ ] CI green (build-and-test, Security workflow including OSV-Scanner)
- [ ] OSV CVE table is empty in the Security workflow output