### PR TITLE
fix(cli): wrap main() with defer recover() to avoid raw panic exit (v0.2.1-5.8)

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -34,11 +34,13 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -84,6 +86,16 @@ func resolveManifestPath(path string) string {
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("wt: unrecovered panic",
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+			os.Exit(1)
+		}
+	}()
+
 	cmd, args, manifestPath := parseArgs()
 	manifestPath = resolveManifestPath(manifestPath)
 


### PR DESCRIPTION
## Summary

Wraps `cmd/wt/main.go` `main()` with a deferred `recover()` block that logs the panic + stack via slog and exits with status 1.

## Consolidated doc reference

Closes item **5.8** in `wondertwin-docs/v0.2.1-consolidated-priorities-2026-06-10.md`.

## Rationale

A nil-pointer deref anywhere in wt's call graph would crash with the raw runtime stack trace to stderr. Wrap turns silent panic into a structured log line for operators debugging at 2am. The `run()` helper refactor (deferred §3.4) is out of scope for this PR.

## What changed

- `cmd/wt/main.go`: +12 / -0. Added `log/slog` and `runtime/debug` imports; deferred recover block as the first statement in `main()`.

## Verification

- `go build ./... && go test ./... && go vet ./...` all clean.
- Static grep: `recover()`, `debug.Stack`, `os.Exit(1)` all live in the same defer block at the top of `main()`.