### PR TITLE
feat(installer): F-007 Phase A — soft-WARN on missing checksum + strict opt-in

### DIFF
--- a/internal/registry/install_integration_test.go
+++ b/internal/registry/install_integration_test.go
@@ -170,6 +170,100 @@ func TestIntegrationFetchRegistryFromServer(t *testing.T) {
 	}
 }
 
+// TestInstallFromURL_SoftWarnsWhenChecksumMissing is F-007 Phase A
+// regression coverage for the WARN tripwire. Default behaviour without
+// the strict-checksum opt-in: install proceeds (no break for users
+// pre-flip) but writes a loud WARN line to stderr so the publisher
+// surfaces a missing checksum during the rollout release.
+//
+// Removing the warnMissingChecksum call would let an unchecksummed
+// install slip through silently — exactly the F-007 bug.
+func TestInstallFromURL_SoftWarnsWhenChecksumMissing(t *testing.T) {
+	t.Setenv("WT_STRICT_CHECKSUMS", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("twin binary"))
+	}))
+	defer srv.Close()
+
+	stderr := captureStderr(t, func() {
+		dir := t.TempDir()
+		if err := InstallFromURL("warntest", "0.1.0", srv.URL+"/twin-warntest", "", dir); err != nil {
+			t.Fatalf("InstallFromURL: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "WARN") || !strings.Contains(stderr, "no checksum") || !strings.Contains(stderr, "F-007") {
+		t.Errorf("expected WARN about missing checksum + F-007 reference; got: %q", stderr)
+	}
+}
+
+// TestInstallFromURL_StrictModeRejectsMissingChecksum is the Phase B
+// preview: when the operator opts in to strict mode now, missing
+// checksums hard-fail. This proves the next-release flip is a config
+// change, not a code change.
+func TestInstallFromURL_StrictModeRejectsMissingChecksum(t *testing.T) {
+	t.Setenv("WT_STRICT_CHECKSUMS", "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("twin binary"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := InstallFromURL("stricttest", "0.1.0", srv.URL+"/twin-stricttest", "", dir)
+	if err == nil {
+		t.Fatal("expected install to be rejected under strict checksum mode")
+	}
+	if !strings.Contains(err.Error(), "strict-checksum") || !strings.Contains(err.Error(), "no checksum") {
+		t.Errorf("expected error mentioning strict-checksum + missing checksum; got: %v", err)
+	}
+}
+
+// TestInstallFromURL_StrictModeWithChecksumStillVerifies guards the
+// "happy path still works" case under strict mode — checksum present
+// and valid → install proceeds.
+func TestInstallFromURL_StrictModeWithChecksumStillVerifies(t *testing.T) {
+	t.Setenv("WT_STRICT_CHECKSUMS", "1")
+
+	content := []byte("twin binary with valid checksum")
+	checksum := fmt.Sprintf("sha256:%x", sha256.Sum256(content))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(content)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if err := InstallFromURL("happytest", "0.1.0", srv.URL+"/twin-happytest", checksum, dir); err != nil {
+		t.Fatalf("install with valid checksum under strict mode should succeed: %v", err)
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns
+// what was written. Used by the F-007 WARN-emission test.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = orig })
+
+	done := make(chan string, 1)
+	go func() {
+		var buf [4096]byte
+		n, _ := r.Read(buf[:])
+		done <- string(buf[:n])
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
 // TestInstallFromURL_RejectsOversizedBody asserts that a server streaming a
 // body larger than httpio.MaxResponseBytes is rejected without OOMing the process.
 // Regression test for F-008: bound network downloads with io.LimitReader.

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -15,6 +15,32 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 )
 
+// strictChecksumsEnvVar opts a CLI into Phase B behavior: reject installs
+// without a checksum, instead of the Phase A default (soft-WARN to stderr,
+// install proceeds). The next release flips the default to strict and
+// removes this opt-in. F-007 in wondertwin-docs/security/known-findings.yaml;
+// design in wondertwin-docs/adr/adr-twin-binary-trust-model.md.
+const strictChecksumsEnvVar = "WT_STRICT_CHECKSUMS"
+
+// requireChecksum returns true when the operator has opted into hard-fail
+// on missing checksums via the strictChecksumsEnvVar. Phase A default is
+// false (soft-WARN). The next release cycle flips the default.
+func requireChecksum() bool {
+	v := os.Getenv(strictChecksumsEnvVar)
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// warnMissingChecksum writes the loud-WARN line for Phase A's soft-WARN
+// path. Centralised so the message stays consistent across Install() and
+// InstallFromURL() and so a single test can assert the tripwire fired.
+func warnMissingChecksum(twinName, version, source string) {
+	fmt.Fprintf(os.Stderr,
+		"  WARN: no checksum for twin-%s v%s from %s; install will be rejected once strict-checksum default ships (F-007). "+
+			"Verify the registry/lockfile has a sha256 entry for this platform.\n",
+		twinName, version, source,
+	)
+}
+
 // Install downloads a twin binary for the current platform, verifies its
 // checksum, and saves it to binaryDir. It also writes a .version sidecar file.
 func Install(twinName string, resolvedVersion string, ver Version, binaryDir string) error {
@@ -59,13 +85,24 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 		return fmt.Errorf("binary exceeds maximum size of %d bytes", httpio.MaxResponseBytes)
 	}
 
-	// Verify checksum
+	// Verify checksum. Phase A of F-007 closure: when no checksum is
+	// provided we either soft-WARN (default) or hard-fail (operator opts
+	// in via WT_STRICT_CHECKSUMS). The registry-side validator
+	// (cmd/verify-registry) already enforces that every published version
+	// carries checksums for every platform; this is the CLI tripwire
+	// against a malformed registry slipping through.
 	if hasChecksum {
 		fmt.Printf("  Verifying checksum...\n")
 		actual := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 		if actual != expectedChecksum {
 			return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actual)
 		}
+	} else if requireChecksum() {
+		return fmt.Errorf("install rejected: no checksum for twin-%s v%s (%s); "+
+			"strict-checksum mode is enabled via %s. Re-publish the registry entry with sha256 checksums",
+			twinName, resolvedVersion, platform, strictChecksumsEnvVar)
+	} else {
+		warnMissingChecksum(twinName, resolvedVersion, "registry")
 	}
 
 	// Write binary to disk
@@ -148,12 +185,22 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 		return fmt.Errorf("binary exceeds maximum size of %d bytes", httpio.MaxResponseBytes)
 	}
 
-	// Verify checksum if provided
+	// Verify checksum. F-007 Phase A — see Install() for full rationale.
+	// InstallFromURL is the lockfile path; missing checksums here mean
+	// the lockfile was generated against an unchecksummed registry entry,
+	// which the registry-side validator should not allow but the CLI
+	// still defends against.
 	if expectedChecksum != "" {
 		actual := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 		if actual != expectedChecksum {
 			return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actual)
 		}
+	} else if requireChecksum() {
+		return fmt.Errorf("install rejected: no checksum for twin-%s v%s; "+
+			"strict-checksum mode is enabled via %s. Re-generate the lockfile against a registry with checksums",
+			twinName, version, strictChecksumsEnvVar)
+	} else {
+		warnMissingChecksum(twinName, version, "lockfile")
 	}
 
 	binaryPath := filepath.Join(binaryDir, "twin-"+twinName)


### PR DESCRIPTION
## Summary

Implements **Phase A** of the [binary-trust ADR](https://github.com/WonderTwin-AI/wondertwin-docs/blob/main/adr/adr-twin-binary-trust-model.md). Closes F-007 in the security-harness registry.

## What changed

When an install runs without a registry-supplied checksum, the CLI now:
- **Default (Phase A):** writes a loud WARN to stderr referencing F-007 and the strict-checksum opt-in. Install proceeds — users don't break mid-rollout.
- **\`WT_STRICT_CHECKSUMS=1\`:** install is rejected with a clear error pointing at the registry-entry fix.

The next release cycle will flip the default to strict (one-line change) and remove the opt-in.

## Why this matters

F-007 is closed because **there is no longer a silent-skip path**:
- Checksum present + valid → install proceeds (existing behavior)
- Checksum missing + default mode → WARN to stderr, install proceeds, publisher sees the gap
- Checksum missing + strict mode → hard fail with actionable error

The registry-side validator (\`cmd/verify-registry\`) already enforces that every published version carries checksums for every platform. This PR closes the CLI side so a malformed registry slipping through is caught at install time.

## Scope

- \`internal/registry/installer.go\`: \`requireChecksum()\` + \`warnMissingChecksum()\` helpers; \`Install()\` and \`InstallFromURL()\` use them on the no-checksum branch.
- \`internal/registry/install_integration_test.go\`: 3 new tests with \`captureStderr\` helper:
  - \`TestInstallFromURL_SoftWarnsWhenChecksumMissing\` — asserts WARN line + completion
  - \`TestInstallFromURL_StrictModeRejectsMissingChecksum\` — strict + missing = hard fail
  - \`TestInstallFromURL_StrictModeWithChecksumStillVerifies\` — strict + valid = happy path

## Out of scope (deliberate next steps)

- **Flip default to strict** — next release cycle, per ADR §3 rollout. Simple config change.
- **Phase B (signed registry manifest)** — separate ADR and PR cycle.

## Verified

- \`go build + vet\` clean
- Full short suite: **26 packages pass, 0 failures**
- 3 new tests pass

## Test plan

- [x] go build/vet clean
- [x] new tests pass
- [x] full short suite green
- [ ] CI green