### PR TITLE
feat(httpclient): v0.2.1-5.7 — new internal/httpclient package with TLS 1.2 floor + route all 12 call sites

### DIFF
--- a/cmd/verify-registry/main.go
+++ b/cmd/verify-registry/main.go
@@ -19,6 +19,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 )
 
 const defaultRegistryURL = "https://raw.githubusercontent.com/wondertwin-ai/registry/main/registry.json"
@@ -247,7 +249,7 @@ func ValidChecksum(cs string) bool {
 }
 
 func headCheck(url string) (bool, string) {
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := httpclient.New(httpclient.WithTimeout(15 * time.Second))
 	resp, err := client.Head(url)
 	if err != nil {
 		return false, err.Error()
@@ -274,7 +276,7 @@ func headCheck(url string) (bool, string) {
 }
 
 func fetchRegistry(url string) ([]byte, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := httpclient.New(httpclient.WithTimeout(30 * time.Second))
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("fetching registry: %w", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 )
 
 // AdminClient talks to twin /admin/* endpoints.
@@ -19,7 +21,7 @@ type AdminClient struct {
 // New creates an AdminClient with a 5-second timeout.
 func New() *AdminClient {
 	return &AdminClient{
-		http: &http.Client{Timeout: 5 * time.Second},
+		http: httpclient.New(httpclient.WithTimeout(5 * time.Second)),
 	}
 }
 

--- a/internal/content/client.go
+++ b/internal/content/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"time"
@@ -22,7 +23,7 @@ func NewClient(baseURL, token string) *Client {
 	return &Client{
 		BaseURL: baseURL,
 		Token:   token,
-		http:    &http.Client{Timeout: 30 * time.Second},
+		http:    httpclient.New(httpclient.WithTimeout(30 * time.Second)),
 	}
 }
 

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -1,0 +1,164 @@
+// Package httpclient is the wondertwin CLI's HTTP client factory.
+//
+// Every outbound HTTP call from cmd/wt, internal/registry,
+// internal/platform, internal/content, internal/mcp, etc., goes
+// through New. The reason this package exists rather than continuing
+// to write `&http.Client{Timeout: ...}` inline at each call site:
+//
+//   - TLS floor. Every client returned by New enforces
+//     tls.VersionTLS12 as the minimum negotiated version, defending
+//     against a deploy that lands on an old Go stdlib default or a
+//     middlebox that downgrades.
+//   - Sane transport. The default transport is a clone of
+//     http.DefaultTransport, so dialer / proxy / keep-alive defaults
+//     remain identical to a stdlib client — not the zero-value
+//     http.Transport{} that fresh `&http.Client{}` constructions get.
+//   - User-Agent. A wrapping RoundTripper sets a default User-Agent on
+//     every request that doesn't already declare one, so wondertwin
+//     traffic is identifiable in vendor logs.
+//
+// Construction is option-driven; the zero-arg form is the right
+// default for most callers (30s timeout, TLS 1.2 floor, default UA).
+// Callers that need a different timeout — registry installer's
+// 5-minute downloads, MCP tool calls' 5-second floors — pass
+// WithTimeout.
+//
+// To keep this discipline, the audit-script (when added) will reject
+// `&http.Client{` outside _test.go files. New call sites should route
+// through this package.
+package httpclient
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+const (
+	// DefaultTimeout matches the stdlib examples and the prior most-
+	// common timeout (`time.Second * 30`) across the wondertwin call
+	// sites. Callers with hard-real-time budgets (MCP at 5s, registry
+	// installer at 5m) override with WithTimeout.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultUserAgent identifies wondertwin CLI traffic to vendor
+	// dashboards. Concrete tooling (cmd/wt) overrides this with its
+	// embedded build version via WithUserAgent so support can
+	// correlate by CLI version.
+	DefaultUserAgent = "wondertwin-cli"
+)
+
+// Option tunes a client built by New.
+type Option func(*config)
+
+type config struct {
+	timeout   time.Duration
+	minTLS    uint16
+	userAgent string
+}
+
+// WithTimeout overrides DefaultTimeout. Pass 0 to disable the timeout
+// entirely (matches *http.Client.Timeout zero-value semantics) —
+// callers that disable the timeout must enforce one via context, or
+// the request can block forever.
+func WithTimeout(d time.Duration) Option {
+	return func(c *config) { c.timeout = d }
+}
+
+// WithMinTLS overrides the TLS floor. The default is tls.VersionTLS12;
+// production callers should not lower this. Tests may set
+// tls.VersionTLS13 to assert preference, or lower to exercise a
+// downgrade path against a controlled fixture.
+func WithMinTLS(v uint16) Option {
+	return func(c *config) { c.minTLS = v }
+}
+
+// WithUserAgent overrides DefaultUserAgent. cmd/wt's main package
+// typically passes "wt/" + Version so the UA carries the build
+// version. Empty string disables the UA-rewriting RoundTripper
+// entirely — useful for callers that already manage UA at the
+// request level.
+func WithUserAgent(s string) Option {
+	return func(c *config) { c.userAgent = s }
+}
+
+// New returns an *http.Client with the TLS floor, default timeout,
+// and a wrapping RoundTripper that sets a default User-Agent on every
+// outbound request. The returned client is safe for concurrent use.
+//
+// Reuse the same client across calls — every New() pays the
+// http.DefaultTransport.Clone() cost. Callers that need many one-shot
+// clients should hoist a package-level *http.Client built from New.
+func New(opts ...Option) *http.Client {
+	cfg := config{
+		timeout:   DefaultTimeout,
+		minTLS:    tls.VersionTLS12,
+		userAgent: DefaultUserAgent,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Clone DefaultTransport so the dialer, proxy, keep-alive, and
+	// idle-connection settings stay aligned with stdlib defaults.
+	// Constructing a fresh http.Transport{} would reset those to
+	// zero-value defaults — slower in steady state.
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = &tls.Config{MinVersion: cfg.minTLS}
+
+	var rt http.RoundTripper = base
+	if cfg.userAgent != "" {
+		rt = uaTransport{base: rt, ua: cfg.userAgent}
+	}
+	return &http.Client{
+		Timeout:   cfg.timeout,
+		Transport: rt,
+	}
+}
+
+// MinTLSVersion returns the TLS floor configured on c, or 0 if c was
+// not constructed by this package (or if any wrapping transport hides
+// the underlying *http.Transport). Used by package tests and by
+// observability code that wants to log the negotiated floor.
+func MinTLSVersion(c *http.Client) uint16 {
+	if c == nil {
+		return 0
+	}
+	t := underlyingTransport(c.Transport)
+	if t == nil || t.TLSClientConfig == nil {
+		return 0
+	}
+	return t.TLSClientConfig.MinVersion
+}
+
+// underlyingTransport walks past the package's UA wrapper to the
+// underlying *http.Transport, if any. Returns nil if the chain leads
+// somewhere else (caller passed a custom RoundTripper).
+func underlyingTransport(rt http.RoundTripper) *http.Transport {
+	for {
+		switch v := rt.(type) {
+		case *http.Transport:
+			return v
+		case uaTransport:
+			rt = v.base
+		default:
+			return nil
+		}
+	}
+}
+
+// uaTransport sets a default User-Agent header on every outbound
+// request that doesn't already declare one. Wraps base; concurrent-
+// safe because http.Request.Clone is.
+type uaTransport struct {
+	base http.RoundTripper
+	ua   string
+}
+
+func (t uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", t.ua)
+	}
+	return t.base.RoundTrip(req)
+}

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -1,0 +1,155 @@
+package httpclient
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestNew_DefaultMinTLSIs12 pins the TLS floor. Lowering the floor
+// (or losing it to a refactor) is the load-bearing concern this
+// package was created to defend.
+func TestNew_DefaultMinTLSIs12(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if got := MinTLSVersion(c); got != tls.VersionTLS12 {
+		t.Fatalf("MinTLSVersion = %#x, want tls.VersionTLS12 (%#x)", got, tls.VersionTLS12)
+	}
+}
+
+// TestNew_WithMinTLS_Overrides asserts the option wins over the default.
+func TestNew_WithMinTLS_Overrides(t *testing.T) {
+	t.Parallel()
+	c := New(WithMinTLS(tls.VersionTLS13))
+	if got := MinTLSVersion(c); got != tls.VersionTLS13 {
+		t.Fatalf("MinTLSVersion = %#x, want tls.VersionTLS13 (%#x)", got, tls.VersionTLS13)
+	}
+}
+
+// TestNew_DefaultTimeout pins the timeout default at 30s.
+func TestNew_DefaultTimeout(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Timeout != DefaultTimeout {
+		t.Fatalf("Timeout = %v, want %v", c.Timeout, DefaultTimeout)
+	}
+}
+
+// TestNew_WithTimeout_Overrides asserts the option wins over the default.
+func TestNew_WithTimeout_Overrides(t *testing.T) {
+	t.Parallel()
+	c := New(WithTimeout(7 * time.Second))
+	if c.Timeout != 7*time.Second {
+		t.Fatalf("Timeout = %v, want 7s", c.Timeout)
+	}
+}
+
+// TestNew_UserAgentSetByDefault drives a real request through the
+// client at an httptest.Server and asserts the UA header lands.
+func TestNew_UserAgentSetByDefault(t *testing.T) {
+	t.Parallel()
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New()
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+	if seen != DefaultUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", seen, DefaultUserAgent)
+	}
+}
+
+// TestNew_WithUserAgent_Overrides asserts the override wins over the
+// default. Important for cmd/wt's main, which embeds the build
+// version in the UA so support can correlate by CLI version.
+func TestNew_WithUserAgent_Overrides(t *testing.T) {
+	t.Parallel()
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(WithUserAgent("wt/1.2.3"))
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+	if seen != "wt/1.2.3" {
+		t.Fatalf("User-Agent = %q, want %q", seen, "wt/1.2.3")
+	}
+}
+
+// TestNew_UserAgentDoesNotOverrideCallerSet asserts the wrapping
+// RoundTripper only fills in a UA when the caller hasn't already set
+// one. Useful for callers (e.g., a downstream proxy) that want to
+// pass through a third-party UA.
+func TestNew_UserAgentDoesNotOverrideCallerSet(t *testing.T) {
+	t.Parallel()
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New()
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("User-Agent", "caller/9.9.9")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+	if seen != "caller/9.9.9" {
+		t.Fatalf("User-Agent = %q, want caller-supplied %q (wrapper should not override)", seen, "caller/9.9.9")
+	}
+}
+
+// TestNew_WithEmptyUserAgentDisablesWrapper asserts WithUserAgent("")
+// skips the RoundTripper wrapping entirely. Net effect: requests go
+// out with Go's stdlib default UA. Useful for callers that manage UA
+// at the request level.
+func TestNew_WithEmptyUserAgentDisablesWrapper(t *testing.T) {
+	t.Parallel()
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(WithUserAgent(""))
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+	// Stdlib default: "Go-http-client/1.1" — assert non-empty and not
+	// our package default (i.e. the wrapper was bypassed).
+	if seen == DefaultUserAgent {
+		t.Fatalf("User-Agent = %q, expected wrapper to be disabled", seen)
+	}
+}
+
+// TestMinTLSVersion_NilClient is a defensive nil check.
+func TestMinTLSVersion_NilClient(t *testing.T) {
+	t.Parallel()
+	if got := MinTLSVersion(nil); got != 0 {
+		t.Fatalf("MinTLSVersion(nil) = %#x, want 0", got)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"strings"
@@ -323,7 +324,7 @@ func handleInspect(m *manifest.Manifest, _ *client.AdminClient, params json.RawM
 	}
 
 	// GET /admin/state to retrieve current twin state
-	httpClient := &http.Client{Timeout: 5 * time.Second}
+	httpClient := httpclient.New(httpclient.WithTimeout(5 * time.Second))
 	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/admin/state", twin.AdminPort))
 	if err != nil {
 		return textResult(fmt.Sprintf("Error inspecting %s: %v", p.Twin, err))
@@ -360,7 +361,7 @@ func handleConfig(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 		return textResult(fmt.Sprintf("Error: %v", err))
 	}
 
-	httpClient := &http.Client{Timeout: 5 * time.Second}
+	httpClient := httpclient.New(httpclient.WithTimeout(5 * time.Second))
 
 	if len(p.Updates) > 0 {
 		// PUT /admin/config with updates
@@ -418,7 +419,7 @@ func handleQuirks(m *manifest.Manifest, _ *client.AdminClient, params json.RawMe
 		return textResult(fmt.Sprintf("Error: %v", err))
 	}
 
-	httpClient := &http.Client{Timeout: 5 * time.Second}
+	httpClient := httpclient.New(httpclient.WithTimeout(5 * time.Second))
 
 	if p.Action != "" {
 		if p.QuirkID == "" {

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"net/url"
@@ -34,11 +35,9 @@ func New(baseURL, apiKey string) *Client {
 		baseURL = DefaultBaseURL
 	}
 	return &Client{
-		baseURL: baseURL,
-		apiKey:  apiKey,
-		httpClient: &http.Client{
-			Timeout: requestTimeout,
-		},
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		httpClient: httpclient.New(httpclient.WithTimeout(requestTimeout)),
 	}
 }
 

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/wondertwin-ai/wondertwin/internal/config"
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 )
 
@@ -62,7 +63,7 @@ func Install(twinName string, resolvedVersion string, ver Version, binaryDir str
 	// Download binary
 	fmt.Printf("  Downloading twin-%s v%s (%s)...\n", twinName, resolvedVersion, platform)
 
-	client := &http.Client{Timeout: 5 * time.Minute}
+	client := httpclient.New(httpclient.WithTimeout(5 * time.Minute))
 	resp, err := client.Get(binaryURL)
 	if err != nil {
 		return fmt.Errorf("downloading binary: %w", err)
@@ -166,7 +167,7 @@ func InstallFromURL(twinName, version, binaryURL, expectedChecksum, binaryDir st
 		return fmt.Errorf("creating binary dir %s: %w", binaryDir, err)
 	}
 
-	client := &http.Client{Timeout: 5 * time.Minute}
+	client := httpclient.New(httpclient.WithTimeout(5 * time.Minute))
 	resp, err := client.Get(binaryURL)
 	if err != nil {
 		return fmt.Errorf("downloading binary: %w", err)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/httpio"
 	"net/http"
 	"strings"
@@ -214,7 +215,7 @@ func toJSONURL(url string) string {
 // fetchAndParse downloads a registry file and parses it based on the URL extension.
 // JSON is used for .json URLs, YAML for everything else.
 func fetchAndParse(url, token string) (*Registry, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := httpclient.New(httpclient.WithTimeout(30 * time.Second))
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/internal/scenario/v2/runner.go
+++ b/internal/scenario/v2/runner.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wondertwin-ai/wondertwin/internal/httpclient"
 	"github.com/wondertwin-ai/wondertwin/internal/manifest"
 )
 
@@ -42,7 +43,7 @@ type Runner struct {
 func NewRunner(m *manifest.Manifest) *Runner {
 	return &Runner{
 		manifest: m,
-		http:     &http.Client{Timeout: 10 * time.Second},
+		http:     httpclient.New(httpclient.WithTimeout(10 * time.Second)),
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes consolidated-doc row **5.7**. New \`internal/httpclient\` package enforces TLS 1.2 floor + 30s default timeout + project User-Agent. All 12 ad-hoc \`&http.Client{}\` call sites across 8 files rewired.

### API

- \`httpclient.New(opts ...Option) *http.Client\`
- \`WithTimeout(d time.Duration)\`
- \`WithMinTLS(v uint16)\` — defaults to \`tls.VersionTLS12\`
- \`WithUserAgent(s string)\` — defaults to \`"wondertwin-cli"\`

### Coverage

\`grep -rE "&http\.Client\{" cmd/ internal/\` returns zero non-test occurrences.

### Wrinkles

None. All existing clients were vanilla \`&http.Client{Timeout: ...}\` — no custom transports, no per-client TLS. MCP-side clients target localhost so TLS floor is no-op at runtime; routing keeps the grep clean.

### Follow-ups surfaced

1. **Audit-script lock-in** — wondertwin has no \`scripts/\` directory. Recommended: \`scripts/audit-wt.sh\` mirroring wondertwin-pro's pattern, with the \`&http.Client{\` grep as check #1 + \`_test.go\` + \`internal/httpclient/\` allowlist.
2. **User-Agent wiring** — \`cmd/wt\`'s \`version = "dev"\` isn't wired into UA yet; package defaults to literal \`"wondertwin-cli"\`. \`WithUserAgent("wt/" + version)\` at main entry is the natural follow-up.

## Test plan

- [x] Build/test/vet clean
- [x] \`MinVersion: tls.VersionTLS12\` unit test passes
- [x] grep is clean
- [ ] CI passes