### PR TITLE
refactor(config): rename ParseLicenseKey to ValidateChecksum (v0.2.1-1.6)

### DIFF
--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -1412,7 +1412,7 @@ func cmdAuthLogin() error {
 		return fmt.Errorf("no license key provided")
 	}
 
-	info := config.ParseLicenseKey(key)
+	info := config.ValidateChecksum(key)
 	if info == nil {
 		return fmt.Errorf("invalid license key format")
 	}
@@ -1454,7 +1454,7 @@ func cmdAuthStatus() error {
 		return nil
 	}
 
-	info := config.ParseLicenseKey(cfg.LicenseKey)
+	info := config.ValidateChecksum(cfg.LicenseKey)
 	if info == nil {
 		fmt.Println("Tier: free (invalid license key)")
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 // LicenseInfo holds parsed fields from a license key in the
 // wt_{tier}_{org}_{random}_{check} format.
 //
-// IMPORTANT: this type and ParseLicenseKey predate the current production
+// IMPORTANT: this type and ValidateChecksum predate the current production
 // auth model. The real production flow uses org-context login
 // (cfg.OrgSlug + cfg.OrgID + cfg.APIKey via `wt login --org <slug>`),
 // and pro-twin licensing is the ed25519-signed JSON at
@@ -201,9 +201,9 @@ func Save(cfg *Config) error {
 	return nil
 }
 
-// ParseLicenseKey parses a license key of the format wt_{tier}_{org}_{random}_{check}.
+// ValidateChecksum parses a license key of the format wt_{tier}_{org}_{random}_{check}.
 // Returns nil if the key is empty or invalid.
-func ParseLicenseKey(key string) *LicenseInfo {
+func ValidateChecksum(key string) *LicenseInfo {
 	if key == "" {
 		return nil
 	}
@@ -259,7 +259,7 @@ func ParseLicenseKey(key string) *LicenseInfo {
 
 // HasValidLicense returns true if the config has a parseable license key.
 func (c *Config) HasValidLicense() bool {
-	return ParseLicenseKey(c.LicenseKey) != nil
+	return ValidateChecksum(c.LicenseKey) != nil
 }
 
 // HasOrgContext returns true if the config has stored org credentials.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,10 +214,10 @@ func TestOrgContextRoundTrip(t *testing.T) {
 	}
 }
 
-func TestParseLicenseKey(t *testing.T) {
+func TestValidateChecksum(t *testing.T) {
 	// Compute a valid checksum for the key "wt_com_acme_abcdef"
 	// payload bytes sum = 1842, 1842 % 256 = 50 = 0x32
-	info := ParseLicenseKey("wt_com_acme_abcdef_32")
+	info := ValidateChecksum("wt_com_acme_abcdef_32")
 	if info == nil {
 		t.Fatal("expected non-nil LicenseInfo")
 	}


### PR DESCRIPTION
## Summary

Renames `config.ParseLicenseKey` → `config.ValidateChecksum` to match what the function actually does — validates a 2-byte XOR checksum on the dead `wt_<tier>_<org>_<random>_<check>` string format, not license parsing.

## Consolidated doc reference

Closes item **1.6** in `wondertwin-docs/v0.2.1-consolidated-priorities-2026-06-10.md`. Completes F-004 closure: the SECURITY doc comment (commit `07580a8`) closed the docstring half; this PR aligns the function name with the semantics.

## Rationale

A function named `ParseLicenseKey` implies cryptographic license verification. It's a checksum check on a dead string format. The misleading name is itself a security smell — operators reading the code shouldn't have to read the docstring to know what the function does.

## What changed

- `internal/config/config.go`: function rename + SECURITY doc comment now references the new name.
- `cmd/wt/main.go`: 2 callers updated (`cmdAuthLicense` line 1415, `cmdAuthStatus` line 1457).
- `internal/config/config_test.go`: test body + `TestParseLicenseKey` → `TestValidateChecksum`.

Exported (capital `V`) because callers live in `cmd/wt/` outside the `config` package.

## Verification

- `git grep ParseLicenseKey` → 0 hits in source (a stale local build artifact matched, ignored).
- `go build ./... && go test ./... && go vet ./...` all clean.