### PR TITLE
fix(installer): allowlist BinaryURL host + require https (v0.2.1-5.5)

### DIFF
--- a/internal/registry/bundle.go
+++ b/internal/registry/bundle.go
@@ -3,9 +3,52 @@ package registry
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 )
+
+// allowedBinaryURLHosts is the closed set of hosts CommitInstallBundle
+// will fetch a twin binary from. BinaryURL is server-supplied (the MCP
+// registry returns it in the install envelope), so a compromised or
+// misconfigured registry could otherwise hand the installer a
+// file:///etc/passwd or http://evil.com URL that http.Client.Get would
+// happily honor. The 2026-06-04 audit (F-007-adjacent) flagged this.
+// Extending the list is a deliberate follow-up PR, not a config knob.
+var allowedBinaryURLHosts = map[string]struct{}{
+	"releases.wondertwin.ai":    {},
+	"github.com":                {},
+	"raw.githubusercontent.com": {},
+}
+
+// testSkipBinaryURLValidation, when true, bypasses validateBinaryURL.
+// Set ONLY by TestMain in this package because the integration tests
+// drive the installer via httptest.Server (http loopback), which by
+// design fails the production allowlist + https check. Never reference
+// this from non-test code; there is no production escape hatch.
+var testSkipBinaryURLValidation bool
+
+// validateBinaryURL parses rawURL, requires the https scheme, and
+// confirms the host is in allowedBinaryURLHosts. The returned *url.URL
+// is currently unused by callers — a later refactor could thread it
+// into InstallFromURL to avoid the re-parse, but that's out of scope.
+func validateBinaryURL(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse binary URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("binary URL scheme must be https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("binary URL must have a host")
+	}
+	if _, ok := allowedBinaryURLHosts[host]; !ok {
+		return nil, fmt.Errorf("binary URL host %q not in allowlist (releases.wondertwin.ai, github.com, raw.githubusercontent.com)", host)
+	}
+	return u, nil
+}
 
 // InstallBundle is the local view of the wire-shape install bundle
 // the MCP server returns. The exact wire shape lives in
@@ -51,6 +94,11 @@ func CommitInstallBundle(twinName string, bundle InstallBundle, binaryDir, licen
 	}
 	if bundle.LicenseFileB64 == "" {
 		return fmt.Errorf("install bundle: license_file is required")
+	}
+	if !testSkipBinaryURLValidation {
+		if _, err := validateBinaryURL(bundle.BinaryURL); err != nil {
+			return fmt.Errorf("install bundle binary URL invalid: %w", err)
+		}
 	}
 
 	licenseBytes, err := base64.StdEncoding.DecodeString(bundle.LicenseFileB64)

--- a/internal/registry/bundle_test.go
+++ b/internal/registry/bundle_test.go
@@ -12,6 +12,15 @@ import (
 	"testing"
 )
 
+// TestMain bypasses the BinaryURL allowlist for the integration tests
+// below — httptest.Server serves http://127.0.0.1:PORT, which by design
+// fails the production https + host-allowlist check. The validator
+// itself is covered directly by TestValidateBinaryURL.
+func TestMain(m *testing.M) {
+	testSkipBinaryURLValidation = true
+	os.Exit(m.Run())
+}
+
 // serveBinary returns an httptest server that returns the given bytes
 // at every request — useful for the bundle commit tests.
 func serveBinary(t *testing.T, body []byte) *httptest.Server {
@@ -188,6 +197,35 @@ func TestCommitInstallBundle_RejectsMissingFields(t *testing.T) {
 				filepath.Join(dir, "bin"), filepath.Join(dir, "license.json"))
 			if err == nil {
 				t.Errorf("want error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateBinaryURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"allowed-releases", "https://releases.wondertwin.ai/v0.1.0/wt", false},
+		{"allowed-github", "https://github.com/wondertwin-ai/wt/releases/v0.1.0/wt", false},
+		{"allowed-raw-githubusercontent", "https://raw.githubusercontent.com/wondertwin-ai/wt/main/wt", false},
+		{"reject-http", "http://releases.wondertwin.ai/v0.1.0/wt", true},
+		{"reject-file", "file:///etc/passwd", true},
+		{"reject-non-allowed-host", "https://evil.com/payload", true},
+		{"reject-empty-host", "https:///just-a-path", true},
+		{"reject-malformed", "ht!tps://broken", true},
+		{"reject-empty", "", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateBinaryURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBinaryURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds scheme + host allowlist validation on `CommitInstallBundle`'s `BinaryURL`. Closes the SSRF / `file://` ingress surface.

## Consolidated doc reference

Closes item **5.5** in `wondertwin-docs/v0.2.1-consolidated-priorities-2026-06-10.md`. F-007-adjacent finding from the 2026-06-04 audit.

## Rationale

`internal/registry/bundle.go`'s `CommitInstallBundle` required non-empty `BinaryURL` but did NO scheme check, NO host allowlist, NO `url.URL` parse — the value was passed straight to `InstallFromURL` → `http.Client.Get`. A compromised or misconfigured registry could have handed the installer `file:///etc/passwd`, `http://evil.com/payload`, or `https://internal-vpn-host/...` and the client would have honored it.

Allowlist: `releases.wondertwin.ai`, `github.com`, `raw.githubusercontent.com`. No escape-hatch env var — the install-bundle path is the production flow; dev workflows use different paths.

## What changed

- `internal/registry/bundle.go`: added `validateBinaryURL` (url.Parse → require `https` → require host in allowlist via `u.Hostname()` so `releases.wondertwin.ai:443` still matches). Wired into `CommitInstallBundle` right after the existing non-empty check.
- `internal/registry/bundle_test.go`: 9-case table test for the validator + a `testSkipBinaryURLValidation` package-private bypass for the pre-existing httptest-driven integration tests (`http://127.0.0.1:PORT` URLs that can't satisfy the new check).

## Sole production caller

`internal/mcp/tools_install.go:174` is the only production caller, and it already flows through `CommitInstallBundle`. No other BinaryURL ingress to protect.

## Sharp-edge note

The `testSkipBinaryURLValidation` bypass is package-private and not env-var reachable, so production is safe. Worth knowing it exists — a future refactor of bundle.go that moves validation elsewhere could lose the bypass.

## Verification

- `go build ./... && go test ./... && go vet ./...` all clean.
- `TestValidateBinaryURL` PASSes all 9 cases.