### PR TITLE
fix(installer): flip strict-checksum default; env becomes opt-out (v0.2.1-5.4)

### DIFF
--- a/internal/registry/install_integration_test.go
+++ b/internal/registry/install_integration_test.go
@@ -106,28 +106,29 @@ func TestIntegrationInstallFromURLHTTPError(t *testing.T) {
 	}
 }
 
-// TestIntegrationInstallNoChecksum verifies install works without a checksum.
+// TestIntegrationInstallNoChecksum verifies the Phase B strict-by-default
+// behavior: with no checksum and no opt-out, the install is rejected.
+// Pre-Phase B this test asserted the install succeeded; flipped per F-007.
 func TestIntegrationInstallNoChecksum(t *testing.T) {
-	binaryContent := []byte("twin binary no checksum")
+	t.Setenv("WT_STRICT_CHECKSUMS", "")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(binaryContent)
+		w.Write([]byte("twin binary no checksum"))
 	}))
 	defer srv.Close()
 
 	dir := t.TempDir()
 
 	err := InstallFromURL("test", "0.1.0", srv.URL+"/twin-test", "", dir)
-	if err != nil {
-		t.Fatalf("InstallFromURL without checksum: %v", err)
+	if err == nil {
+		t.Fatal("expected install to be rejected under strict-by-default mode")
+	}
+	if !strings.Contains(err.Error(), "sunsets in v0.3") || !strings.Contains(err.Error(), "no expected_sha256") {
+		t.Errorf("expected error mentioning sunset + missing expected_sha256; got: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "twin-test"))
-	if err != nil {
-		t.Fatalf("reading binary: %v", err)
-	}
-	if string(data) != string(binaryContent) {
-		t.Error("binary content mismatch")
+	if _, statErr := os.Stat(filepath.Join(dir, "twin-test")); statErr == nil {
+		t.Error("binary should not exist after strict-checksum rejection")
 	}
 }
 
@@ -170,16 +171,17 @@ func TestIntegrationFetchRegistryFromServer(t *testing.T) {
 	}
 }
 
-// TestInstallFromURL_SoftWarnsWhenChecksumMissing is F-007 Phase A
-// regression coverage for the WARN tripwire. Default behaviour without
-// the strict-checksum opt-in: install proceeds (no break for users
-// pre-flip) but writes a loud WARN line to stderr so the publisher
-// surfaces a missing checksum during the rollout release.
+// TestInstallFromURL_SoftWarnsWhenOptOut is F-007 Phase B coverage for
+// the WARN tripwire on the temporary opt-out path. With
+// WT_STRICT_CHECKSUMS=0 the install proceeds but writes a loud WARN line
+// to stderr referencing the v0.3 sunset, so operators relying on the
+// opt-out get a steady reminder it's going away.
 //
-// Removing the warnMissingChecksum call would let an unchecksummed
-// install slip through silently — exactly the F-007 bug.
-func TestInstallFromURL_SoftWarnsWhenChecksumMissing(t *testing.T) {
-	t.Setenv("WT_STRICT_CHECKSUMS", "")
+// Removing the warnMissingChecksum call on the opt-out branch would let
+// an unchecksummed install slip through silently — exactly the F-007 bug
+// that Phase B exists to retire.
+func TestInstallFromURL_SoftWarnsWhenOptOut(t *testing.T) {
+	t.Setenv("WT_STRICT_CHECKSUMS", "0")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("twin binary"))
@@ -189,19 +191,22 @@ func TestInstallFromURL_SoftWarnsWhenChecksumMissing(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		dir := t.TempDir()
 		if err := InstallFromURL("warntest", "0.1.0", srv.URL+"/twin-warntest", "", dir); err != nil {
-			t.Fatalf("InstallFromURL: %v", err)
+			t.Fatalf("InstallFromURL with opt-out: %v", err)
 		}
 	})
 
 	if !strings.Contains(stderr, "WARN") || !strings.Contains(stderr, "no checksum") || !strings.Contains(stderr, "F-007") {
 		t.Errorf("expected WARN about missing checksum + F-007 reference; got: %q", stderr)
 	}
+	if !strings.Contains(stderr, "v0.3") {
+		t.Errorf("expected WARN to mention v0.3 sunset; got: %q", stderr)
+	}
 }
 
-// TestInstallFromURL_StrictModeRejectsMissingChecksum is the Phase B
-// preview: when the operator opts in to strict mode now, missing
-// checksums hard-fail. This proves the next-release flip is a config
-// change, not a code change.
+// TestInstallFromURL_StrictModeRejectsMissingChecksum verifies that
+// the explicit strict signal (WT_STRICT_CHECKSUMS=1) keeps rejecting
+// missing checksums under the Phase B regime — anything in the env that
+// is not literal "0" must land in the strict bucket.
 func TestInstallFromURL_StrictModeRejectsMissingChecksum(t *testing.T) {
 	t.Setenv("WT_STRICT_CHECKSUMS", "1")
 
@@ -215,8 +220,8 @@ func TestInstallFromURL_StrictModeRejectsMissingChecksum(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected install to be rejected under strict checksum mode")
 	}
-	if !strings.Contains(err.Error(), "strict-checksum") || !strings.Contains(err.Error(), "no checksum") {
-		t.Errorf("expected error mentioning strict-checksum + missing checksum; got: %v", err)
+	if !strings.Contains(err.Error(), "no expected_sha256") || !strings.Contains(err.Error(), "sunsets in v0.3") {
+		t.Errorf("expected error mentioning missing expected_sha256 + v0.3 sunset; got: %v", err)
 	}
 }
 

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -15,28 +15,29 @@ import (
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 )
 
-// strictChecksumsEnvVar opts a CLI into Phase B behavior: reject installs
-// without a checksum, instead of the Phase A default (soft-WARN to stderr,
-// install proceeds). The next release flips the default to strict and
-// removes this opt-in. F-007 in wondertwin-docs/security/known-findings.yaml;
-// design in wondertwin-docs/adr/adr-twin-binary-trust-model.md.
+// strictChecksumsEnvVar is the F-007 Phase B escape hatch: setting it to
+// "0" opts a CLI OUT of the new strict default (which rejects installs
+// when the registry entry has no expected_sha256). Any other value, or
+// unset, keeps the strict default. The opt-out sunsets in v0.3.
+// F-007 in wondertwin-docs/security/known-findings.yaml; design in
+// wondertwin-docs/adr/adr-twin-binary-trust-model.md.
 const strictChecksumsEnvVar = "WT_STRICT_CHECKSUMS"
 
-// requireChecksum returns true when the operator has opted into hard-fail
-// on missing checksums via the strictChecksumsEnvVar. Phase A default is
-// false (soft-WARN). The next release cycle flips the default.
+// requireChecksum returns true when missing checksums must hard-fail.
+// Phase B default is strict; only the literal "0" opts out into legacy
+// soft-WARN behavior. The opt-out sunsets in v0.3.
 func requireChecksum() bool {
-	v := os.Getenv(strictChecksumsEnvVar)
-	return v == "1" || strings.EqualFold(v, "true")
+	return os.Getenv(strictChecksumsEnvVar) != "0"
 }
 
-// warnMissingChecksum writes the loud-WARN line for Phase A's soft-WARN
-// path. Centralised so the message stays consistent across Install() and
-// InstallFromURL() and so a single test can assert the tripwire fired.
+// warnMissingChecksum writes the loud-WARN line for the opt-out path
+// (WT_STRICT_CHECKSUMS=0). Centralised so the message stays consistent
+// across Install() and InstallFromURL() and so a single test can assert
+// the tripwire fired.
 func warnMissingChecksum(twinName, version, source string) {
 	fmt.Fprintf(os.Stderr,
-		"  WARN: no checksum for twin-%s v%s from %s; install will be rejected once strict-checksum default ships (F-007). "+
-			"Verify the registry/lockfile has a sha256 entry for this platform.\n",
+		"  WARN: no checksum for twin-%s v%s from %s; WT_STRICT_CHECKSUMS=0 opt-out is deprecated and sunsets in v0.3 (F-007). "+
+			"Re-publish the registry/lockfile with a sha256 entry for this platform.\n",
 		twinName, version, source,
 	)
 }
@@ -85,12 +86,12 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 		return fmt.Errorf("binary exceeds maximum size of %d bytes", httpio.MaxResponseBytes)
 	}
 
-	// Verify checksum. Phase A of F-007 closure: when no checksum is
-	// provided we either soft-WARN (default) or hard-fail (operator opts
-	// in via WT_STRICT_CHECKSUMS). The registry-side validator
-	// (cmd/verify-registry) already enforces that every published version
-	// carries checksums for every platform; this is the CLI tripwire
-	// against a malformed registry slipping through.
+	// Verify checksum. Phase B of F-007 closure: strict-by-default. When
+	// no checksum is provided we hard-fail unless the operator has opted
+	// out via WT_STRICT_CHECKSUMS=0 (sunsets in v0.3). The registry-side
+	// validator (cmd/verify-registry) already enforces that every
+	// published version carries checksums for every platform; this is
+	// the CLI tripwire against a malformed registry slipping through.
 	if hasChecksum {
 		fmt.Printf("  Verifying checksum...\n")
 		actual := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
@@ -98,8 +99,8 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 			return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actual)
 		}
 	} else if requireChecksum() {
-		return fmt.Errorf("install rejected: no checksum for twin-%s v%s (%s); "+
-			"strict-checksum mode is enabled via %s. Re-publish the registry entry with sha256 checksums",
+		return fmt.Errorf("install rejected: no expected_sha256 in registry entry for twin-%s v%s (%s); "+
+			"set %s=0 to bypass for now (escape hatch sunsets in v0.3 — re-publish the registry entry with a SHA256 before then)",
 			twinName, resolvedVersion, platform, strictChecksumsEnvVar)
 	} else {
 		warnMissingChecksum(twinName, resolvedVersion, "registry")
@@ -185,7 +186,7 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 		return fmt.Errorf("binary exceeds maximum size of %d bytes", httpio.MaxResponseBytes)
 	}
 
-	// Verify checksum. F-007 Phase A — see Install() for full rationale.
+	// Verify checksum. F-007 Phase B — see Install() for full rationale.
 	// InstallFromURL is the lockfile path; missing checksums here mean
 	// the lockfile was generated against an unchecksummed registry entry,
 	// which the registry-side validator should not allow but the CLI
@@ -196,8 +197,8 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 			return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actual)
 		}
 	} else if requireChecksum() {
-		return fmt.Errorf("install rejected: no checksum for twin-%s v%s; "+
-			"strict-checksum mode is enabled via %s. Re-generate the lockfile against a registry with checksums",
+		return fmt.Errorf("install rejected: no expected_sha256 in lockfile entry for twin-%s v%s; "+
+			"set %s=0 to bypass for now (escape hatch sunsets in v0.3 — re-generate the lockfile against a registry with a SHA256 before then)",
 			twinName, version, strictChecksumsEnvVar)
 	} else {
 		warnMissingChecksum(twinName, version, "lockfile")

--- a/internal/registry/installer_test.go
+++ b/internal/registry/installer_test.go
@@ -64,7 +64,13 @@ func TestInstallFromURLChecksumMismatch(t *testing.T) {
 	}
 }
 
+// TestInstallFromURLNoChecksum asserts the Phase B strict-by-default
+// behavior: with WT_STRICT_CHECKSUMS unset, a missing checksum hard-fails
+// and no binary is written. The pre-Phase-B version of this test asserted
+// the opposite (install succeeds) — flipped here per F-007 closure.
 func TestInstallFromURLNoChecksum(t *testing.T) {
+	t.Setenv("WT_STRICT_CHECKSUMS", "")
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("binary content"))
 	}))
