### PR TITLE
fix(twincore): add ReadHeaderTimeout to shared twin HTTP server (v0.2.1-5.13)

### DIFF
--- a/twinkit/twincore/server.go
+++ b/twinkit/twincore/server.go
@@ -200,12 +200,13 @@ func (t *Twin) Serve() error {
 	addr := fmt.Sprintf(":%d", t.Config.Port)
 
 	srv := &http.Server{
-		Addr:           addr,
-		Handler:        http.MaxBytesHandler(t.Router, 10<<20), // 10MB request body limit
-		ReadTimeout:    30 * time.Second,
-		WriteTimeout:   30 * time.Second,
-		IdleTimeout:    60 * time.Second,
-		MaxHeaderBytes: 1 << 20, // 1MB max header
+		Addr:              addr,
+		Handler:           http.MaxBytesHandler(t.Router, 10<<20), // 10MB request body limit
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1MB max header
 	}
 
 	// Graceful shutdown


### PR DESCRIPTION
## Summary

Adds `ReadHeaderTimeout: 5 * time.Second` to the shared `*http.Server` in `twinkit/twincore/server.go`. Affects every twin binary in the fleet.

## Consolidated doc reference

Closes item **5.13** in `wondertwin-docs/v0.2.1-consolidated-priorities-2026-06-10.md`.

## Rationale

The shared HTTP server had `Read/Write/Idle` timeouts but was missing `ReadHeaderTimeout` — the RFC-correct knob for header-trickle (Slowloris) attacks. Without it, header-only attacks are bounded only by `ReadTimeout`.

## What changed

- `twinkit/twincore/server.go`: +1 field (`ReadHeaderTimeout: 5 * time.Second`), positioned adjacent to other timeouts; gofmt re-spaced field values (+7 / -6 net for alignment).
- `time` already imported.

## Verification

- Full sweep across both modules (root + `twinkit/`): `go build`, `go vet`, `go test` clean in both.
- One pre-existing unrelated failure was confirmed on `origin/main` too: `twinkit/admin/TestHandleListQuirksNilStore` — already tracked as issue #248.