@@ -72,13 +78,13 @@ func TestInstallFromURLNoChecksum(t *testing.T) {
 
 	dir := t.TempDir()
 	err := InstallFromURL("stripe", "0.1.0", srv.URL+"/twin-stripe", "", dir)
-	if err != nil {
-		t.Fatalf("InstallFromURL without checksum: %v", err)
+	if err == nil {
+		t.Fatal("expected install to be rejected under strict-by-default mode")
 	}
 
 	binaryPath := filepath.Join(dir, "twin-stripe")
-	if _, err := os.Stat(binaryPath); err != nil {
-		t.Fatalf("binary not found: %v", err)
+	if _, statErr := os.Stat(binaryPath); statErr == nil {
+		t.Error("binary should not exist after strict-checksum rejection")
 	}
 }
 


### PR DESCRIPTION
## Summary

Flips the CLI installer's `WT_STRICT_CHECKSUMS` semantics: default is now strict (reject installs with missing checksum), opt-out via `WT_STRICT_CHECKSUMS=0`. This is Phase B of the 06-04→06-10 hardening; Phase A (commit `a7e2e89`) added the opt-in strict mode.

## Consolidated doc reference

Closes item **5.4** in `wondertwin-docs/v0.2.1-consolidated-priorities-2026-06-10.md` per D4-Option-1 in that doc's frontmatter. Completes F-007 closure trajectory.

## Rationale

Phase A's soft-WARN-by-default plus opt-in strict was the safe-rollout step. Phase B flips the default. The `WT_STRICT_CHECKSUMS=0` escape hatch carries an explicit v0.3 sunset in error messages so unchecked-checksum installers have a re-publish window.

## What changed

- `internal/registry/installer.go`: `requireChecksum()` returns `os.Getenv(strictChecksumsEnvVar) != "0"` (was `== "1" || EqualFold("true")`).
- Both call sites (`Install()` line 103 and `InstallFromURL()` line 201) now strict-by-default.
- Strict-fail error includes the sunset-in-v0.3 language.

## Verification

- `go test ./internal/registry/...` clean.
- 3 tests flipped from "succeeds with missing checksum" → "rejected under strict-default."
- 1 test repurposed to verify the `WT_STRICT_CHECKSUMS=0` opt-out + soft-warn behavior.
- `go build ./... && go vet ./...` clean.