### PR TITLE
style: gofmt -w (formatting only, no semantic change)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: gofmt -w — formatting only
+f697d97f9929eff4bc15cca01ee2bd8b28795c21

--- a/cmd/validate-skill-pins/main.go
+++ b/cmd/validate-skill-pins/main.go
@@ -173,7 +173,7 @@ func compareVersions(schemaVersion, pinnedVersion string) (versionComparison, er
 
 	return versionComparison{
 		majorDrift: schemaMajor > pinMajor,
-		minorDrift: !((schemaMajor > pinMajor)) && schemaMinor > pinMinor,
+		minorDrift: !(schemaMajor > pinMajor) && schemaMinor > pinMinor,
 	}, nil
 }
 

--- a/cmd/validate-skill-templates/main.go
+++ b/cmd/validate-skill-templates/main.go
@@ -22,16 +22,16 @@ import (
 // special cases like {port} which need to become integers.
 var placeholders = map[string]string{
 	// Names and identifiers
-	"{name}":             "test",
-	"{Service}":          "Test Service",
-	"{category}":         "testing",
-	"{Platform}":         "Test Platform",
+	"{name}":     "test",
+	"{Service}":  "Test Service",
+	"{category}": "testing",
+	"{Platform}": "Test Platform",
 
 	// SDK fields
-	"{sdk_import_path}":  "github.com/example/sdk",
-	"{sdk_version}":      "v1.0.0",
-	"{org}":              "example",
-	"{sdk-repo}":         "sdk-repo",
+	"{sdk_import_path}": "github.com/example/sdk",
+	"{sdk_version}":     "v1.0.0",
+	"{org}":             "example",
+	"{sdk-repo}":        "sdk-repo",
 
 	// Timestamps
 	"{ISO 8601 timestamp}": "2026-01-01T00:00:00Z",
@@ -48,12 +48,12 @@ var placeholders = map[string]string{
 	"{git commit of archive}": "abc123def456",
 
 	// Researcher-specific
-	"{developer docs URL}":    "https://developer.example.com",
-	"{platform}":              "test-platform",
-	"{source_type}":           "official_docs",
-	"{url}":                   "https://example.com/docs",
-	"{archive_path}":          "archive/official-docs/2026-01-01",
-	"{scope}":                 "candidate",
+	"{developer docs URL}": "https://developer.example.com",
+	"{platform}":           "test-platform",
+	"{source_type}":        "official_docs",
+	"{url}":                "https://example.com/docs",
+	"{archive_path}":       "archive/official-docs/2026-01-01",
+	"{scope}":              "candidate",
 
 	// Ports (handled specially — substituted as integer)
 	"{port}": "4200",

--- a/cmd/wt-collector/internal/api/handlers_test.go
+++ b/cmd/wt-collector/internal/api/handlers_test.go
@@ -209,7 +209,7 @@ func TestIngest_BearerCompareEdgeCases(t *testing.T) {
 		name   string
 		bearer string
 	}{
-		{"wrong-same-length", "wrong-ingest-stuff"},   // also 18 bytes
+		{"wrong-same-length", "wrong-ingest-stuff"}, // also 18 bytes
 		{"wrong-shorter", "short"},
 		{"wrong-longer", "test-ingest-secret-but-longer"},
 		{"empty-after-prefix", ""},

--- a/docs/TWIN_TEMPLATE/cmd/twin-TEMPLATE/main.go
+++ b/docs/TWIN_TEMPLATE/cmd/twin-TEMPLATE/main.go
@@ -9,10 +9,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/docs/TWIN_TEMPLATE/internal/api/handlers_example.go
+++ b/docs/TWIN_TEMPLATE/internal/api/handlers_example.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // createResourceRequest matches the real service's create request body.

--- a/docs/TWIN_TEMPLATE/internal/api/handlers_test.go
+++ b/docs/TWIN_TEMPLATE/internal/api/handlers_test.go
@@ -4,11 +4,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
 )
 
 // setupTwin creates a test server with the twin wired up.

--- a/docs/TWIN_TEMPLATE/internal/api/router.go
+++ b/docs/TWIN_TEMPLATE/internal/api/router.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-TEMPLATE/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Handler holds all API handler state.

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -3,9 +3,9 @@ package content
 
 // ContentPayload is the top-level response from the Content API.
 type ContentPayload struct {
-	Twin    string          `json:"twin"`
-	Version string          `json:"version"`
-	Quirks  []QuirkRecord   `json:"quirks,omitempty"`
+	Twin    string        `json:"twin"`
+	Version string        `json:"version"`
+	Quirks  []QuirkRecord `json:"quirks,omitempty"`
 }
 
 // QuirkRecord describes a single SDK quirk.

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -33,11 +33,11 @@ type RPCError struct {
 
 // Standard JSON-RPC 2.0 error codes.
 const (
-	ErrCodeParse      = -32700
-	ErrCodeInvalidReq = -32600
-	ErrCodeNoMethod   = -32601
+	ErrCodeParse         = -32700
+	ErrCodeInvalidReq    = -32600
+	ErrCodeNoMethod      = -32601
 	ErrCodeInvalidParams = -32602
-	ErrCodeInternal   = -32603
+	ErrCodeInternal      = -32603
 )
 
 // newResponse creates a successful JSON-RPC response.

--- a/internal/mcp/tools_license_refresh.go
+++ b/internal/mcp/tools_license_refresh.go
@@ -171,4 +171,3 @@ func refreshLicenseIfStale(ctx context.Context, pc *platform.Client, cfg *config
 			"err", err)
 	}
 }
-

--- a/internal/scenario/v2/types.go
+++ b/internal/scenario/v2/types.go
@@ -6,8 +6,8 @@ package v2
 type Scenario struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
-	Setup     *Setup            `json:"setup,omitempty"`
-	Variables map[string]string `json:"variables,omitempty"`
+	Setup       *Setup            `json:"setup,omitempty"`
+	Variables   map[string]string `json:"variables,omitempty"`
 	Steps       []Step            `json:"steps"`
 }
 

--- a/twin-github/cmd/twin-github/main.go
+++ b/twin-github/cmd/twin-github/main.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-github/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-github/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-github/internal/api/handlers_checks.go
+++ b/twin-github/internal/api/handlers_checks.go
@@ -16,12 +16,12 @@ func (h *Handler) CreateCheckRun(w http.ResponseWriter, r *http.Request) {
 	repo := chi.URLParam(r, "repo")
 
 	var req struct {
-		Name       string           `json:"name"`
-		HeadSHA    string           `json:"head_sha"`
-		Status     string           `json:"status"`
-		Conclusion string           `json:"conclusion,omitempty"`
-		DetailsURL string           `json:"details_url,omitempty"`
-		ExternalID string           `json:"external_id,omitempty"`
+		Name       string                `json:"name"`
+		HeadSHA    string                `json:"head_sha"`
+		Status     string                `json:"status"`
+		Conclusion string                `json:"conclusion,omitempty"`
+		DetailsURL string                `json:"details_url,omitempty"`
+		ExternalID string                `json:"external_id,omitempty"`
 		Output     *store.CheckRunOutput `json:"output,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/twin-github/internal/api/handlers_git.go
+++ b/twin-github/internal/api/handlers_git.go
@@ -185,7 +185,7 @@ func (h *Handler) CreateGitTree(w http.ResponseWriter, r *http.Request) {
 	repo := chi.URLParam(r, "repo")
 
 	var req struct {
-		BaseTree string             `json:"base_tree,omitempty"`
+		BaseTree string               `json:"base_tree,omitempty"`
 		Tree     []store.GitTreeEntry `json:"tree"`
 	}
 	json.NewDecoder(r.Body).Decode(&req)

--- a/twin-github/internal/api/handlers_remaining.go
+++ b/twin-github/internal/api/handlers_remaining.go
@@ -488,10 +488,10 @@ func (h *Handler) GetApp(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListAppInstallations(w http.ResponseWriter, r *http.Request) {
 	ghJSON(w, 200, []map[string]any{
 		{
-			"id":         1,
-			"app_id":     1,
+			"id":          1,
+			"app_id":      1,
 			"target_type": "Organization",
-			"account":    store.User{ID: 1, Login: "twin-bot", Type: "Organization"},
+			"account":     store.User{ID: 1, Login: "twin-bot", Type: "Organization"},
 		},
 	})
 }

--- a/twin-github/internal/api/handlers_repos_extra.go
+++ b/twin-github/internal/api/handlers_repos_extra.go
@@ -107,12 +107,12 @@ func (h *Handler) GetCommit(w http.ResponseWriter, r *http.Request) {
 // CompareCommits handles GET /repos/{owner}/{repo}/compare/{basehead}
 func (h *Handler) CompareCommits(w http.ResponseWriter, r *http.Request) {
 	ghJSON(w, 200, map[string]any{
-		"status":       "ahead",
-		"ahead_by":     1,
-		"behind_by":    0,
+		"status":        "ahead",
+		"ahead_by":      1,
+		"behind_by":     0,
 		"total_commits": 1,
-		"commits":      []any{},
-		"files":        []any{},
+		"commits":       []any{},
+		"files":         []any{},
 	})
 }
 

--- a/twin-github/internal/api/handlers_statuses.go
+++ b/twin-github/internal/api/handlers_statuses.go
@@ -85,9 +85,9 @@ func (h *Handler) GetCombinedStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ghJSON(w, 200, map[string]any{
-		"state":      combined,
-		"statuses":   statuses,
-		"sha":        ref,
+		"state":       combined,
+		"statuses":    statuses,
+		"sha":         ref,
 		"total_count": len(statuses),
 		"repository": map[string]any{
 			"full_name": owner + "/" + repo,

--- a/twin-github/internal/api/handlers_test.go
+++ b/twin-github/internal/api/handlers_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-github/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-github/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-github/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-github/internal/store"
 )
 
 func setupGitHub(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-github/internal/api/handlers_webhooks.go
+++ b/twin-github/internal/api/handlers_webhooks.go
@@ -23,9 +23,9 @@ func (h *Handler) CreateWebhook(w http.ResponseWriter, r *http.Request) {
 	repo := chi.URLParam(r, "repo")
 
 	var req struct {
-		Name   string            `json:"name"`
-		Active *bool             `json:"active,omitempty"`
-		Events []string          `json:"events"`
+		Name   string              `json:"name"`
+		Active *bool               `json:"active,omitempty"`
+		Events []string            `json:"events"`
 		Config store.WebhookConfig `json:"config"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/twin-github/internal/api/router.go
+++ b/twin-github/internal/api/router.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-github/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Handler holds GitHub API state.

--- a/twin-github/internal/store/memory.go
+++ b/twin-github/internal/store/memory.go
@@ -46,9 +46,9 @@ type MemoryStore struct {
 	Clock            *pkgstate.Clock
 
 	// Monotonic counters
-	issueCounter  atomic.Int64
-	idCounter     atomic.Int64
-	runCounter    atomic.Int64
+	issueCounter atomic.Int64
+	idCounter    atomic.Int64
+	runCounter   atomic.Int64
 }
 
 // New creates a new MemoryStore with empty state.
@@ -242,17 +242,17 @@ func MakeSHA(input string) string {
 }
 
 type stateSnapshot struct {
-	Repos        map[string]Repository    `json:"repos,omitempty"`
-	Issues       map[string]Issue         `json:"issues,omitempty"`
-	PullRequests map[string]PullRequest   `json:"pull_requests,omitempty"`
-	Comments     map[string]Comment       `json:"comments,omitempty"`
-	Labels       map[string]Label         `json:"labels,omitempty"`
-	Milestones   map[string]Milestone     `json:"milestones,omitempty"`
-	Users        map[string]User          `json:"users,omitempty"`
-	Webhooks     map[string]Webhook       `json:"webhooks,omitempty"`
-	Statuses     map[string]CommitStatus  `json:"statuses,omitempty"`
-	Releases     map[string]Release       `json:"releases,omitempty"`
-	Branches     map[string]Branch        `json:"branches,omitempty"`
+	Repos        map[string]Repository   `json:"repos,omitempty"`
+	Issues       map[string]Issue        `json:"issues,omitempty"`
+	PullRequests map[string]PullRequest  `json:"pull_requests,omitempty"`
+	Comments     map[string]Comment      `json:"comments,omitempty"`
+	Labels       map[string]Label        `json:"labels,omitempty"`
+	Milestones   map[string]Milestone    `json:"milestones,omitempty"`
+	Users        map[string]User         `json:"users,omitempty"`
+	Webhooks     map[string]Webhook      `json:"webhooks,omitempty"`
+	Statuses     map[string]CommitStatus `json:"statuses,omitempty"`
+	Releases     map[string]Release      `json:"releases,omitempty"`
+	Branches     map[string]Branch       `json:"branches,omitempty"`
 }
 
 func (s *MemoryStore) Snapshot() any {

--- a/twin-github/internal/store/types.go
+++ b/twin-github/internal/store/types.go
@@ -3,50 +3,50 @@ package store
 
 // Repository represents a GitHub repository.
 type Repository struct {
-	ID            int64  `json:"id"`
-	Name          string `json:"name"`
-	FullName      string `json:"full_name"`
-	Description   string `json:"description"`
-	Private       bool   `json:"private"`
-	Fork          bool   `json:"fork"`
-	HTMLURL       string `json:"html_url"`
-	CloneURL      string `json:"clone_url"`
-	SSHURL        string `json:"ssh_url"`
-	DefaultBranch string `json:"default_branch"`
-	Language      string `json:"language,omitempty"`
-	ForksCount    int    `json:"forks_count"`
-	StarCount     int    `json:"stargazers_count"`
-	WatcherCount  int    `json:"watchers_count"`
-	OpenIssues    int    `json:"open_issues_count"`
-	HasIssues     bool   `json:"has_issues"`
-	HasProjects   bool   `json:"has_projects"`
-	HasWiki       bool   `json:"has_wiki"`
-	Archived      bool   `json:"archived"`
-	Disabled      bool   `json:"disabled"`
-	Owner         User   `json:"owner"`
-	CreatedAt     string `json:"created_at"`
-	UpdatedAt     string `json:"updated_at"`
-	PushedAt      string `json:"pushed_at"`
+	ID            int64    `json:"id"`
+	Name          string   `json:"name"`
+	FullName      string   `json:"full_name"`
+	Description   string   `json:"description"`
+	Private       bool     `json:"private"`
+	Fork          bool     `json:"fork"`
+	HTMLURL       string   `json:"html_url"`
+	CloneURL      string   `json:"clone_url"`
+	SSHURL        string   `json:"ssh_url"`
+	DefaultBranch string   `json:"default_branch"`
+	Language      string   `json:"language,omitempty"`
+	ForksCount    int      `json:"forks_count"`
+	StarCount     int      `json:"stargazers_count"`
+	WatcherCount  int      `json:"watchers_count"`
+	OpenIssues    int      `json:"open_issues_count"`
+	HasIssues     bool     `json:"has_issues"`
+	HasProjects   bool     `json:"has_projects"`
+	HasWiki       bool     `json:"has_wiki"`
+	Archived      bool     `json:"archived"`
+	Disabled      bool     `json:"disabled"`
+	Owner         User     `json:"owner"`
+	CreatedAt     string   `json:"created_at"`
+	UpdatedAt     string   `json:"updated_at"`
+	PushedAt      string   `json:"pushed_at"`
 	Topics        []string `json:"topics,omitempty"`
 }
 
 // Issue represents a GitHub issue.
 type Issue struct {
-	ID        int64    `json:"id"`
-	Number    int      `json:"number"`
-	Title     string   `json:"title"`
-	Body      string   `json:"body"`
-	State     string   `json:"state"` // "open" or "closed"
-	User      User     `json:"user"`
-	Labels    []Label  `json:"labels,omitempty"`
-	Assignees []User   `json:"assignees,omitempty"`
+	ID        int64      `json:"id"`
+	Number    int        `json:"number"`
+	Title     string     `json:"title"`
+	Body      string     `json:"body"`
+	State     string     `json:"state"` // "open" or "closed"
+	User      User       `json:"user"`
+	Labels    []Label    `json:"labels,omitempty"`
+	Assignees []User     `json:"assignees,omitempty"`
 	Milestone *Milestone `json:"milestone,omitempty"`
-	Locked    bool     `json:"locked"`
-	Comments  int      `json:"comments"`
-	HTMLURL   string   `json:"html_url"`
-	CreatedAt string   `json:"created_at"`
-	UpdatedAt string   `json:"updated_at"`
-	ClosedAt  string   `json:"closed_at,omitempty"`
+	Locked    bool       `json:"locked"`
+	Comments  int        `json:"comments"`
+	HTMLURL   string     `json:"html_url"`
+	CreatedAt string     `json:"created_at"`
+	UpdatedAt string     `json:"updated_at"`
+	ClosedAt  string     `json:"closed_at,omitempty"`
 
 	// Internal: which repo this belongs to
 	RepoOwner string `json:"-"`
@@ -55,31 +55,31 @@ type Issue struct {
 
 // PullRequest represents a GitHub pull request.
 type PullRequest struct {
-	ID        int64  `json:"id"`
-	Number    int    `json:"number"`
-	Title     string `json:"title"`
-	Body      string `json:"body"`
-	State     string `json:"state"` // "open", "closed"
-	Draft     bool   `json:"draft"`
-	Merged    bool   `json:"merged"`
-	User      User   `json:"user"`
-	Head      PRRef  `json:"head"`
-	Base      PRRef  `json:"base"`
-	Labels    []Label `json:"labels,omitempty"`
-	Assignees []User  `json:"assignees,omitempty"`
-	HTMLURL   string `json:"html_url"`
-	DiffURL   string `json:"diff_url"`
-	MergeCommitSHA string `json:"merge_commit_sha,omitempty"`
-	Mergeable      *bool  `json:"mergeable,omitempty"`
-	Comments       int    `json:"comments"`
-	Commits        int    `json:"commits"`
-	Additions      int    `json:"additions"`
-	Deletions      int    `json:"deletions"`
-	ChangedFiles   int    `json:"changed_files"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-	ClosedAt       string `json:"closed_at,omitempty"`
-	MergedAt       string `json:"merged_at,omitempty"`
+	ID             int64   `json:"id"`
+	Number         int     `json:"number"`
+	Title          string  `json:"title"`
+	Body           string  `json:"body"`
+	State          string  `json:"state"` // "open", "closed"
+	Draft          bool    `json:"draft"`
+	Merged         bool    `json:"merged"`
+	User           User    `json:"user"`
+	Head           PRRef   `json:"head"`
+	Base           PRRef   `json:"base"`
+	Labels         []Label `json:"labels,omitempty"`
+	Assignees      []User  `json:"assignees,omitempty"`
+	HTMLURL        string  `json:"html_url"`
+	DiffURL        string  `json:"diff_url"`
+	MergeCommitSHA string  `json:"merge_commit_sha,omitempty"`
+	Mergeable      *bool   `json:"mergeable,omitempty"`
+	Comments       int     `json:"comments"`
+	Commits        int     `json:"commits"`
+	Additions      int     `json:"additions"`
+	Deletions      int     `json:"deletions"`
+	ChangedFiles   int     `json:"changed_files"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+	ClosedAt       string  `json:"closed_at,omitempty"`
+	MergedAt       string  `json:"merged_at,omitempty"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -150,13 +150,13 @@ type User struct {
 
 // Webhook represents a GitHub webhook.
 type Webhook struct {
-	ID        int64    `json:"id"`
-	Name      string   `json:"name"`
-	Active    bool     `json:"active"`
-	Events    []string `json:"events"`
+	ID        int64         `json:"id"`
+	Name      string        `json:"name"`
+	Active    bool          `json:"active"`
+	Events    []string      `json:"events"`
 	Config    WebhookConfig `json:"config"`
-	CreatedAt string   `json:"created_at"`
-	UpdatedAt string   `json:"updated_at"`
+	CreatedAt string        `json:"created_at"`
+	UpdatedAt string        `json:"updated_at"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -206,8 +206,8 @@ type Release struct {
 
 // Branch represents a Git branch.
 type Branch struct {
-	Name      string `json:"name"`
-	Protected bool   `json:"protected"`
+	Name      string       `json:"name"`
+	Protected bool         `json:"protected"`
 	Commit    BranchCommit `json:"commit"`
 
 	RepoOwner string `json:"-"`
@@ -243,46 +243,46 @@ type PRReview struct {
 	CommitID    string `json:"commit_id"`
 	SubmittedAt string `json:"submitted_at"`
 
-	RepoOwner  string `json:"-"`
-	RepoName   string `json:"-"`
-	PRNumber   int    `json:"-"`
+	RepoOwner string `json:"-"`
+	RepoName  string `json:"-"`
+	PRNumber  int    `json:"-"`
 }
 
 // PRReviewComment represents an inline/diff comment on a PR.
 type PRReviewComment struct {
-	ID                int64  `json:"id"`
-	Body              string `json:"body"`
-	Path              string `json:"path"`
-	Position          *int   `json:"position,omitempty"`
-	Line              *int   `json:"line,omitempty"`
-	Side              string `json:"side,omitempty"`
-	CommitID          string `json:"commit_id"`
-	OriginalCommitID  string `json:"original_commit_id"`
-	DiffHunk          string `json:"diff_hunk"`
-	User              User   `json:"user"`
-	HTMLURL           string `json:"html_url"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
-	InReplyToID       *int64 `json:"in_reply_to_id,omitempty"`
+	ID               int64  `json:"id"`
+	Body             string `json:"body"`
+	Path             string `json:"path"`
+	Position         *int   `json:"position,omitempty"`
+	Line             *int   `json:"line,omitempty"`
+	Side             string `json:"side,omitempty"`
+	CommitID         string `json:"commit_id"`
+	OriginalCommitID string `json:"original_commit_id"`
+	DiffHunk         string `json:"diff_hunk"`
+	User             User   `json:"user"`
+	HTMLURL          string `json:"html_url"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
+	InReplyToID      *int64 `json:"in_reply_to_id,omitempty"`
 
-	RepoOwner  string `json:"-"`
-	RepoName   string `json:"-"`
-	PRNumber   int    `json:"-"`
-	ReviewID   int64  `json:"-"`
+	RepoOwner string `json:"-"`
+	RepoName  string `json:"-"`
+	PRNumber  int    `json:"-"`
+	ReviewID  int64  `json:"-"`
 }
 
 // CheckRun represents a GitHub check run.
 type CheckRun struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	HeadSHA     string `json:"head_sha"`
-	Status      string `json:"status"` // "queued", "in_progress", "completed"
-	Conclusion  string `json:"conclusion,omitempty"` // "success", "failure", "neutral", "cancelled", "timed_out", "action_required", "skipped"
-	StartedAt   string `json:"started_at,omitempty"`
-	CompletedAt string `json:"completed_at,omitempty"`
-	HTMLURL     string `json:"html_url"`
-	DetailsURL  string `json:"details_url,omitempty"`
-	ExternalID  string `json:"external_id,omitempty"`
+	ID          int64           `json:"id"`
+	Name        string          `json:"name"`
+	HeadSHA     string          `json:"head_sha"`
+	Status      string          `json:"status"`               // "queued", "in_progress", "completed"
+	Conclusion  string          `json:"conclusion,omitempty"` // "success", "failure", "neutral", "cancelled", "timed_out", "action_required", "skipped"
+	StartedAt   string          `json:"started_at,omitempty"`
+	CompletedAt string          `json:"completed_at,omitempty"`
+	HTMLURL     string          `json:"html_url"`
+	DetailsURL  string          `json:"details_url,omitempty"`
+	ExternalID  string          `json:"external_id,omitempty"`
 	Output      *CheckRunOutput `json:"output,omitempty"`
 
 	RepoOwner string `json:"-"`
@@ -291,9 +291,9 @@ type CheckRun struct {
 
 // CheckRunOutput holds check run output details.
 type CheckRunOutput struct {
-	Title       string `json:"title"`
-	Summary     string `json:"summary"`
-	Text        string `json:"text,omitempty"`
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+	Text    string `json:"text,omitempty"`
 }
 
 // CheckSuite represents a GitHub check suite.
@@ -319,7 +319,7 @@ type Content struct {
 	Size        int    `json:"size"`
 	HTMLURL     string `json:"html_url"`
 	DownloadURL string `json:"download_url,omitempty"`
-	Content     string `json:"content,omitempty"` // base64-encoded for files
+	Content     string `json:"content,omitempty"`  // base64-encoded for files
 	Encoding    string `json:"encoding,omitempty"` // "base64"
 
 	RepoOwner string `json:"-"`
@@ -346,7 +346,7 @@ type Team struct {
 	Slug        string `json:"slug"`
 	Description string `json:"description,omitempty"`
 	Permission  string `json:"permission"` // "pull", "push", "admin"
-	Privacy     string `json:"privacy"` // "secret", "closed"
+	Privacy     string `json:"privacy"`    // "secret", "closed"
 	HTMLURL     string `json:"html_url"`
 
 	OrgLogin string   `json:"-"`
@@ -384,15 +384,15 @@ type Deployment struct {
 
 // DeploymentStatus represents a status for a deployment.
 type DeploymentStatus struct {
-	ID            int64  `json:"id"`
-	State         string `json:"state"` // "error", "failure", "inactive", "in_progress", "queued", "pending", "success"
-	Description   string `json:"description,omitempty"`
-	Environment   string `json:"environment,omitempty"`
+	ID             int64  `json:"id"`
+	State          string `json:"state"` // "error", "failure", "inactive", "in_progress", "queued", "pending", "success"
+	Description    string `json:"description,omitempty"`
+	Environment    string `json:"environment,omitempty"`
 	EnvironmentURL string `json:"environment_url,omitempty"`
-	LogURL        string `json:"log_url,omitempty"`
-	Creator       User   `json:"creator"`
-	CreatedAt     string `json:"created_at"`
-	UpdatedAt     string `json:"updated_at"`
+	LogURL         string `json:"log_url,omitempty"`
+	Creator        User   `json:"creator"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
 
 	RepoOwner    string `json:"-"`
 	RepoName     string `json:"-"`
@@ -401,17 +401,17 @@ type DeploymentStatus struct {
 
 // ReleaseAsset represents an asset attached to a release.
 type ReleaseAsset struct {
-	ID            int64  `json:"id"`
-	Name          string `json:"name"`
-	Label         string `json:"label,omitempty"`
-	ContentType   string `json:"content_type"`
-	Size          int    `json:"size"`
-	State         string `json:"state"` // "uploaded"
-	DownloadCount int    `json:"download_count"`
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
+	Label              string `json:"label,omitempty"`
+	ContentType        string `json:"content_type"`
+	Size               int    `json:"size"`
+	State              string `json:"state"` // "uploaded"
+	DownloadCount      int    `json:"download_count"`
 	BrowserDownloadURL string `json:"browser_download_url"`
-	CreatedAt     string `json:"created_at"`
-	UpdatedAt     string `json:"updated_at"`
-	Uploader      User   `json:"uploader"`
+	CreatedAt          string `json:"created_at"`
+	UpdatedAt          string `json:"updated_at"`
+	Uploader           User   `json:"uploader"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -437,20 +437,20 @@ type Workflow struct {
 
 // WorkflowRun represents a single execution of a workflow.
 type WorkflowRun struct {
-	ID           int64  `json:"id"`
-	Name         string `json:"name"`
-	WorkflowID   int64  `json:"workflow_id"`
-	HeadBranch   string `json:"head_branch"`
-	HeadSHA      string `json:"head_sha"`
-	Status       string `json:"status"` // "queued", "in_progress", "completed"
-	Conclusion   string `json:"conclusion,omitempty"` // "success", "failure", "cancelled", etc.
-	Event        string `json:"event"` // "push", "pull_request", "workflow_dispatch", etc.
-	RunNumber    int    `json:"run_number"`
-	RunAttempt   int    `json:"run_attempt"`
-	HTMLURL      string `json:"html_url"`
-	Actor        User   `json:"actor"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	WorkflowID int64  `json:"workflow_id"`
+	HeadBranch string `json:"head_branch"`
+	HeadSHA    string `json:"head_sha"`
+	Status     string `json:"status"`               // "queued", "in_progress", "completed"
+	Conclusion string `json:"conclusion,omitempty"` // "success", "failure", "cancelled", etc.
+	Event      string `json:"event"`                // "push", "pull_request", "workflow_dispatch", etc.
+	RunNumber  int    `json:"run_number"`
+	RunAttempt int    `json:"run_attempt"`
+	HTMLURL    string `json:"html_url"`
+	Actor      User   `json:"actor"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -458,15 +458,15 @@ type WorkflowRun struct {
 
 // WorkflowJob represents a job within a workflow run.
 type WorkflowJob struct {
-	ID          int64    `json:"id"`
-	RunID       int64    `json:"run_id"`
-	Name        string   `json:"name"`
-	Status      string   `json:"status"` // "queued", "in_progress", "completed"
-	Conclusion  string   `json:"conclusion,omitempty"`
-	StartedAt   string   `json:"started_at,omitempty"`
-	CompletedAt string   `json:"completed_at,omitempty"`
+	ID          int64     `json:"id"`
+	RunID       int64     `json:"run_id"`
+	Name        string    `json:"name"`
+	Status      string    `json:"status"` // "queued", "in_progress", "completed"
+	Conclusion  string    `json:"conclusion,omitempty"`
+	StartedAt   string    `json:"started_at,omitempty"`
+	CompletedAt string    `json:"completed_at,omitempty"`
 	Steps       []JobStep `json:"steps,omitempty"`
-	HTMLURL     string   `json:"html_url"`
+	HTMLURL     string    `json:"html_url"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -530,12 +530,12 @@ type GitObject struct {
 
 // GitCommit represents a Git commit object (low-level).
 type GitCommit struct {
-	SHA     string        `json:"sha"`
-	Message string        `json:"message"`
-	Tree    GitTreeRef    `json:"tree"`
-	Parents []GitTreeRef  `json:"parents,omitempty"`
-	Author  GitSignature  `json:"author"`
-	HTMLURL string        `json:"html_url"`
+	SHA     string       `json:"sha"`
+	Message string       `json:"message"`
+	Tree    GitTreeRef   `json:"tree"`
+	Parents []GitTreeRef `json:"parents,omitempty"`
+	Author  GitSignature `json:"author"`
+	HTMLURL string       `json:"html_url"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`
@@ -556,10 +556,10 @@ type GitSignature struct {
 
 // GitTree represents a Git tree object.
 type GitTree struct {
-	SHA       string        `json:"sha"`
+	SHA       string         `json:"sha"`
 	Tree      []GitTreeEntry `json:"tree"`
-	Truncated bool          `json:"truncated"`
-	URL       string        `json:"url"`
+	Truncated bool           `json:"truncated"`
+	URL       string         `json:"url"`
 
 	RepoOwner string `json:"-"`
 	RepoName  string `json:"-"`

--- a/twin-hubspot/cmd/twin-hubspot/main.go
+++ b/twin-hubspot/cmd/twin-hubspot/main.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-hubspot/internal/api/handlers_associations.go
+++ b/twin-hubspot/internal/api/handlers_associations.go
@@ -148,8 +148,8 @@ func (h *Handler) BatchCreateAssociations(w http.ResponseWriter, r *http.Request
 		h.store.Associations.Set(id, assoc)
 
 		results = append(results, map[string]any{
-			"from":               map[string]any{"id": input.From.ID},
-			"to":                 map[string]any{"id": input.To.ID},
+			"from":                map[string]any{"id": input.From.ID},
+			"to":                  map[string]any{"id": input.To.ID},
 			"associationCategory": category,
 			"associationTypeId":   typeID,
 		})

--- a/twin-hubspot/internal/api/handlers_pipelines.go
+++ b/twin-hubspot/internal/api/handlers_pipelines.go
@@ -23,7 +23,7 @@ func (h *Handler) CreatePipeline(w http.ResponseWriter, r *http.Request) {
 	objectType := chi.URLParam(r, "objectType")
 
 	var body struct {
-		Label  string               `json:"label"`
+		Label  string                `json:"label"`
 		Stages []store.PipelineStage `json:"stages"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/twin-hubspot/internal/api/handlers_properties.go
+++ b/twin-hubspot/internal/api/handlers_properties.go
@@ -71,11 +71,11 @@ func (h *Handler) UpdateProperty(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Label       *string           `json:"label,omitempty"`
-		Type        *string           `json:"type,omitempty"`
-		FieldType   *string           `json:"fieldType,omitempty"`
-		GroupName   *string           `json:"groupName,omitempty"`
-		Description *string           `json:"description,omitempty"`
+		Label       *string                `json:"label,omitempty"`
+		Type        *string                `json:"type,omitempty"`
+		FieldType   *string                `json:"fieldType,omitempty"`
+		GroupName   *string                `json:"groupName,omitempty"`
+		Description *string                `json:"description,omitempty"`
 		Options     []store.PropertyOption `json:"options,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/twin-hubspot/internal/api/handlers_test.go
+++ b/twin-hubspot/internal/api/handlers_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/store"
 )
 
 func setupHubSpot(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-hubspot/internal/api/router.go
+++ b/twin-hubspot/internal/api/router.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-hubspot/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 type Handler struct {

--- a/twin-hubspot/internal/store/types.go
+++ b/twin-hubspot/internal/store/types.go
@@ -28,8 +28,8 @@ type Association struct {
 type Property struct {
 	Name        string           `json:"name"`
 	Label       string           `json:"label"`
-	Type        string           `json:"type"`        // "string", "number", "date", "datetime", "enumeration", "bool"
-	FieldType   string           `json:"fieldType"`   // "text", "textarea", "number", "select", etc.
+	Type        string           `json:"type"`      // "string", "number", "date", "datetime", "enumeration", "bool"
+	FieldType   string           `json:"fieldType"` // "text", "textarea", "number", "select", etc.
 	GroupName   string           `json:"groupName"`
 	Description string           `json:"description,omitempty"`
 	Options     []PropertyOption `json:"options,omitempty"`
@@ -44,27 +44,27 @@ type PropertyOption struct {
 
 // PropertyGroup groups related properties.
 type PropertyGroup struct {
-	Name        string `json:"name"`
-	Label       string `json:"label"`
-	ObjectType  string `json:"-"`
+	Name       string `json:"name"`
+	Label      string `json:"label"`
+	ObjectType string `json:"-"`
 }
 
 // Pipeline represents a deal or ticket pipeline.
 type Pipeline struct {
-	ID          string          `json:"id"`
-	Label       string          `json:"label"`
-	Stages      []PipelineStage `json:"stages"`
-	ObjectType  string          `json:"-"` // "deals" or "tickets"
-	CreatedAt   string          `json:"createdAt"`
-	UpdatedAt   string          `json:"updatedAt"`
+	ID         string          `json:"id"`
+	Label      string          `json:"label"`
+	Stages     []PipelineStage `json:"stages"`
+	ObjectType string          `json:"-"` // "deals" or "tickets"
+	CreatedAt  string          `json:"createdAt"`
+	UpdatedAt  string          `json:"updatedAt"`
 }
 
 // PipelineStage represents a stage within a pipeline.
 type PipelineStage struct {
-	ID          string  `json:"id"`
-	Label       string  `json:"label"`
-	DisplayOrder int    `json:"displayOrder"`
-	Metadata    map[string]any `json:"metadata,omitempty"` // probability for deals, ticketState for tickets
+	ID           string         `json:"id"`
+	Label        string         `json:"label"`
+	DisplayOrder int            `json:"displayOrder"`
+	Metadata     map[string]any `json:"metadata,omitempty"` // probability for deals, ticketState for tickets
 }
 
 // Owner represents a HubSpot owner (user).
@@ -82,9 +82,9 @@ type Owner struct {
 type List struct {
 	ID             string   `json:"listId"`
 	Name           string   `json:"name"`
-	ObjectTypeID   string   `json:"objectTypeId"` // "0-1" contacts, "0-2" companies, etc.
+	ObjectTypeID   string   `json:"objectTypeId"`   // "0-1" contacts, "0-2" companies, etc.
 	ProcessingType string   `json:"processingType"` // "MANUAL" or "DYNAMIC"
-	MemberIDs      []string `json:"-"` // internal: member object IDs
+	MemberIDs      []string `json:"-"`              // internal: member object IDs
 }
 
 // Webhook represents a HubSpot webhook subscription.

--- a/twin-linear/cmd/twin-linear/main.go
+++ b/twin-linear/cmd/twin-linear/main.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-linear/internal/api/handlers_test.go
+++ b/twin-linear/internal/api/handlers_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
 )
 
 func setupLinear(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-linear/internal/api/resolvers.go
+++ b/twin-linear/internal/api/resolvers.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/graphql"
 	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/graphql"
 )
 
 // RegisterResolvers registers all Linear API queries and mutations on the schema.
@@ -345,14 +345,14 @@ func registerMutations(schema *graphql.Schema, s *store.MemoryStore) {
 		now := s.Now()
 		id := s.NextID()
 		p := store.Project{
-			ID:        id,
-			Name:      getString(input, "name"),
+			ID:          id,
+			Name:        getString(input, "name"),
 			Description: getString(input, "description"),
-			State:     "planned",
-			SlugID:    id,
-			URL:       "https://linear.app/wondertwin/project/" + id,
-			CreatedAt: now,
-			UpdatedAt: now,
+			State:       "planned",
+			SlugID:      id,
+			URL:         "https://linear.app/wondertwin/project/" + id,
+			CreatedAt:   now,
+			UpdatedAt:   now,
 		}
 		s.Projects.Set(id, p)
 		return store.MutationResult(true, p, "project"), nil

--- a/twin-linear/internal/api/router.go
+++ b/twin-linear/internal/api/router.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
 	gql "github.com/wondertwin-ai/wondertwin/twinkit/graphql"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-linear/internal/store"
 )
 
 // Handler holds Linear API state.

--- a/twin-linear/internal/store/memory.go
+++ b/twin-linear/internal/store/memory.go
@@ -30,9 +30,9 @@ type MemoryStore struct {
 
 	Org Organization
 
-	idCounter     atomic.Int64
-	issueCounter  atomic.Int64
-	cycleCounter  atomic.Int64
+	idCounter    atomic.Int64
+	issueCounter atomic.Int64
+	cycleCounter atomic.Int64
 }
 
 func New() *MemoryStore {

--- a/twin-linear/internal/store/types.go
+++ b/twin-linear/internal/store/types.go
@@ -3,27 +3,27 @@ package store
 
 // Issue is the core work item in Linear.
 type Issue struct {
-	ID          string  `json:"id"`
-	Identifier  string  `json:"identifier"` // "ENG-123"
-	Title       string  `json:"title"`
-	Description string  `json:"description,omitempty"`
-	Priority    int     `json:"priority"` // 0=none, 1=urgent, 2=high, 3=medium, 4=low
-	Estimate    float64 `json:"estimate,omitempty"`
-	SortOrder   float64 `json:"sortOrder"`
-	BoardOrder  float64 `json:"boardOrder"`
-	DueDate     string  `json:"dueDate,omitempty"`
-	TeamID      string  `json:"teamId"`       // internal: team reference
-	StateID     string  `json:"stateId"`      // internal: workflow state
-	AssigneeID  string  `json:"assigneeId,omitempty"`
-	ProjectID   string  `json:"projectId,omitempty"`
-	CycleID     string  `json:"cycleId,omitempty"`
-	ParentID    string  `json:"parentId,omitempty"`
+	ID          string   `json:"id"`
+	Identifier  string   `json:"identifier"` // "ENG-123"
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Priority    int      `json:"priority"` // 0=none, 1=urgent, 2=high, 3=medium, 4=low
+	Estimate    float64  `json:"estimate,omitempty"`
+	SortOrder   float64  `json:"sortOrder"`
+	BoardOrder  float64  `json:"boardOrder"`
+	DueDate     string   `json:"dueDate,omitempty"`
+	TeamID      string   `json:"teamId"`  // internal: team reference
+	StateID     string   `json:"stateId"` // internal: workflow state
+	AssigneeID  string   `json:"assigneeId,omitempty"`
+	ProjectID   string   `json:"projectId,omitempty"`
+	CycleID     string   `json:"cycleId,omitempty"`
+	ParentID    string   `json:"parentId,omitempty"`
 	LabelIDs    []string `json:"labelIds,omitempty"`
-	CreatedAt   string  `json:"createdAt"`
-	UpdatedAt   string  `json:"updatedAt"`
-	ArchivedAt  string  `json:"archivedAt,omitempty"`
-	Number      int     `json:"number"`
-	URL         string  `json:"url"`
+	CreatedAt   string   `json:"createdAt"`
+	UpdatedAt   string   `json:"updatedAt"`
+	ArchivedAt  string   `json:"archivedAt,omitempty"`
+	Number      int      `json:"number"`
+	URL         string   `json:"url"`
 }
 
 // Team is an organizational unit. Issues belong to teams.
@@ -38,12 +38,12 @@ type Team struct {
 
 // WorkflowState represents an issue status.
 type WorkflowState struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Type     string `json:"type"` // "backlog", "unstarted", "started", "completed", "canceled", "triage"
-	Color    string `json:"color"`
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Type     string  `json:"type"` // "backlog", "unstarted", "started", "completed", "canceled", "triage"
+	Color    string  `json:"color"`
 	Position float64 `json:"position"`
-	TeamID   string `json:"teamId"`
+	TeamID   string  `json:"teamId"`
 }
 
 // User represents a Linear workspace member.

--- a/twin-logodev/cmd/twin-logodev/main.go
+++ b/twin-logodev/cmd/twin-logodev/main.go
@@ -4,10 +4,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-logodev/internal/api/handlers_search.go
+++ b/twin-logodev/internal/api/handlers_search.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // SearchBrands handles GET /api/v1/search?q=query — searches seeded brands.

--- a/twin-logodev/internal/api/handlers_test.go
+++ b/twin-logodev/internal/api/handlers_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
 )
 
 func setupLogodev(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-logodev/internal/api/router.go
+++ b/twin-logodev/internal/api/router.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-logodev/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Handler holds logo API state.
@@ -27,7 +27,6 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Use(h.tokenAuthMiddleware)
 		r.Use(h.mw.FaultInjection)
 
-
 		r.Get("/name/{name}", h.GetLogoByName)
 		r.Get("/ticker/{symbol}", h.GetLogoByTicker)
 		r.Get("/crypto/{symbol}", h.GetLogoByCrypto)
@@ -39,7 +38,6 @@ func (h *Handler) Routes(r chi.Router) {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(h.tokenAuthMiddleware)
 		r.Use(h.mw.FaultInjection)
-
 
 		r.Get("/search", h.SearchBrands)
 		r.Get("/describe/{domain}", h.DescribeBrand)

--- a/twin-posthog/cmd/twin-posthog/main.go
+++ b/twin-posthog/cmd/twin-posthog/main.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"os"
 
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	pkgevents "github.com/wondertwin-ai/wondertwin/twinkit/events"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 )
 
 func main() {

--- a/twin-posthog/internal/api/handlers_capture.go
+++ b/twin-posthog/internal/api/handlers_capture.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 	pkgevents "github.com/wondertwin-ai/wondertwin/twinkit/events"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 )
 
 // captureRequest represents a PostHog capture request body.
@@ -146,11 +146,11 @@ func (h *Handler) Decide(w http.ResponseWriter, r *http.Request) {
 	}
 
 	twincore.JSON(w, http.StatusOK, map[string]any{
-		"featureFlags":                featureFlags,
-		"featureFlagPayloads":         featureFlagPayloads,
-		"errorsWhileComputingFlags":   false,
-		"requestId":                   h.store.Events.NextID(),
-		"quotaLimited":               []string{},
+		"featureFlags":              featureFlags,
+		"featureFlagPayloads":       featureFlagPayloads,
+		"errorsWhileComputingFlags": false,
+		"requestId":                 h.store.Events.NextID(),
+		"quotaLimited":              []string{},
 	})
 }
 

--- a/twin-posthog/internal/api/handlers_flags.go
+++ b/twin-posthog/internal/api/handlers_flags.go
@@ -35,7 +35,7 @@ func (h *Handler) Flags(w http.ResponseWriter, r *http.Request) {
 		"featureFlagPayloads":       featureFlagPayloads,
 		"errorsWhileComputingFlags": false,
 		"requestId":                 h.store.Events.NextID(),
-		"quotaLimited":             []string{},
+		"quotaLimited":              []string{},
 	})
 }
 
@@ -59,13 +59,13 @@ func (h *Handler) LocalEvaluation(w http.ResponseWriter, r *http.Request) {
 	flagDefs := make([]map[string]any, 0, len(flags))
 	for _, flag := range flags {
 		def := map[string]any{
-			"id":                  flag.Key,
-			"key":                 flag.Key,
-			"name":                flag.Key,
-			"active":              flag.Enabled,
-			"is_simple_flag":      true,
-			"rollout_percentage":  100,
-			"filters":             map[string]any{
+			"id":                 flag.Key,
+			"key":                flag.Key,
+			"name":               flag.Key,
+			"active":             flag.Enabled,
+			"is_simple_flag":     true,
+			"rollout_percentage": 100,
+			"filters": map[string]any{
 				"groups": []map[string]any{
 					{
 						"rollout_percentage": 100,
@@ -88,7 +88,7 @@ func (h *Handler) LocalEvaluation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	twincore.JSON(w, http.StatusOK, map[string]any{
-		"flags":             flagDefs,
+		"flags":              flagDefs,
 		"group_type_mapping": map[string]any{},
 	})
 }

--- a/twin-posthog/internal/api/handlers_flags_mgmt.go
+++ b/twin-posthog/internal/api/handlers_flags_mgmt.go
@@ -51,10 +51,10 @@ func (h *Handler) GetFeatureFlag(w http.ResponseWriter, r *http.Request) {
 // CreateFeatureFlag handles POST /api/projects/{project_id}/feature_flags/
 func (h *Handler) CreateFeatureFlag(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Key                string `json:"key"`
-		Name               string `json:"name"`
-		Active             *bool  `json:"active"`
-		RolloutPercentage  *int   `json:"rollout_percentage"`
+		Key               string `json:"key"`
+		Name              string `json:"name"`
+		Active            *bool  `json:"active"`
+		RolloutPercentage *int   `json:"rollout_percentage"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Key == "" {
 		twincore.JSON(w, http.StatusBadRequest, map[string]any{
@@ -146,12 +146,12 @@ func (h *Handler) ListEarlyAccessFeatures(w http.ResponseWriter, r *http.Request
 // flagToAPI converts a FeatureFlag to the PostHog API response format.
 func flagToAPI(flag store.FeatureFlag) map[string]any {
 	result := map[string]any{
-		"id":                   flag.Key, // use key as ID in sim
-		"key":                  flag.Key,
-		"name":                 flag.Key,
-		"active":               flag.Enabled,
-		"is_simple_flag":       flag.Variant == "",
-		"rollout_percentage":   100,
+		"id":                           flag.Key, // use key as ID in sim
+		"key":                          flag.Key,
+		"name":                         flag.Key,
+		"active":                       flag.Enabled,
+		"is_simple_flag":               flag.Variant == "",
+		"rollout_percentage":           100,
 		"ensure_experience_continuity": false,
 		"filters": map[string]any{
 			"groups": []map[string]any{

--- a/twin-posthog/internal/api/handlers_test.go
+++ b/twin-posthog/internal/api/handlers_test.go
@@ -4,11 +4,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 )
 
 func setupPostHog(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-posthog/internal/api/router.go
+++ b/twin-posthog/internal/api/router.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 	pkgevents "github.com/wondertwin-ai/wondertwin/twinkit/events"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-posthog/internal/store"
 )
 
 // Handler holds all API handler state.
@@ -32,11 +32,11 @@ func (h *Handler) Routes(r chi.Router) {
 		r.Post("/capture/", h.CaptureEvent)
 		r.Post("/batch", h.BatchCapture)
 		r.Post("/batch/", h.BatchCapture)
-		r.Post("/e", h.CaptureEvent)   // JS SDK alternative endpoint
+		r.Post("/e", h.CaptureEvent) // JS SDK alternative endpoint
 		r.Post("/e/", h.CaptureEvent)
-		r.Post("/decide/", h.Decide)    // Feature flag evaluation
+		r.Post("/decide/", h.Decide) // Feature flag evaluation
 		r.Post("/decide", h.Decide)
-		r.Post("/flags", h.Flags)       // Feature flags v2
+		r.Post("/flags", h.Flags) // Feature flags v2
 		r.Post("/flags/", h.Flags)
 		r.Get("/api/feature_flag/local_evaluation", h.LocalEvaluation)
 		r.Get("/api/feature_flag/local_evaluation/", h.LocalEvaluation)

--- a/twin-resend/cmd/twin-resend/main.go
+++ b/twin-resend/cmd/twin-resend/main.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"os"
 
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 )
 
 func main() {

--- a/twin-resend/internal/api/handlers_emails.go
+++ b/twin-resend/internal/api/handlers_emails.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 )
 
 // sendEmailRequest matches the Resend send email API request body.

--- a/twin-resend/internal/api/handlers_test.go
+++ b/twin-resend/internal/api/handlers_test.go
@@ -4,11 +4,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 )
 
 func setupResend(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-resend/internal/api/router.go
+++ b/twin-resend/internal/api/router.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-resend/internal/store"
 )
 
 // Handler holds all API handler state.

--- a/twin-resend/internal/store/types.go
+++ b/twin-resend/internal/store/types.go
@@ -38,11 +38,11 @@ type Domain struct {
 
 // DomainRecord is a DNS record needed for domain verification.
 type DomainRecord struct {
-	Record   string `json:"record"`   // CNAME, TXT, MX
+	Record   string `json:"record"` // CNAME, TXT, MX
 	Name     string `json:"name"`
 	Type     string `json:"type"`
 	TTL      string `json:"ttl"`
-	Status   string `json:"status"`   // not_started, verified
+	Status   string `json:"status"` // not_started, verified
 	Value    string `json:"value"`
 	Priority *int   `json:"priority,omitempty"`
 }
@@ -78,16 +78,16 @@ type Contact struct {
 
 // Broadcast represents a broadcast email to an audience.
 type Broadcast struct {
-	ID         string `json:"id"`
-	Object     string `json:"object"` // "broadcast"
-	Name       string `json:"name"`
-	AudienceID string `json:"audience_id"`
-	From       string `json:"from"`
-	Subject    string `json:"subject"`
+	ID         string   `json:"id"`
+	Object     string   `json:"object"` // "broadcast"
+	Name       string   `json:"name"`
+	AudienceID string   `json:"audience_id"`
+	From       string   `json:"from"`
+	Subject    string   `json:"subject"`
 	ReplyTo    []string `json:"reply_to,omitempty"`
-	HTML       string `json:"html,omitempty"`
-	Text       string `json:"text,omitempty"`
-	Status     string `json:"status"` // draft, queued, sending, sent
-	CreatedAt  string `json:"created_at"`
-	SentAt     string `json:"sent_at,omitempty"`
+	HTML       string   `json:"html,omitempty"`
+	Text       string   `json:"text,omitempty"`
+	Status     string   `json:"status"` // draft, queued, sending, sent
+	CreatedAt  string   `json:"created_at"`
+	SentAt     string   `json:"sent_at,omitempty"`
 }

--- a/twin-shopify/cmd/twin-shopify/main.go
+++ b/twin-shopify/cmd/twin-shopify/main.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-shopify/internal/api/handlers_test.go
+++ b/twin-shopify/internal/api/handlers_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/store"
 )
 
 const v = "/admin/api/2025-04"
@@ -80,9 +80,9 @@ func TestProductCRUD(t *testing.T) {
 	// Create
 	resp := sPost(tc, v+"/products.json", map[string]any{
 		"product": map[string]any{
-			"title":   "Test Widget",
-			"vendor":  "ACME",
-			"status":  "active",
+			"title":  "Test Widget",
+			"vendor": "ACME",
+			"status": "active",
 		},
 	})
 	resp.AssertStatus(201)
@@ -247,7 +247,7 @@ func TestInventoryLevels(t *testing.T) {
 	resp = sPost(tc, v+"/inventory_levels/set.json", map[string]any{
 		"inventory_item_id": 1,
 		"location_id":       1,
-		"available":          50,
+		"available":         50,
 	})
 	resp.AssertStatus(200)
 }

--- a/twin-shopify/internal/api/router.go
+++ b/twin-shopify/internal/api/router.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-shopify/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Handler holds Shopify API state.

--- a/twin-shopify/internal/store/memory.go
+++ b/twin-shopify/internal/store/memory.go
@@ -100,13 +100,13 @@ func (s *MemoryStore) Now() string {
 }
 
 type stateSnapshot struct {
-	Products          map[string]Product     `json:"products,omitempty"`
-	Orders            map[string]Order       `json:"orders,omitempty"`
-	Customers         map[string]Customer    `json:"customers,omitempty"`
-	CustomCollections map[string]Collection  `json:"custom_collections,omitempty"`
-	Webhooks          map[string]Webhook     `json:"webhooks,omitempty"`
-	Locations         map[string]Location    `json:"locations,omitempty"`
-	Shop              *Shop                  `json:"shop,omitempty"`
+	Products          map[string]Product    `json:"products,omitempty"`
+	Orders            map[string]Order      `json:"orders,omitempty"`
+	Customers         map[string]Customer   `json:"customers,omitempty"`
+	CustomCollections map[string]Collection `json:"custom_collections,omitempty"`
+	Webhooks          map[string]Webhook    `json:"webhooks,omitempty"`
+	Locations         map[string]Location   `json:"locations,omitempty"`
+	Shop              *Shop                 `json:"shop,omitempty"`
 }
 
 func (s *MemoryStore) Snapshot() any {

--- a/twin-shopify/internal/store/types.go
+++ b/twin-shopify/internal/store/types.go
@@ -20,23 +20,23 @@ type Product struct {
 
 // Variant represents a product variant.
 type Variant struct {
-	ID                int64  `json:"id"`
-	ProductID         int64  `json:"product_id"`
-	Title             string `json:"title"`
-	Price             string `json:"price"`
-	CompareAtPrice    string `json:"compare_at_price,omitempty"`
-	SKU               string `json:"sku"`
-	Barcode           string `json:"barcode,omitempty"`
-	Position          int    `json:"position"`
-	InventoryItemID   int64  `json:"inventory_item_id"`
-	InventoryQuantity int    `json:"inventory_quantity"`
+	ID                int64   `json:"id"`
+	ProductID         int64   `json:"product_id"`
+	Title             string  `json:"title"`
+	Price             string  `json:"price"`
+	CompareAtPrice    string  `json:"compare_at_price,omitempty"`
+	SKU               string  `json:"sku"`
+	Barcode           string  `json:"barcode,omitempty"`
+	Position          int     `json:"position"`
+	InventoryItemID   int64   `json:"inventory_item_id"`
+	InventoryQuantity int     `json:"inventory_quantity"`
 	Weight            float64 `json:"weight"`
-	WeightUnit        string `json:"weight_unit"`
-	Option1           string `json:"option1,omitempty"`
-	Option2           string `json:"option2,omitempty"`
-	Option3           string `json:"option3,omitempty"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
+	WeightUnit        string  `json:"weight_unit"`
+	Option1           string  `json:"option1,omitempty"`
+	Option2           string  `json:"option2,omitempty"`
+	Option3           string  `json:"option3,omitempty"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
 }
 
 // Image represents a product image.
@@ -54,58 +54,58 @@ type Image struct {
 
 // Order represents a Shopify order.
 type Order struct {
-	ID                  int64       `json:"id"`
-	Name                string      `json:"name"` // "#1001"
-	OrderNumber         int         `json:"order_number"`
-	Email               string      `json:"email"`
-	FinancialStatus     string      `json:"financial_status"` // "pending", "paid", "refunded", etc.
-	FulfillmentStatus   string      `json:"fulfillment_status,omitempty"` // null, "fulfilled", "partial"
-	Currency            string      `json:"currency"`
-	TotalPrice          string      `json:"total_price"`
-	SubtotalPrice       string      `json:"subtotal_price"`
-	TotalTax            string      `json:"total_tax"`
-	TotalDiscounts      string      `json:"total_discounts"`
-	LineItems           []LineItem  `json:"line_items,omitempty"`
-	Customer            *Customer   `json:"customer,omitempty"`
-	ShippingAddress     *Address    `json:"shipping_address,omitempty"`
-	BillingAddress      *Address    `json:"billing_address,omitempty"`
-	Note                string      `json:"note,omitempty"`
-	Tags                string      `json:"tags,omitempty"`
-	Cancelled           bool        `json:"cancelled"`
-	CancelledAt         string      `json:"cancelled_at,omitempty"`
-	ClosedAt            string      `json:"closed_at,omitempty"`
-	CreatedAt           string      `json:"created_at"`
-	UpdatedAt           string      `json:"updated_at"`
+	ID                int64      `json:"id"`
+	Name              string     `json:"name"` // "#1001"
+	OrderNumber       int        `json:"order_number"`
+	Email             string     `json:"email"`
+	FinancialStatus   string     `json:"financial_status"`             // "pending", "paid", "refunded", etc.
+	FulfillmentStatus string     `json:"fulfillment_status,omitempty"` // null, "fulfilled", "partial"
+	Currency          string     `json:"currency"`
+	TotalPrice        string     `json:"total_price"`
+	SubtotalPrice     string     `json:"subtotal_price"`
+	TotalTax          string     `json:"total_tax"`
+	TotalDiscounts    string     `json:"total_discounts"`
+	LineItems         []LineItem `json:"line_items,omitempty"`
+	Customer          *Customer  `json:"customer,omitempty"`
+	ShippingAddress   *Address   `json:"shipping_address,omitempty"`
+	BillingAddress    *Address   `json:"billing_address,omitempty"`
+	Note              string     `json:"note,omitempty"`
+	Tags              string     `json:"tags,omitempty"`
+	Cancelled         bool       `json:"cancelled"`
+	CancelledAt       string     `json:"cancelled_at,omitempty"`
+	ClosedAt          string     `json:"closed_at,omitempty"`
+	CreatedAt         string     `json:"created_at"`
+	UpdatedAt         string     `json:"updated_at"`
 }
 
 // LineItem represents an order line item.
 type LineItem struct {
-	ID         int64  `json:"id"`
-	ProductID  int64  `json:"product_id"`
-	VariantID  int64  `json:"variant_id"`
-	Title      string `json:"title"`
-	Quantity   int    `json:"quantity"`
-	Price      string `json:"price"`
-	SKU        string `json:"sku,omitempty"`
-	Name       string `json:"name"`
+	ID        int64  `json:"id"`
+	ProductID int64  `json:"product_id"`
+	VariantID int64  `json:"variant_id"`
+	Title     string `json:"title"`
+	Quantity  int    `json:"quantity"`
+	Price     string `json:"price"`
+	SKU       string `json:"sku,omitempty"`
+	Name      string `json:"name"`
 }
 
 // Customer represents a Shopify customer.
 type Customer struct {
-	ID               int64      `json:"id"`
-	Email            string     `json:"email"`
-	FirstName        string     `json:"first_name"`
-	LastName         string     `json:"last_name"`
-	Phone            string     `json:"phone,omitempty"`
-	OrdersCount      int        `json:"orders_count"`
-	TotalSpent       string     `json:"total_spent"`
-	State            string     `json:"state"` // "enabled", "disabled", "invited"
-	Tags             string     `json:"tags,omitempty"`
-	Note             string     `json:"note,omitempty"`
-	Addresses        []Address  `json:"addresses,omitempty"`
-	DefaultAddress   *Address   `json:"default_address,omitempty"`
-	CreatedAt        string     `json:"created_at"`
-	UpdatedAt        string     `json:"updated_at"`
+	ID             int64     `json:"id"`
+	Email          string    `json:"email"`
+	FirstName      string    `json:"first_name"`
+	LastName       string    `json:"last_name"`
+	Phone          string    `json:"phone,omitempty"`
+	OrdersCount    int       `json:"orders_count"`
+	TotalSpent     string    `json:"total_spent"`
+	State          string    `json:"state"` // "enabled", "disabled", "invited"
+	Tags           string    `json:"tags,omitempty"`
+	Note           string    `json:"note,omitempty"`
+	Addresses      []Address `json:"addresses,omitempty"`
+	DefaultAddress *Address  `json:"default_address,omitempty"`
+	CreatedAt      string    `json:"created_at"`
+	UpdatedAt      string    `json:"updated_at"`
 }
 
 // Address represents a customer or order address.
@@ -142,22 +142,22 @@ type Collection struct {
 
 // Collect represents a product-to-collection link.
 type Collect struct {
-	ID           int64 `json:"id"`
-	CollectionID int64 `json:"collection_id"`
-	ProductID    int64 `json:"product_id"`
-	Position     int   `json:"position"`
+	ID           int64  `json:"id"`
+	CollectionID int64  `json:"collection_id"`
+	ProductID    int64  `json:"product_id"`
+	Position     int    `json:"position"`
 	CreatedAt    string `json:"created_at"`
 }
 
 // InventoryItem represents an inventory item.
 type InventoryItem struct {
-	ID                int64  `json:"id"`
-	SKU               string `json:"sku"`
-	Tracked           bool   `json:"tracked"`
-	Cost              string `json:"cost,omitempty"`
+	ID                  int64  `json:"id"`
+	SKU                 string `json:"sku"`
+	Tracked             bool   `json:"tracked"`
+	Cost                string `json:"cost,omitempty"`
 	CountryCodeOfOrigin string `json:"country_code_of_origin,omitempty"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
+	CreatedAt           string `json:"created_at"`
+	UpdatedAt           string `json:"updated_at"`
 }
 
 // InventoryLevel represents inventory at a location.
@@ -193,17 +193,17 @@ type Fulfillment struct {
 
 // FulfillmentOrder represents a fulfillment order.
 type FulfillmentOrder struct {
-	ID             int64  `json:"id"`
-	OrderID        int64  `json:"order_id"`
-	Status         string `json:"status"` // "open", "in_progress", "closed", "cancelled"
-	AssignedLocationID int64 `json:"assigned_location_id"`
+	ID                 int64  `json:"id"`
+	OrderID            int64  `json:"order_id"`
+	Status             string `json:"status"` // "open", "in_progress", "closed", "cancelled"
+	AssignedLocationID int64  `json:"assigned_location_id"`
 }
 
 // Transaction represents a payment transaction on an order.
 type Transaction struct {
 	ID        int64  `json:"id"`
 	OrderID   int64  `json:"order_id"`
-	Kind      string `json:"kind"` // "sale", "capture", "authorization", "void", "refund"
+	Kind      string `json:"kind"`   // "sale", "capture", "authorization", "void", "refund"
 	Status    string `json:"status"` // "success", "failure", "pending", "error"
 	Amount    string `json:"amount"`
 	Currency  string `json:"currency"`
@@ -246,15 +246,15 @@ type Webhook struct {
 
 // Metafield represents a metafield on any resource.
 type Metafield struct {
-	ID          int64  `json:"id"`
-	Namespace   string `json:"namespace"`
-	Key         string `json:"key"`
-	Value       string `json:"value"`
-	Type        string `json:"type"` // "single_line_text_field", "number_integer", etc.
-	OwnerID     int64  `json:"owner_id"`
+	ID            int64  `json:"id"`
+	Namespace     string `json:"namespace"`
+	Key           string `json:"key"`
+	Value         string `json:"value"`
+	Type          string `json:"type"` // "single_line_text_field", "number_integer", etc.
+	OwnerID       int64  `json:"owner_id"`
 	OwnerResource string `json:"owner_resource"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
 }
 
 // Theme represents a Shopify theme.
@@ -290,17 +290,17 @@ type Page struct {
 
 // PriceRule represents a Shopify price rule.
 type PriceRule struct {
-	ID                int64  `json:"id"`
-	Title             string `json:"title"`
-	TargetType        string `json:"target_type"` // "line_item", "shipping_line"
-	ValueType         string `json:"value_type"` // "fixed_amount", "percentage"
-	Value             string `json:"value"`
-	OncePerCustomer   bool   `json:"once_per_customer"`
-	UsageLimit        *int   `json:"usage_limit,omitempty"`
-	StartsAt          string `json:"starts_at"`
-	EndsAt            string `json:"ends_at,omitempty"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
+	ID              int64  `json:"id"`
+	Title           string `json:"title"`
+	TargetType      string `json:"target_type"` // "line_item", "shipping_line"
+	ValueType       string `json:"value_type"`  // "fixed_amount", "percentage"
+	Value           string `json:"value"`
+	OncePerCustomer bool   `json:"once_per_customer"`
+	UsageLimit      *int   `json:"usage_limit,omitempty"`
+	StartsAt        string `json:"starts_at"`
+	EndsAt          string `json:"ends_at,omitempty"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
 }
 
 // DiscountCode represents a discount code.
@@ -315,29 +315,29 @@ type DiscountCode struct {
 
 // GiftCard represents a Shopify gift card.
 type GiftCard struct {
-	ID          int64  `json:"id"`
-	Code        string `json:"code"`
-	Balance     string `json:"balance"`
+	ID           int64  `json:"id"`
+	Code         string `json:"code"`
+	Balance      string `json:"balance"`
 	InitialValue string `json:"initial_value"`
-	Currency    string `json:"currency"`
-	Disabled    bool   `json:"disabled_at,omitempty"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	Currency     string `json:"currency"`
+	Disabled     bool   `json:"disabled_at,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 }
 
 // Shop represents shop info.
 type Shop struct {
-	ID            int64  `json:"id"`
-	Name          string `json:"name"`
-	Email         string `json:"email"`
-	Domain        string `json:"domain"`
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	Email           string `json:"email"`
+	Domain          string `json:"domain"`
 	MyshopifyDomain string `json:"myshopify_domain"`
-	Currency      string `json:"currency"`
-	PlanName      string `json:"plan_name"`
-	Country       string `json:"country_name"`
-	Timezone      string `json:"timezone"`
-	CreatedAt     string `json:"created_at"`
-	UpdatedAt     string `json:"updated_at"`
+	Currency        string `json:"currency"`
+	PlanName        string `json:"plan_name"`
+	Country         string `json:"country_name"`
+	Timezone        string `json:"timezone"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
 }
 
 // ScriptTag represents a script tag.

--- a/twin-slack/cmd/twin-slack/main.go
+++ b/twin-slack/cmd/twin-slack/main.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/api"
 	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func main() {

--- a/twin-slack/internal/api/handlers_conversations.go
+++ b/twin-slack/internal/api/handlers_conversations.go
@@ -277,8 +277,8 @@ func (h *Handler) ConversationsSetTopic(w http.ResponseWriter, r *http.Request) 
 // ConversationsInvite handles POST /api/conversations.invite
 func (h *Handler) ConversationsInvite(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Channel string   `json:"channel"`
-		Users   string   `json:"users"` // comma-separated
+		Channel string `json:"channel"`
+		Users   string `json:"users"` // comma-separated
 	}
 	if err := parseJSON(r, &req); err != nil {
 		slackError(w, "invalid_json")
@@ -428,9 +428,9 @@ func (h *Handler) ConversationsOpen(w http.ResponseWriter, r *http.Request) {
 	}
 	h.store.Channels.Set(id, ch)
 	slackOK(w, map[string]any{
-		"channel":          ch,
-		"no_op":            false,
-		"already_open":     false,
+		"channel":      ch,
+		"no_op":        false,
+		"already_open": false,
 	})
 }
 
@@ -485,4 +485,3 @@ func splitParts(s string) []string {
 	parts = append(parts, s[start:])
 	return parts
 }
-

--- a/twin-slack/internal/api/handlers_files.go
+++ b/twin-slack/internal/api/handlers_files.go
@@ -20,12 +20,12 @@ func (h *Handler) FilesGetUploadURLExternal(w http.ResponseWriter, r *http.Reque
 
 	id := h.store.Files.NextID()
 	file := store.File{
-		ID:       id,
-		Name:     req.Filename,
-		Title:    req.Filename,
-		Size:     req.Length,
-		User:     "U_BOT",
-		Created:  h.store.Clock.Now().Unix(),
+		ID:      id,
+		Name:    req.Filename,
+		Title:   req.Filename,
+		Size:    req.Length,
+		User:    "U_BOT",
+		Created: h.store.Clock.Now().Unix(),
 	}
 	h.store.Files.Set(id, file)
 
@@ -38,7 +38,7 @@ func (h *Handler) FilesGetUploadURLExternal(w http.ResponseWriter, r *http.Reque
 // FilesCompleteUploadExternal handles POST /api/files.completeUploadExternal
 func (h *Handler) FilesCompleteUploadExternal(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Files   []struct {
+		Files []struct {
 			ID    string `json:"id"`
 			Title string `json:"title,omitempty"`
 		} `json:"files"`

--- a/twin-slack/internal/api/handlers_stubs.go
+++ b/twin-slack/internal/api/handlers_stubs.go
@@ -151,7 +151,7 @@ func (h *Handler) ViewsOpen(w http.ResponseWriter, r *http.Request) {
 	}
 	parseJSON(r, &req)
 	slackOK(w, map[string]any{"view": map[string]any{
-		"id": "V_" + h.store.Channels.NextID(),
+		"id":   "V_" + h.store.Channels.NextID(),
 		"type": "modal",
 	}})
 }
@@ -163,7 +163,7 @@ func (h *Handler) ViewsPush(w http.ResponseWriter, r *http.Request) {
 	}
 	parseJSON(r, &req)
 	slackOK(w, map[string]any{"view": map[string]any{
-		"id": "V_" + h.store.Channels.NextID(),
+		"id":   "V_" + h.store.Channels.NextID(),
 		"type": "modal",
 	}})
 }
@@ -180,7 +180,7 @@ func (h *Handler) ViewsUpdate(w http.ResponseWriter, r *http.Request) {
 		viewID = req.ExternalID
 	}
 	slackOK(w, map[string]any{"view": map[string]any{
-		"id": viewID,
+		"id":   viewID,
 		"type": "modal",
 	}})
 }
@@ -201,8 +201,8 @@ func (h *Handler) ViewsPublish(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) EmojiList(w http.ResponseWriter, r *http.Request) {
 	slackOK(w, map[string]any{"emoji": map[string]any{
-		"thumbsup":   "alias:+1",
-		"shipit":     "alias:squirrel",
+		"thumbsup": "alias:+1",
+		"shipit":   "alias:squirrel",
 	}})
 }
 
@@ -390,8 +390,8 @@ func (h *Handler) DndSetSnooze(w http.ResponseWriter, r *http.Request) {
 		NextStart: now, NextEnd: endtime,
 	}
 	slackOK(w, map[string]any{
-		"snooze_enabled":  true,
-		"snooze_endtime":  endtime,
+		"snooze_enabled":   true,
+		"snooze_endtime":   endtime,
 		"snooze_remaining": req.NumMinutes * 60,
 	})
 }

--- a/twin-slack/internal/api/handlers_test.go
+++ b/twin-slack/internal/api/handlers_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/store"
 )
 
 func setupSlack(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-slack/internal/api/router.go
+++ b/twin-slack/internal/api/router.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-slack/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Handler holds Slack API state.

--- a/twin-slack/internal/store/types.go
+++ b/twin-slack/internal/store/types.go
@@ -77,19 +77,19 @@ type User struct {
 
 // UserProfile holds profile fields for a Slack user.
 type UserProfile struct {
-	Email               string `json:"email,omitempty"`
-	DisplayName         string `json:"display_name"`
-	DisplayNameNorm     string `json:"display_name_normalized"`
-	RealName            string `json:"real_name"`
-	RealNameNorm        string `json:"real_name_normalized"`
-	StatusText          string `json:"status_text,omitempty"`
-	StatusEmoji         string `json:"status_emoji,omitempty"`
-	Image24             string `json:"image_24,omitempty"`
-	Image32             string `json:"image_32,omitempty"`
-	Image48             string `json:"image_48,omitempty"`
-	Image72             string `json:"image_72,omitempty"`
-	Image192            string `json:"image_192,omitempty"`
-	Image512            string `json:"image_512,omitempty"`
+	Email           string `json:"email,omitempty"`
+	DisplayName     string `json:"display_name"`
+	DisplayNameNorm string `json:"display_name_normalized"`
+	RealName        string `json:"real_name"`
+	RealNameNorm    string `json:"real_name_normalized"`
+	StatusText      string `json:"status_text,omitempty"`
+	StatusEmoji     string `json:"status_emoji,omitempty"`
+	Image24         string `json:"image_24,omitempty"`
+	Image32         string `json:"image_32,omitempty"`
+	Image48         string `json:"image_48,omitempty"`
+	Image72         string `json:"image_72,omitempty"`
+	Image192        string `json:"image_192,omitempty"`
+	Image512        string `json:"image_512,omitempty"`
 }
 
 // Pin represents a pinned item in a channel.
@@ -121,11 +121,11 @@ type File struct {
 
 // ScheduledMessage holds a message scheduled for future delivery.
 type ScheduledMessage struct {
-	ID        string `json:"id"`
-	Channel   string `json:"channel_id"`
-	PostAt    int64  `json:"post_at"`
+	ID          string `json:"id"`
+	Channel     string `json:"channel_id"`
+	PostAt      int64  `json:"post_at"`
 	DateCreated int64  `json:"date_created"`
-	Text      string `json:"text"`
+	Text        string `json:"text"`
 }
 
 // Team represents workspace info.
@@ -172,17 +172,17 @@ type Usergroup struct {
 
 // Star represents a starred item.
 type Star struct {
-	Type    string `json:"type"` // "message", "file", "channel"
-	Channel string `json:"channel,omitempty"`
+	Type    string   `json:"type"` // "message", "file", "channel"
+	Channel string   `json:"channel,omitempty"`
 	Message *Message `json:"message,omitempty"`
 	File    *File    `json:"file,omitempty"`
 }
 
 // DndStatus holds a user's Do Not Disturb state.
 type DndStatus struct {
-	DndEnabled   bool  `json:"dnd_enabled"`
-	NextStart    int64 `json:"next_dnd_start_ts"`
-	NextEnd      int64 `json:"next_dnd_end_ts"`
-	SnoozeEnabled bool `json:"snooze_enabled"`
+	DndEnabled    bool  `json:"dnd_enabled"`
+	NextStart     int64 `json:"next_dnd_start_ts"`
+	NextEnd       int64 `json:"next_dnd_end_ts"`
+	SnoozeEnabled bool  `json:"snooze_enabled"`
 	SnoozeEndtime int64 `json:"snooze_endtime,omitempty"`
 }

--- a/twin-stripe/cmd/twin-stripe/main.go
+++ b/twin-stripe/cmd/twin-stripe/main.go
@@ -10,13 +10,13 @@ import (
 	"log"
 	"os"
 
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	stripewh "github.com/wondertwin-ai/wondertwin/twin-stripe/internal/webhook"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	pkgwebhook "github.com/wondertwin-ai/wondertwin/twinkit/webhook"
 	"github.com/wondertwin-ai/wondertwin/twinkit/workspace"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
-	stripewh "github.com/wondertwin-ai/wondertwin/twin-stripe/internal/webhook"
 )
 
 func main() {

--- a/twin-stripe/internal/api/handlers_accounts.go
+++ b/twin-stripe/internal/api/handlers_accounts.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // CreateAccount handles POST /v1/accounts.
@@ -325,4 +325,3 @@ func accountToMap(acct store.Account) map[string]any {
 	json.Unmarshal(data, &m)
 	return m
 }
-

--- a/twin-stripe/internal/api/handlers_admin.go
+++ b/twin-stripe/internal/api/handlers_admin.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // fundRequest is the JSON body for POST /admin/accounts/{id}/fund.

--- a/twin-stripe/internal/api/handlers_application_fees.go
+++ b/twin-stripe/internal/api/handlers_application_fees.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // ── Application Fees ─────────────────────────────────────────────────

--- a/twin-stripe/internal/api/handlers_billing_extras.go
+++ b/twin-stripe/internal/api/handlers_billing_extras.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // --- Coupons ---
@@ -96,15 +96,15 @@ func (h *Handler) CreateSetupIntent(w http.ResponseWriter, r *http.Request) {
 
 	id := h.store.SetupIntents.NextID()
 	si := store.SetupIntent{
-		ID:            id,
-		Object:        "setup_intent",
-		Customer:      r.FormValue("customer"),
-		Status:        "requires_payment_method",
-		ClientSecret:  id + "_secret_" + h.randomHex(12),
-		Usage:         "off_session",
-		Livemode:      false,
-		Metadata:      parseMetadata(r),
-		Created:       h.store.Now(),
+		ID:           id,
+		Object:       "setup_intent",
+		Customer:     r.FormValue("customer"),
+		Status:       "requires_payment_method",
+		ClientSecret: id + "_secret_" + h.randomHex(12),
+		Usage:        "off_session",
+		Livemode:     false,
+		Metadata:     parseMetadata(r),
+		Created:      h.store.Now(),
 	}
 	if u := r.FormValue("usage"); u != "" {
 		si.Usage = u

--- a/twin-stripe/internal/api/handlers_charges.go
+++ b/twin-stripe/internal/api/handlers_charges.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // CreateCharge handles POST /v1/charges (direct charge creation).

--- a/twin-stripe/internal/api/handlers_checkout.go
+++ b/twin-stripe/internal/api/handlers_checkout.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // ── Checkout Sessions ──────────────────────────────────────────────

--- a/twin-stripe/internal/api/handlers_checkout_completion_test.go
+++ b/twin-stripe/internal/api/handlers_checkout_completion_test.go
@@ -72,8 +72,8 @@ func TestCompleteSubscriptionCheckoutSession(t *testing.T) {
 
 	// Create session with mode=subscription and line items.
 	resp = stripePostWithParams(tc, "/v1/checkout/sessions", map[string]string{
-		"mode":                      "subscription",
-		"customer":                  custID,
+		"mode":                    "subscription",
+		"customer":                custID,
 		"line_items[0][price]":    priceID,
 		"line_items[0][quantity]": "1",
 	})
@@ -157,7 +157,7 @@ func TestCheckoutSessionLineItems(t *testing.T) {
 
 	// Create session with line items.
 	resp = stripePostWithParams(tc, "/v1/checkout/sessions", map[string]string{
-		"mode":                      "payment",
+		"mode":                    "payment",
 		"line_items[0][price]":    priceID,
 		"line_items[0][quantity]": "2",
 	})

--- a/twin-stripe/internal/api/handlers_connect_extras.go
+++ b/twin-stripe/internal/api/handlers_connect_extras.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // ── Transfer Reversals ───────────────────────────────────────────────

--- a/twin-stripe/internal/api/handlers_credit_notes.go
+++ b/twin-stripe/internal/api/handlers_credit_notes.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateCreditNote(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_customers.go
+++ b/twin-stripe/internal/api/handlers_customers.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateCustomer(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_events.go
+++ b/twin-stripe/internal/api/handlers_events.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // emitEvent creates a Stripe event and optionally enqueues a webhook.

--- a/twin-stripe/internal/api/handlers_external_accounts.go
+++ b/twin-stripe/internal/api/handlers_external_accounts.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // CreateExternalAccount handles POST /v1/accounts/{account_id}/external_accounts.

--- a/twin-stripe/internal/api/handlers_files.go
+++ b/twin-stripe/internal/api/handlers_files.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // --- Files ---

--- a/twin-stripe/internal/api/handlers_invoices.go
+++ b/twin-stripe/internal/api/handlers_invoices.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/workspace"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 )
 
 func (h *Handler) CreateInvoice(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_payment_intents.go
+++ b/twin-stripe/internal/api/handlers_payment_intents.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/workspace"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 )
 
 func (h *Handler) CreatePaymentIntent(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_payment_methods.go
+++ b/twin-stripe/internal/api/handlers_payment_methods.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreatePaymentMethod(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_payouts.go
+++ b/twin-stripe/internal/api/handlers_payouts.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // Payout transition timing (in simulated seconds from creation).

--- a/twin-stripe/internal/api/handlers_prices.go
+++ b/twin-stripe/internal/api/handlers_prices.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreatePrice(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_products.go
+++ b/twin-stripe/internal/api/handlers_products.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateProduct(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_promotion_codes.go
+++ b/twin-stripe/internal/api/handlers_promotion_codes.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreatePromotionCode(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_quotes.go
+++ b/twin-stripe/internal/api/handlers_quotes.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // --- Quotes ---

--- a/twin-stripe/internal/api/handlers_refunds.go
+++ b/twin-stripe/internal/api/handlers_refunds.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateRefund(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_shipping_rates.go
+++ b/twin-stripe/internal/api/handlers_shipping_rates.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateShippingRate(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_subscription_items.go
+++ b/twin-stripe/internal/api/handlers_subscription_items.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateSubscriptionItem(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/handlers_subscriptions.go
+++ b/twin-stripe/internal/api/handlers_subscriptions.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/workspace"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 )
 
 func (h *Handler) CreateSubscription(w http.ResponseWriter, r *http.Request) {
@@ -31,17 +31,17 @@ func (h *Handler) CreateSubscription(w http.ResponseWriter, r *http.Request) {
 	id := h.store.Subscriptions.NextID()
 
 	sub := store.Subscription{
-		ID:                 id,
-		Object:             "subscription",
-		Customer:           customer,
-		Status:             "active",
-		CurrentPeriodStart: now.Unix(),
-		CurrentPeriodEnd:   now.AddDate(0, 1, 0).Unix(), // default monthly
-		CollectionMethod:   "charge_automatically",
+		ID:                   id,
+		Object:               "subscription",
+		Customer:             customer,
+		Status:               "active",
+		CurrentPeriodStart:   now.Unix(),
+		CurrentPeriodEnd:     now.AddDate(0, 1, 0).Unix(), // default monthly
+		CollectionMethod:     "charge_automatically",
 		DefaultPaymentMethod: r.FormValue("default_payment_method"),
-		Livemode:           false,
-		Metadata:           parseMetadata(r),
-		Created:            now.Unix(),
+		Livemode:             false,
+		Metadata:             parseMetadata(r),
+		Created:              now.Unix(),
 	}
 
 	if cm := r.FormValue("collection_method"); cm != "" {

--- a/twin-stripe/internal/api/handlers_tax_ids.go
+++ b/twin-stripe/internal/api/handlers_tax_ids.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // --- Tax IDs ---

--- a/twin-stripe/internal/api/handlers_test.go
+++ b/twin-stripe/internal/api/handlers_test.go
@@ -4,12 +4,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/webhook"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 )
 
 func setupStripe(t *testing.T) (*httptest.Server, *testutil.TwinClient) {

--- a/twin-stripe/internal/api/handlers_tokens.go
+++ b/twin-stripe/internal/api/handlers_tokens.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // ---------- Tokens ----------

--- a/twin-stripe/internal/api/handlers_transfers.go
+++ b/twin-stripe/internal/api/handlers_transfers.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // CreateTransfer handles POST /v1/transfers.

--- a/twin-stripe/internal/api/handlers_webhook_delivery_test.go
+++ b/twin-stripe/internal/api/handlers_webhook_delivery_test.go
@@ -10,18 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	stripewh "github.com/wondertwin-ai/wondertwin/twin-stripe/internal/webhook"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/webhook"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
-	stripewh "github.com/wondertwin-ai/wondertwin/twin-stripe/internal/webhook"
 )
 
 // webhookReceiver collects incoming webhook deliveries for assertions.
 type webhookReceiver struct {
-	mu        sync.Mutex
+	mu         sync.Mutex
 	deliveries []map[string]any
 	headers    []http.Header
 }

--- a/twin-stripe/internal/api/handlers_webhook_endpoints.go
+++ b/twin-stripe/internal/api/handlers_webhook_endpoints.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 func (h *Handler) CreateWebhookEndpoint(w http.ResponseWriter, r *http.Request) {

--- a/twin-stripe/internal/api/router.go
+++ b/twin-stripe/internal/api/router.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twinkit/webhook"
 	"github.com/wondertwin-ai/wondertwin/twinkit/workspace"
-	"github.com/wondertwin-ai/wondertwin/twin-stripe/internal/store"
 )
 
 // Handler holds all API handler state.

--- a/twin-stripe/internal/store/memory.go
+++ b/twin-stripe/internal/store/memory.go
@@ -1,8 +1,8 @@
 package store
 
 import (
-	"encoding/json"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -15,43 +15,43 @@ import (
 type MemoryStore struct {
 	mu sync.RWMutex
 
-	Accounts         *pkgstate.Store[Account]
-	ExternalAccts    *pkgstate.Store[ExternalAccount]
-	Transfers        *pkgstate.Store[Transfer]
-	Payouts          *pkgstate.Store[Payout]
-	Events               *pkgstate.Store[Event]
-	BalanceTransactions  *pkgstate.Store[BalanceTransaction]
-	Customers            *pkgstate.Store[Customer]
-	Products             *pkgstate.Store[Product]
-	Prices               *pkgstate.Store[Price]
-	PaymentIntents       *pkgstate.Store[PaymentIntent]
-	PaymentMethods       *pkgstate.Store[PaymentMethod]
-	Charges              *pkgstate.Store[Charge]
-	Refunds              *pkgstate.Store[Refund]
-	Subscriptions        *pkgstate.Store[Subscription]
-	Invoices             *pkgstate.Store[Invoice]
-	InvoiceItems         *pkgstate.Store[InvoiceItem]
-	Coupons              *pkgstate.Store[Coupon]
-	SetupIntents         *pkgstate.Store[SetupIntent]
-	TaxRates             *pkgstate.Store[TaxRate]
-	Disputes             *pkgstate.Store[Dispute]
-	CheckoutSessions     *pkgstate.Store[CheckoutSession]
-	PaymentLinks         *pkgstate.Store[PaymentLink]
-	Tokens               *pkgstate.Store[Token]
-	Sources              *pkgstate.Store[Source]
-	Mandates             *pkgstate.Store[Mandate]
-	ConfirmationTokens   *pkgstate.Store[ConfirmationToken]
-	CreditNotes          *pkgstate.Store[CreditNote]
-	PromotionCodes       *pkgstate.Store[PromotionCode]
-	SubItems             *pkgstate.Store[SubscriptionItem]
-	Quotes               *pkgstate.Store[Quote]
+	Accounts              *pkgstate.Store[Account]
+	ExternalAccts         *pkgstate.Store[ExternalAccount]
+	Transfers             *pkgstate.Store[Transfer]
+	Payouts               *pkgstate.Store[Payout]
+	Events                *pkgstate.Store[Event]
+	BalanceTransactions   *pkgstate.Store[BalanceTransaction]
+	Customers             *pkgstate.Store[Customer]
+	Products              *pkgstate.Store[Product]
+	Prices                *pkgstate.Store[Price]
+	PaymentIntents        *pkgstate.Store[PaymentIntent]
+	PaymentMethods        *pkgstate.Store[PaymentMethod]
+	Charges               *pkgstate.Store[Charge]
+	Refunds               *pkgstate.Store[Refund]
+	Subscriptions         *pkgstate.Store[Subscription]
+	Invoices              *pkgstate.Store[Invoice]
+	InvoiceItems          *pkgstate.Store[InvoiceItem]
+	Coupons               *pkgstate.Store[Coupon]
+	SetupIntents          *pkgstate.Store[SetupIntent]
+	TaxRates              *pkgstate.Store[TaxRate]
+	Disputes              *pkgstate.Store[Dispute]
+	CheckoutSessions      *pkgstate.Store[CheckoutSession]
+	PaymentLinks          *pkgstate.Store[PaymentLink]
+	Tokens                *pkgstate.Store[Token]
+	Sources               *pkgstate.Store[Source]
+	Mandates              *pkgstate.Store[Mandate]
+	ConfirmationTokens    *pkgstate.Store[ConfirmationToken]
+	CreditNotes           *pkgstate.Store[CreditNote]
+	PromotionCodes        *pkgstate.Store[PromotionCode]
+	SubItems              *pkgstate.Store[SubscriptionItem]
+	Quotes                *pkgstate.Store[Quote]
 	BillingPortalSessions *pkgstate.Store[BillingPortalSession]
-	Reviews              *pkgstate.Store[Review]
-	TaxIDs               *pkgstate.Store[TaxID]
-	WebhookEndpoints     *pkgstate.Store[WebhookEndpoint]
-	Files                *pkgstate.Store[File]
-	FileLinks            *pkgstate.Store[FileLink]
-	ShippingRates        *pkgstate.Store[ShippingRate]
+	Reviews               *pkgstate.Store[Review]
+	TaxIDs                *pkgstate.Store[TaxID]
+	WebhookEndpoints      *pkgstate.Store[WebhookEndpoint]
+	Files                 *pkgstate.Store[File]
+	FileLinks             *pkgstate.Store[FileLink]
+	ShippingRates         *pkgstate.Store[ShippingRate]
 	ApplicationFees       *pkgstate.Store[ApplicationFee]
 	ApplicationFeeRefunds *pkgstate.Store[ApplicationFeeRefund]
 	TransferReversals     *pkgstate.Store[TransferReversal]
@@ -59,12 +59,12 @@ type MemoryStore struct {
 	TopUps                *pkgstate.Store[TopUp]
 
 	// Per-account balances (account ID -> balance)
-	Balances         map[string]*AccountBalance
+	Balances map[string]*AccountBalance
 
 	// Platform balance (the main Stripe account)
-	PlatformBalance  *AccountBalance
+	PlatformBalance *AccountBalance
 
-	Clock            *pkgstate.Clock
+	Clock *pkgstate.Clock
 
 	// Rand is the deterministic random source used by handlers for
 	// token-shaped strings (whsec_, client_secret, etc.). Wired by
@@ -90,51 +90,51 @@ func (s *MemoryStore) RandHex(n int) string {
 // New creates a new MemoryStore with empty state.
 func New() *MemoryStore {
 	return &MemoryStore{
-		Accounts:        pkgstate.New[Account]("acct"),
-		ExternalAccts:   pkgstate.New[ExternalAccount]("ba"),
-		Transfers:       pkgstate.New[Transfer]("tr"),
-		Payouts:         pkgstate.New[Payout]("po"),
-		Events:              pkgstate.New[Event]("evt"),
-		BalanceTransactions: pkgstate.New[BalanceTransaction]("txn"),
-		Customers:           pkgstate.New[Customer]("cus"),
-		Products:            pkgstate.New[Product]("prod"),
-		Prices:              pkgstate.New[Price]("price"),
-		PaymentIntents:      pkgstate.New[PaymentIntent]("pi"),
-		PaymentMethods:      pkgstate.New[PaymentMethod]("pm"),
-		Charges:             pkgstate.New[Charge]("ch"),
-		Refunds:             pkgstate.New[Refund]("re"),
-		Subscriptions:       pkgstate.New[Subscription]("sub"),
-		Invoices:            pkgstate.New[Invoice]("in"),
-		InvoiceItems:        pkgstate.New[InvoiceItem]("ii"),
-		Coupons:             pkgstate.New[Coupon]("coup"),
-		SetupIntents:        pkgstate.New[SetupIntent]("seti"),
-		TaxRates:            pkgstate.New[TaxRate]("txr"),
-		Disputes:            pkgstate.New[Dispute]("dp"),
-		CheckoutSessions:    pkgstate.New[CheckoutSession]("cs"),
-		PaymentLinks:        pkgstate.New[PaymentLink]("plink"),
-		Tokens:              pkgstate.New[Token]("tok"),
-		Sources:             pkgstate.New[Source]("src"),
-		Mandates:            pkgstate.New[Mandate]("mandate"),
-		ConfirmationTokens:  pkgstate.New[ConfirmationToken]("ctoken"),
-		CreditNotes:         pkgstate.New[CreditNote]("cn"),
-		PromotionCodes:      pkgstate.New[PromotionCode]("promo"),
-		SubItems:            pkgstate.New[SubscriptionItem]("si"),
-		Quotes:              pkgstate.New[Quote]("qt"),
+		Accounts:              pkgstate.New[Account]("acct"),
+		ExternalAccts:         pkgstate.New[ExternalAccount]("ba"),
+		Transfers:             pkgstate.New[Transfer]("tr"),
+		Payouts:               pkgstate.New[Payout]("po"),
+		Events:                pkgstate.New[Event]("evt"),
+		BalanceTransactions:   pkgstate.New[BalanceTransaction]("txn"),
+		Customers:             pkgstate.New[Customer]("cus"),
+		Products:              pkgstate.New[Product]("prod"),
+		Prices:                pkgstate.New[Price]("price"),
+		PaymentIntents:        pkgstate.New[PaymentIntent]("pi"),
+		PaymentMethods:        pkgstate.New[PaymentMethod]("pm"),
+		Charges:               pkgstate.New[Charge]("ch"),
+		Refunds:               pkgstate.New[Refund]("re"),
+		Subscriptions:         pkgstate.New[Subscription]("sub"),
+		Invoices:              pkgstate.New[Invoice]("in"),
+		InvoiceItems:          pkgstate.New[InvoiceItem]("ii"),
+		Coupons:               pkgstate.New[Coupon]("coup"),
+		SetupIntents:          pkgstate.New[SetupIntent]("seti"),
+		TaxRates:              pkgstate.New[TaxRate]("txr"),
+		Disputes:              pkgstate.New[Dispute]("dp"),
+		CheckoutSessions:      pkgstate.New[CheckoutSession]("cs"),
+		PaymentLinks:          pkgstate.New[PaymentLink]("plink"),
+		Tokens:                pkgstate.New[Token]("tok"),
+		Sources:               pkgstate.New[Source]("src"),
+		Mandates:              pkgstate.New[Mandate]("mandate"),
+		ConfirmationTokens:    pkgstate.New[ConfirmationToken]("ctoken"),
+		CreditNotes:           pkgstate.New[CreditNote]("cn"),
+		PromotionCodes:        pkgstate.New[PromotionCode]("promo"),
+		SubItems:              pkgstate.New[SubscriptionItem]("si"),
+		Quotes:                pkgstate.New[Quote]("qt"),
 		BillingPortalSessions: pkgstate.New[BillingPortalSession]("bps"),
-		Reviews:             pkgstate.New[Review]("prv"),
-		TaxIDs:              pkgstate.New[TaxID]("txi"),
-		WebhookEndpoints:    pkgstate.New[WebhookEndpoint]("we"),
-		Files:               pkgstate.New[File]("file"),
-		FileLinks:           pkgstate.New[FileLink]("link"),
-		ShippingRates:       pkgstate.New[ShippingRate]("shr"),
+		Reviews:               pkgstate.New[Review]("prv"),
+		TaxIDs:                pkgstate.New[TaxID]("txi"),
+		WebhookEndpoints:      pkgstate.New[WebhookEndpoint]("we"),
+		Files:                 pkgstate.New[File]("file"),
+		FileLinks:             pkgstate.New[FileLink]("link"),
+		ShippingRates:         pkgstate.New[ShippingRate]("shr"),
 		ApplicationFees:       pkgstate.New[ApplicationFee]("fee"),
 		ApplicationFeeRefunds: pkgstate.New[ApplicationFeeRefund]("fr"),
 		TransferReversals:     pkgstate.New[TransferReversal]("trr"),
 		Persons:               pkgstate.New[Person]("person"),
 		TopUps:                pkgstate.New[TopUp]("tu"),
-		Balances:        make(map[string]*AccountBalance),
-		PlatformBalance: NewAccountBalance(),
-		Clock:           pkgstate.NewClock(),
+		Balances:              make(map[string]*AccountBalance),
+		PlatformBalance:       NewAccountBalance(),
+		Clock:                 pkgstate.NewClock(),
 	}
 }
 
@@ -258,99 +258,99 @@ func (s *MemoryStore) RecordBalanceTransaction(txType, source, currency string, 
 
 // stateSnapshot is the JSON-serializable state for admin endpoints.
 type stateSnapshot struct {
-	Accounts            map[string]Account             `json:"accounts"`
-	ExternalAccts       map[string]ExternalAccount     `json:"external_accounts"`
-	Transfers           map[string]Transfer            `json:"transfers"`
-	Payouts             map[string]Payout              `json:"payouts"`
-	Events              map[string]Event               `json:"events"`
-	BalanceTransactions map[string]BalanceTransaction   `json:"balance_transactions"`
-	Customers           map[string]Customer            `json:"customers"`
-	Products            map[string]Product             `json:"products"`
-	Prices              map[string]Price               `json:"prices"`
-	PaymentIntents      map[string]PaymentIntent       `json:"payment_intents"`
-	PaymentMethods      map[string]PaymentMethod       `json:"payment_methods"`
-	Charges             map[string]Charge              `json:"charges"`
-	Refunds             map[string]Refund              `json:"refunds"`
-	Subscriptions       map[string]Subscription        `json:"subscriptions"`
-	Invoices            map[string]Invoice             `json:"invoices"`
-	InvoiceItems        map[string]InvoiceItem         `json:"invoice_items"`
-	Coupons             map[string]Coupon              `json:"coupons"`
-	SetupIntents        map[string]SetupIntent         `json:"setup_intents"`
-	TaxRates            map[string]TaxRate             `json:"tax_rates"`
-	Disputes            map[string]Dispute             `json:"disputes"`
-	CheckoutSessions    map[string]CheckoutSession     `json:"checkout_sessions"`
-	PaymentLinks        map[string]PaymentLink         `json:"payment_links"`
-	Tokens              map[string]Token               `json:"tokens"`
-	Sources             map[string]Source              `json:"sources"`
-	Mandates            map[string]Mandate             `json:"mandates"`
-	ConfirmationTokens  map[string]ConfirmationToken   `json:"confirmation_tokens"`
-	CreditNotes         map[string]CreditNote          `json:"credit_notes"`
-	PromotionCodes      map[string]PromotionCode       `json:"promotion_codes"`
-	SubItems            map[string]SubscriptionItem    `json:"sub_items"`
-	Quotes              map[string]Quote               `json:"quotes"`
+	Accounts              map[string]Account              `json:"accounts"`
+	ExternalAccts         map[string]ExternalAccount      `json:"external_accounts"`
+	Transfers             map[string]Transfer             `json:"transfers"`
+	Payouts               map[string]Payout               `json:"payouts"`
+	Events                map[string]Event                `json:"events"`
+	BalanceTransactions   map[string]BalanceTransaction   `json:"balance_transactions"`
+	Customers             map[string]Customer             `json:"customers"`
+	Products              map[string]Product              `json:"products"`
+	Prices                map[string]Price                `json:"prices"`
+	PaymentIntents        map[string]PaymentIntent        `json:"payment_intents"`
+	PaymentMethods        map[string]PaymentMethod        `json:"payment_methods"`
+	Charges               map[string]Charge               `json:"charges"`
+	Refunds               map[string]Refund               `json:"refunds"`
+	Subscriptions         map[string]Subscription         `json:"subscriptions"`
+	Invoices              map[string]Invoice              `json:"invoices"`
+	InvoiceItems          map[string]InvoiceItem          `json:"invoice_items"`
+	Coupons               map[string]Coupon               `json:"coupons"`
+	SetupIntents          map[string]SetupIntent          `json:"setup_intents"`
+	TaxRates              map[string]TaxRate              `json:"tax_rates"`
+	Disputes              map[string]Dispute              `json:"disputes"`
+	CheckoutSessions      map[string]CheckoutSession      `json:"checkout_sessions"`
+	PaymentLinks          map[string]PaymentLink          `json:"payment_links"`
+	Tokens                map[string]Token                `json:"tokens"`
+	Sources               map[string]Source               `json:"sources"`
+	Mandates              map[string]Mandate              `json:"mandates"`
+	ConfirmationTokens    map[string]ConfirmationToken    `json:"confirmation_tokens"`
+	CreditNotes           map[string]CreditNote           `json:"credit_notes"`
+	PromotionCodes        map[string]PromotionCode        `json:"promotion_codes"`
+	SubItems              map[string]SubscriptionItem     `json:"sub_items"`
+	Quotes                map[string]Quote                `json:"quotes"`
 	BillingPortalSessions map[string]BillingPortalSession `json:"billing_portal_sessions"`
-	Reviews             map[string]Review              `json:"reviews"`
-	TaxIDs              map[string]TaxID               `json:"tax_ids"`
-	WebhookEndpoints    map[string]WebhookEndpoint     `json:"webhook_endpoints"`
-	Files               map[string]File                `json:"files"`
-	FileLinks           map[string]FileLink            `json:"file_links"`
-	ShippingRates       map[string]ShippingRate         `json:"shipping_rates"`
+	Reviews               map[string]Review               `json:"reviews"`
+	TaxIDs                map[string]TaxID                `json:"tax_ids"`
+	WebhookEndpoints      map[string]WebhookEndpoint      `json:"webhook_endpoints"`
+	Files                 map[string]File                 `json:"files"`
+	FileLinks             map[string]FileLink             `json:"file_links"`
+	ShippingRates         map[string]ShippingRate         `json:"shipping_rates"`
 	ApplicationFees       map[string]ApplicationFee       `json:"application_fees"`
 	ApplicationFeeRefunds map[string]ApplicationFeeRefund `json:"application_fee_refunds"`
 	TransferReversals     map[string]TransferReversal     `json:"transfer_reversals"`
 	Persons               map[string]Person               `json:"persons"`
 	TopUps                map[string]TopUp                `json:"topups"`
-	Balances            map[string]*AccountBalance     `json:"balances"`
-	PlatformBalance     *AccountBalance                `json:"platform_balance"`
+	Balances              map[string]*AccountBalance      `json:"balances"`
+	PlatformBalance       *AccountBalance                 `json:"platform_balance"`
 }
 
 // Snapshot returns the full state as a JSON-serializable value.
 func (s *MemoryStore) Snapshot() any {
 	return stateSnapshot{
-		Accounts:            s.Accounts.Snapshot(),
-		ExternalAccts:       s.ExternalAccts.Snapshot(),
-		Transfers:           s.Transfers.Snapshot(),
-		Payouts:             s.Payouts.Snapshot(),
-		Events:              s.Events.Snapshot(),
-		BalanceTransactions: s.BalanceTransactions.Snapshot(),
-		Customers:           s.Customers.Snapshot(),
-		Products:            s.Products.Snapshot(),
-		Prices:              s.Prices.Snapshot(),
-		PaymentIntents:      s.PaymentIntents.Snapshot(),
-		PaymentMethods:      s.PaymentMethods.Snapshot(),
-		Charges:             s.Charges.Snapshot(),
-		Refunds:             s.Refunds.Snapshot(),
-		Subscriptions:       s.Subscriptions.Snapshot(),
-		Invoices:            s.Invoices.Snapshot(),
-		InvoiceItems:        s.InvoiceItems.Snapshot(),
-		Coupons:             s.Coupons.Snapshot(),
-		SetupIntents:        s.SetupIntents.Snapshot(),
-		TaxRates:            s.TaxRates.Snapshot(),
-		Disputes:            s.Disputes.Snapshot(),
-		CheckoutSessions:    s.CheckoutSessions.Snapshot(),
-		PaymentLinks:        s.PaymentLinks.Snapshot(),
-		Tokens:              s.Tokens.Snapshot(),
-		Sources:             s.Sources.Snapshot(),
-		Mandates:            s.Mandates.Snapshot(),
-		ConfirmationTokens:  s.ConfirmationTokens.Snapshot(),
-		CreditNotes:         s.CreditNotes.Snapshot(),
-		PromotionCodes:      s.PromotionCodes.Snapshot(),
-		SubItems:            s.SubItems.Snapshot(),
-		Quotes:              s.Quotes.Snapshot(),
+		Accounts:              s.Accounts.Snapshot(),
+		ExternalAccts:         s.ExternalAccts.Snapshot(),
+		Transfers:             s.Transfers.Snapshot(),
+		Payouts:               s.Payouts.Snapshot(),
+		Events:                s.Events.Snapshot(),
+		BalanceTransactions:   s.BalanceTransactions.Snapshot(),
+		Customers:             s.Customers.Snapshot(),
+		Products:              s.Products.Snapshot(),
+		Prices:                s.Prices.Snapshot(),
+		PaymentIntents:        s.PaymentIntents.Snapshot(),
+		PaymentMethods:        s.PaymentMethods.Snapshot(),
+		Charges:               s.Charges.Snapshot(),
+		Refunds:               s.Refunds.Snapshot(),
+		Subscriptions:         s.Subscriptions.Snapshot(),
+		Invoices:              s.Invoices.Snapshot(),
+		InvoiceItems:          s.InvoiceItems.Snapshot(),
+		Coupons:               s.Coupons.Snapshot(),
+		SetupIntents:          s.SetupIntents.Snapshot(),
+		TaxRates:              s.TaxRates.Snapshot(),
+		Disputes:              s.Disputes.Snapshot(),
+		CheckoutSessions:      s.CheckoutSessions.Snapshot(),
+		PaymentLinks:          s.PaymentLinks.Snapshot(),
+		Tokens:                s.Tokens.Snapshot(),
+		Sources:               s.Sources.Snapshot(),
+		Mandates:              s.Mandates.Snapshot(),
+		ConfirmationTokens:    s.ConfirmationTokens.Snapshot(),
+		CreditNotes:           s.CreditNotes.Snapshot(),
+		PromotionCodes:        s.PromotionCodes.Snapshot(),
+		SubItems:              s.SubItems.Snapshot(),
+		Quotes:                s.Quotes.Snapshot(),
 		BillingPortalSessions: s.BillingPortalSessions.Snapshot(),
-		Reviews:             s.Reviews.Snapshot(),
-		TaxIDs:              s.TaxIDs.Snapshot(),
-		WebhookEndpoints:    s.WebhookEndpoints.Snapshot(),
-		Files:               s.Files.Snapshot(),
-		FileLinks:           s.FileLinks.Snapshot(),
-		ShippingRates:       s.ShippingRates.Snapshot(),
+		Reviews:               s.Reviews.Snapshot(),
+		TaxIDs:                s.TaxIDs.Snapshot(),
+		WebhookEndpoints:      s.WebhookEndpoints.Snapshot(),
+		Files:                 s.Files.Snapshot(),
+		FileLinks:             s.FileLinks.Snapshot(),
+		ShippingRates:         s.ShippingRates.Snapshot(),
 		ApplicationFees:       s.ApplicationFees.Snapshot(),
 		ApplicationFeeRefunds: s.ApplicationFeeRefunds.Snapshot(),
 		TransferReversals:     s.TransferReversals.Snapshot(),
 		Persons:               s.Persons.Snapshot(),
 		TopUps:                s.TopUps.Snapshot(),
-		Balances:            s.snapshotBalances(),
-		PlatformBalance:     s.PlatformBalance,
+		Balances:              s.snapshotBalances(),
+		PlatformBalance:       s.PlatformBalance,
 	}
 }
 

--- a/twin-stripe/internal/store/types.go
+++ b/twin-stripe/internal/store/types.go
@@ -1,39 +1,38 @@
 // Package store defines the Stripe twin's state types and in-memory store.
 package store
 
-
 // Account represents a Stripe Connect account.
 type Account struct {
-	ID                 string            `json:"id"`
-	Object             string            `json:"object"`
-	Type               string            `json:"type"`
-	BusinessType       string            `json:"business_type,omitempty"`
-	Email              string            `json:"email,omitempty"`
-	Country            string            `json:"country"`
-	DefaultCurrency    string            `json:"default_currency"`
-	ChargesEnabled     bool              `json:"charges_enabled"`
-	PayoutsEnabled     bool              `json:"payouts_enabled"`
-	DetailsSubmitted   bool              `json:"details_submitted"`
-	Capabilities       map[string]string `json:"capabilities,omitempty"`
-	Requirements       *Requirements     `json:"requirements,omitempty"`
-	Individual         map[string]any    `json:"individual,omitempty"`
-	Company            map[string]any    `json:"company,omitempty"`
-	ExternalAccounts   *ExternalAccounts `json:"external_accounts,omitempty"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	TOSAcceptance      map[string]any    `json:"tos_acceptance,omitempty"`
-	BusinessProfile    map[string]any    `json:"business_profile,omitempty"`
-	Settings           map[string]any    `json:"settings,omitempty"`
-	Created            int64             `json:"created"`
-	Updated            int64             `json:"updated,omitempty"`
+	ID               string            `json:"id"`
+	Object           string            `json:"object"`
+	Type             string            `json:"type"`
+	BusinessType     string            `json:"business_type,omitempty"`
+	Email            string            `json:"email,omitempty"`
+	Country          string            `json:"country"`
+	DefaultCurrency  string            `json:"default_currency"`
+	ChargesEnabled   bool              `json:"charges_enabled"`
+	PayoutsEnabled   bool              `json:"payouts_enabled"`
+	DetailsSubmitted bool              `json:"details_submitted"`
+	Capabilities     map[string]string `json:"capabilities,omitempty"`
+	Requirements     *Requirements     `json:"requirements,omitempty"`
+	Individual       map[string]any    `json:"individual,omitempty"`
+	Company          map[string]any    `json:"company,omitempty"`
+	ExternalAccounts *ExternalAccounts `json:"external_accounts,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	TOSAcceptance    map[string]any    `json:"tos_acceptance,omitempty"`
+	BusinessProfile  map[string]any    `json:"business_profile,omitempty"`
+	Settings         map[string]any    `json:"settings,omitempty"`
+	Created          int64             `json:"created"`
+	Updated          int64             `json:"updated,omitempty"`
 }
 
 // Requirements tracks KYB/KYC verification requirements.
 type Requirements struct {
-	CurrentlyDue  []string `json:"currently_due"`
-	EventuallyDue []string `json:"eventually_due"`
-	PastDue       []string `json:"past_due"`
-	Alternatives  []any    `json:"alternatives,omitempty"`
-	DisabledReason string  `json:"disabled_reason,omitempty"`
+	CurrentlyDue   []string `json:"currently_due"`
+	EventuallyDue  []string `json:"eventually_due"`
+	PastDue        []string `json:"past_due"`
+	Alternatives   []any    `json:"alternatives,omitempty"`
+	DisabledReason string   `json:"disabled_reason,omitempty"`
 }
 
 // ExternalAccounts wraps the external accounts list.
@@ -46,18 +45,18 @@ type ExternalAccounts struct {
 
 // ExternalAccount represents a bank account or card attached to a Connect account.
 type ExternalAccount struct {
-	ID                string `json:"id"`
-	Object            string `json:"object"`
-	AccountID         string `json:"account"`
-	BankName          string `json:"bank_name,omitempty"`
-	Country           string `json:"country"`
-	Currency          string `json:"currency"`
-	Last4             string `json:"last4"`
-	RoutingNumber     string `json:"routing_number,omitempty"`
-	Status            string `json:"status"`
-	DefaultForCurrency bool  `json:"default_for_currency"`
-	Fingerprint       string `json:"fingerprint,omitempty"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	AccountID          string            `json:"account"`
+	BankName           string            `json:"bank_name,omitempty"`
+	Country            string            `json:"country"`
+	Currency           string            `json:"currency"`
+	Last4              string            `json:"last4"`
+	RoutingNumber      string            `json:"routing_number,omitempty"`
+	Status             string            `json:"status"`
+	DefaultForCurrency bool              `json:"default_for_currency"`
+	Fingerprint        string            `json:"fingerprint,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
 }
 
 // Transfer represents a Stripe transfer to a connected account.
@@ -94,20 +93,20 @@ type BalanceAmount struct {
 
 // Payout represents a payout from a connected account to a bank.
 type Payout struct {
-	ID                 string            `json:"id"`
-	Object             string            `json:"object"`
-	Amount             int64             `json:"amount"`
-	Currency           string            `json:"currency"`
-	ArrivalDate        int64             `json:"arrival_date"`
-	Description        string            `json:"description,omitempty"`
-	Destination        string            `json:"destination,omitempty"`
-	Method             string            `json:"method"`
-	Status             string            `json:"status"`
-	Type               string            `json:"type"`
-	FailureCode        string            `json:"failure_code,omitempty"`
-	FailureMessage     string            `json:"failure_message,omitempty"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	Created            int64             `json:"created"`
+	ID             string            `json:"id"`
+	Object         string            `json:"object"`
+	Amount         int64             `json:"amount"`
+	Currency       string            `json:"currency"`
+	ArrivalDate    int64             `json:"arrival_date"`
+	Description    string            `json:"description,omitempty"`
+	Destination    string            `json:"destination,omitempty"`
+	Method         string            `json:"method"`
+	Status         string            `json:"status"`
+	Type           string            `json:"type"`
+	FailureCode    string            `json:"failure_code,omitempty"`
+	FailureMessage string            `json:"failure_message,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	Created        int64             `json:"created"`
 }
 
 // BalanceTransaction represents a Stripe balance transaction ledger entry.
@@ -119,23 +118,23 @@ type BalanceTransaction struct {
 	Description string `json:"description,omitempty"`
 	Net         int64  `json:"net"`
 	Fee         int64  `json:"fee"`
-	Status      string `json:"status"` // "available" or "pending"
-	Type        string `json:"type"`   // "transfer", "payout", "adjustment"
+	Status      string `json:"status"`           // "available" or "pending"
+	Type        string `json:"type"`             // "transfer", "payout", "adjustment"
 	Source      string `json:"source,omitempty"` // transfer/payout ID
 	Created     int64  `json:"created"`
 }
 
 // Event represents a Stripe webhook event.
 type Event struct {
-	ID             string    `json:"id"`
-	Object         string    `json:"object"`
-	Type           string    `json:"type"`
-	Data           EventData `json:"data"`
-	APIVersion     string    `json:"api_version"`
-	Created        int64     `json:"created"`
-	Livemode       bool      `json:"livemode"`
-	PendingWebhooks int      `json:"pending_webhooks"`
-	Request        *EventReq `json:"request,omitempty"`
+	ID              string    `json:"id"`
+	Object          string    `json:"object"`
+	Type            string    `json:"type"`
+	Data            EventData `json:"data"`
+	APIVersion      string    `json:"api_version"`
+	Created         int64     `json:"created"`
+	Livemode        bool      `json:"livemode"`
+	PendingWebhooks int       `json:"pending_webhooks"`
+	Request         *EventReq `json:"request,omitempty"`
 }
 
 // EventData wraps the event's object.
@@ -151,35 +150,35 @@ type EventReq struct {
 
 // Customer represents a Stripe customer.
 type Customer struct {
-	ID             string            `json:"id"`
-	Object         string            `json:"object"`
-	Name           string            `json:"name,omitempty"`
-	Email          string            `json:"email,omitempty"`
-	Phone          string            `json:"phone,omitempty"`
-	Description    string            `json:"description,omitempty"`
-	Currency       string            `json:"currency,omitempty"`
-	DefaultSource  string            `json:"default_source,omitempty"`
-	InvoicePrefix  string            `json:"invoice_prefix,omitempty"`
-	Balance        int64             `json:"balance"`
-	Delinquent     bool              `json:"delinquent"`
-	Livemode       bool              `json:"livemode"`
-	Metadata       map[string]string `json:"metadata,omitempty"`
-	Created        int64             `json:"created"`
+	ID            string            `json:"id"`
+	Object        string            `json:"object"`
+	Name          string            `json:"name,omitempty"`
+	Email         string            `json:"email,omitempty"`
+	Phone         string            `json:"phone,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	Currency      string            `json:"currency,omitempty"`
+	DefaultSource string            `json:"default_source,omitempty"`
+	InvoicePrefix string            `json:"invoice_prefix,omitempty"`
+	Balance       int64             `json:"balance"`
+	Delinquent    bool              `json:"delinquent"`
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Created       int64             `json:"created"`
 }
 
 // Product represents a Stripe product.
 type Product struct {
-	ID          string            `json:"id"`
-	Object      string            `json:"object"`
-	Name        string            `json:"name"`
-	Active      bool              `json:"active"`
-	Description string            `json:"description,omitempty"`
-	Images      []string          `json:"images,omitempty"`
-	Livemode    bool              `json:"livemode"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	DefaultPrice string           `json:"default_price,omitempty"`
-	Created     int64             `json:"created"`
-	Updated     int64             `json:"updated"`
+	ID           string            `json:"id"`
+	Object       string            `json:"object"`
+	Name         string            `json:"name"`
+	Active       bool              `json:"active"`
+	Description  string            `json:"description,omitempty"`
+	Images       []string          `json:"images,omitempty"`
+	Livemode     bool              `json:"livemode"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	DefaultPrice string            `json:"default_price,omitempty"`
+	Created      int64             `json:"created"`
+	Updated      int64             `json:"updated"`
 }
 
 // Price represents a Stripe price.
@@ -191,7 +190,7 @@ type Price struct {
 	Product           string            `json:"product"`
 	UnitAmount        int64             `json:"unit_amount,omitempty"`
 	UnitAmountDecimal string            `json:"unit_amount_decimal,omitempty"`
-	Type              string            `json:"type"` // one_time or recurring
+	Type              string            `json:"type"`           // one_time or recurring
 	BillingScheme     string            `json:"billing_scheme"` // per_unit or tiered
 	Recurring         *PriceRecurring   `json:"recurring,omitempty"`
 	Nickname          string            `json:"nickname,omitempty"`
@@ -209,37 +208,37 @@ type PriceRecurring struct {
 
 // PaymentIntent represents a Stripe payment intent.
 type PaymentIntent struct {
-	ID                    string            `json:"id"`
-	Object                string            `json:"object"`
-	Amount                int64             `json:"amount"`
-	AmountReceived        int64             `json:"amount_received"`
-	Currency              string            `json:"currency"`
-	Customer              string            `json:"customer,omitempty"`
-	Description           string            `json:"description,omitempty"`
-	Status                string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
-	PaymentMethod         string            `json:"payment_method,omitempty"`
-	CaptureMethod         string            `json:"capture_method"` // automatic or manual
-	ConfirmationMethod    string            `json:"confirmation_method"` // automatic or manual
-	ClientSecret          string            `json:"client_secret"`
-	LatestCharge          string            `json:"latest_charge,omitempty"`
-	CanceledAt            int64             `json:"canceled_at,omitempty"`
-	CancellationReason    string            `json:"cancellation_reason,omitempty"`
-	Livemode              bool              `json:"livemode"`
-	Metadata              map[string]string `json:"metadata,omitempty"`
-	Created               int64             `json:"created"`
+	ID                 string            `json:"id"`
+	Object             string            `json:"object"`
+	Amount             int64             `json:"amount"`
+	AmountReceived     int64             `json:"amount_received"`
+	Currency           string            `json:"currency"`
+	Customer           string            `json:"customer,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	Status             string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
+	PaymentMethod      string            `json:"payment_method,omitempty"`
+	CaptureMethod      string            `json:"capture_method"`      // automatic or manual
+	ConfirmationMethod string            `json:"confirmation_method"` // automatic or manual
+	ClientSecret       string            `json:"client_secret"`
+	LatestCharge       string            `json:"latest_charge,omitempty"`
+	CanceledAt         int64             `json:"canceled_at,omitempty"`
+	CancellationReason string            `json:"cancellation_reason,omitempty"`
+	Livemode           bool              `json:"livemode"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Created            int64             `json:"created"`
 }
 
 // PaymentMethod represents a Stripe payment method.
 type PaymentMethod struct {
-	ID          string            `json:"id"`
-	Object      string            `json:"object"`
-	Type        string            `json:"type"` // card, us_bank_account, etc.
-	Customer    string            `json:"customer,omitempty"`
-	Card        *CardDetails      `json:"card,omitempty"`
-	BillingDetails *BillingDetails `json:"billing_details,omitempty"`
-	Livemode    bool              `json:"livemode"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Created     int64             `json:"created"`
+	ID             string            `json:"id"`
+	Object         string            `json:"object"`
+	Type           string            `json:"type"` // card, us_bank_account, etc.
+	Customer       string            `json:"customer,omitempty"`
+	Card           *CardDetails      `json:"card,omitempty"`
+	BillingDetails *BillingDetails   `json:"billing_details,omitempty"`
+	Livemode       bool              `json:"livemode"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	Created        int64             `json:"created"`
 }
 
 // CardDetails holds card payment method details.
@@ -262,23 +261,23 @@ type BillingDetails struct {
 
 // Charge represents a Stripe charge.
 type Charge struct {
-	ID              string            `json:"id"`
-	Object          string            `json:"object"`
-	Amount          int64             `json:"amount"`
-	AmountRefunded  int64             `json:"amount_refunded"`
-	Currency        string            `json:"currency"`
-	Customer        string            `json:"customer,omitempty"`
-	Description     string            `json:"description,omitempty"`
-	PaymentIntent   string            `json:"payment_intent,omitempty"`
-	PaymentMethod   string            `json:"payment_method,omitempty"`
-	Status          string            `json:"status"` // succeeded, pending, failed
-	Captured        bool              `json:"captured"`
-	Refunded        bool              `json:"refunded"`
-	Paid            bool              `json:"paid"`
-	Disputed        bool              `json:"disputed"`
-	Livemode        bool              `json:"livemode"`
-	Metadata        map[string]string `json:"metadata,omitempty"`
-	Created         int64             `json:"created"`
+	ID             string            `json:"id"`
+	Object         string            `json:"object"`
+	Amount         int64             `json:"amount"`
+	AmountRefunded int64             `json:"amount_refunded"`
+	Currency       string            `json:"currency"`
+	Customer       string            `json:"customer,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	PaymentIntent  string            `json:"payment_intent,omitempty"`
+	PaymentMethod  string            `json:"payment_method,omitempty"`
+	Status         string            `json:"status"` // succeeded, pending, failed
+	Captured       bool              `json:"captured"`
+	Refunded       bool              `json:"refunded"`
+	Paid           bool              `json:"paid"`
+	Disputed       bool              `json:"disputed"`
+	Livemode       bool              `json:"livemode"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	Created        int64             `json:"created"`
 }
 
 // Refund represents a Stripe refund.
@@ -290,33 +289,33 @@ type Refund struct {
 	Charge        string            `json:"charge"`
 	PaymentIntent string            `json:"payment_intent,omitempty"`
 	Reason        string            `json:"reason,omitempty"` // duplicate, fraudulent, requested_by_customer
-	Status        string            `json:"status"` // succeeded, pending, failed, canceled
+	Status        string            `json:"status"`           // succeeded, pending, failed, canceled
 	Metadata      map[string]string `json:"metadata,omitempty"`
 	Created       int64             `json:"created"`
 }
 
 // Subscription represents a Stripe subscription.
 type Subscription struct {
-	ID                 string            `json:"id"`
-	Object             string            `json:"object"`
-	Customer           string            `json:"customer"`
-	Status             string            `json:"status"` // trialing, active, past_due, canceled, unpaid, incomplete, incomplete_expired, paused
-	CurrentPeriodStart int64             `json:"current_period_start"`
-	CurrentPeriodEnd   int64             `json:"current_period_end"`
-	CancelAtPeriodEnd  bool              `json:"cancel_at_period_end"`
-	CancelAt           int64             `json:"cancel_at,omitempty"`
-	CanceledAt         int64             `json:"canceled_at,omitempty"`
-	TrialStart         int64             `json:"trial_start,omitempty"`
-	TrialEnd           int64             `json:"trial_end,omitempty"`
-	Items              *SubscriptionItems `json:"items"`
-	LatestInvoice      string            `json:"latest_invoice,omitempty"`
-	Discount           *Discount         `json:"discount,omitempty"`
-	DefaultTaxRates    []TaxRate         `json:"default_tax_rates,omitempty"`
-	DefaultPaymentMethod string          `json:"default_payment_method,omitempty"`
-	CollectionMethod   string            `json:"collection_method"` // charge_automatically or send_invoice
-	Livemode           bool              `json:"livemode"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	Created            int64             `json:"created"`
+	ID                   string             `json:"id"`
+	Object               string             `json:"object"`
+	Customer             string             `json:"customer"`
+	Status               string             `json:"status"` // trialing, active, past_due, canceled, unpaid, incomplete, incomplete_expired, paused
+	CurrentPeriodStart   int64              `json:"current_period_start"`
+	CurrentPeriodEnd     int64              `json:"current_period_end"`
+	CancelAtPeriodEnd    bool               `json:"cancel_at_period_end"`
+	CancelAt             int64              `json:"cancel_at,omitempty"`
+	CanceledAt           int64              `json:"canceled_at,omitempty"`
+	TrialStart           int64              `json:"trial_start,omitempty"`
+	TrialEnd             int64              `json:"trial_end,omitempty"`
+	Items                *SubscriptionItems `json:"items"`
+	LatestInvoice        string             `json:"latest_invoice,omitempty"`
+	Discount             *Discount          `json:"discount,omitempty"`
+	DefaultTaxRates      []TaxRate          `json:"default_tax_rates,omitempty"`
+	DefaultPaymentMethod string             `json:"default_payment_method,omitempty"`
+	CollectionMethod     string             `json:"collection_method"` // charge_automatically or send_invoice
+	Livemode             bool               `json:"livemode"`
+	Metadata             map[string]string  `json:"metadata,omitempty"`
+	Created              int64              `json:"created"`
 }
 
 // SubscriptionItems wraps the list of subscription items.
@@ -340,46 +339,46 @@ type SubscriptionItem struct {
 
 // Discount represents a discount applied to an invoice or subscription.
 type Discount struct {
-	ID             string  `json:"id"`
-	Object         string  `json:"object"`
-	Coupon         *Coupon `json:"coupon"`
-	Customer       string  `json:"customer,omitempty"`
-	Subscription   string  `json:"subscription,omitempty"`
-	Start          int64   `json:"start,omitempty"`
-	End            int64   `json:"end,omitempty"`
+	ID           string  `json:"id"`
+	Object       string  `json:"object"`
+	Coupon       *Coupon `json:"coupon"`
+	Customer     string  `json:"customer,omitempty"`
+	Subscription string  `json:"subscription,omitempty"`
+	Start        int64   `json:"start,omitempty"`
+	End          int64   `json:"end,omitempty"`
 }
 
 // Invoice represents a Stripe invoice.
 type Invoice struct {
-	ID                    string            `json:"id"`
-	Object                string            `json:"object"`
-	Customer              string            `json:"customer"`
-	Subscription          string            `json:"subscription,omitempty"`
-	Status                string            `json:"status"` // draft, open, paid, uncollectible, void
-	AmountDue             int64             `json:"amount_due"`
-	AmountPaid            int64             `json:"amount_paid"`
-	AmountRemaining       int64             `json:"amount_remaining"`
-	Total                 int64             `json:"total"`
-	Subtotal              int64             `json:"subtotal"`
-	Currency              string            `json:"currency"`
-	CollectionMethod      string            `json:"collection_method"`
-	Paid                  bool              `json:"paid"`
-	Lines                 *InvoiceLines     `json:"lines,omitempty"`
-	DefaultPaymentMethod  string            `json:"default_payment_method,omitempty"`
-	Description           string            `json:"description,omitempty"`
-	PaymentIntent         string            `json:"payment_intent,omitempty"`
-	HostedInvoiceURL      string            `json:"hosted_invoice_url,omitempty"`
-	Number                string            `json:"number,omitempty"`
-	TotalDiscountAmounts  []DiscountAmount   `json:"total_discount_amounts,omitempty"`
-	TotalTaxAmounts       []TaxAmount        `json:"total_tax_amounts,omitempty"`
-	Discount              *Discount          `json:"discount,omitempty"`
-	DefaultTaxRates       []TaxRate          `json:"default_tax_rates,omitempty"`
-	DueDate               int64             `json:"due_date,omitempty"`
-	PeriodStart           int64             `json:"period_start,omitempty"`
-	PeriodEnd             int64             `json:"period_end,omitempty"`
-	Livemode              bool              `json:"livemode"`
-	Metadata              map[string]string `json:"metadata,omitempty"`
-	Created               int64             `json:"created"`
+	ID                   string            `json:"id"`
+	Object               string            `json:"object"`
+	Customer             string            `json:"customer"`
+	Subscription         string            `json:"subscription,omitempty"`
+	Status               string            `json:"status"` // draft, open, paid, uncollectible, void
+	AmountDue            int64             `json:"amount_due"`
+	AmountPaid           int64             `json:"amount_paid"`
+	AmountRemaining      int64             `json:"amount_remaining"`
+	Total                int64             `json:"total"`
+	Subtotal             int64             `json:"subtotal"`
+	Currency             string            `json:"currency"`
+	CollectionMethod     string            `json:"collection_method"`
+	Paid                 bool              `json:"paid"`
+	Lines                *InvoiceLines     `json:"lines,omitempty"`
+	DefaultPaymentMethod string            `json:"default_payment_method,omitempty"`
+	Description          string            `json:"description,omitempty"`
+	PaymentIntent        string            `json:"payment_intent,omitempty"`
+	HostedInvoiceURL     string            `json:"hosted_invoice_url,omitempty"`
+	Number               string            `json:"number,omitempty"`
+	TotalDiscountAmounts []DiscountAmount  `json:"total_discount_amounts,omitempty"`
+	TotalTaxAmounts      []TaxAmount       `json:"total_tax_amounts,omitempty"`
+	Discount             *Discount         `json:"discount,omitempty"`
+	DefaultTaxRates      []TaxRate         `json:"default_tax_rates,omitempty"`
+	DueDate              int64             `json:"due_date,omitempty"`
+	PeriodStart          int64             `json:"period_start,omitempty"`
+	PeriodEnd            int64             `json:"period_end,omitempty"`
+	Livemode             bool              `json:"livemode"`
+	Metadata             map[string]string `json:"metadata,omitempty"`
+	Created              int64             `json:"created"`
 }
 
 // InvoiceLines wraps invoice line items.
@@ -392,15 +391,15 @@ type InvoiceLines struct {
 
 // InvoiceLine represents a line item on an invoice.
 type InvoiceLine struct {
-	ID          string `json:"id"`
-	Object      string `json:"object"`
-	Amount      int64  `json:"amount"`
-	Currency    string `json:"currency"`
-	Description string `json:"description,omitempty"`
-	Price       *Price `json:"price,omitempty"`
-	Quantity    int64  `json:"quantity,omitempty"`
+	ID          string  `json:"id"`
+	Object      string  `json:"object"`
+	Amount      int64   `json:"amount"`
+	Currency    string  `json:"currency"`
+	Description string  `json:"description,omitempty"`
+	Price       *Price  `json:"price,omitempty"`
+	Quantity    int64   `json:"quantity,omitempty"`
 	Period      *Period `json:"period,omitempty"`
-	Type        string `json:"type"` // subscription or invoiceitem
+	Type        string  `json:"type"` // subscription or invoiceitem
 }
 
 // DiscountAmount represents a discount amount on an invoice.
@@ -459,16 +458,16 @@ type Coupon struct {
 
 // SetupIntent represents a Stripe setup intent for future payments.
 type SetupIntent struct {
-	ID                 string            `json:"id"`
-	Object             string            `json:"object"`
-	Customer           string            `json:"customer,omitempty"`
-	PaymentMethod      string            `json:"payment_method,omitempty"`
-	Status             string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
-	ClientSecret       string            `json:"client_secret"`
-	Usage              string            `json:"usage"` // off_session or on_session
-	Livemode           bool              `json:"livemode"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	Created            int64             `json:"created"`
+	ID            string            `json:"id"`
+	Object        string            `json:"object"`
+	Customer      string            `json:"customer,omitempty"`
+	PaymentMethod string            `json:"payment_method,omitempty"`
+	Status        string            `json:"status"` // requires_payment_method, requires_confirmation, requires_action, processing, succeeded, canceled
+	ClientSecret  string            `json:"client_secret"`
+	Usage         string            `json:"usage"` // off_session or on_session
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Created       int64             `json:"created"`
 }
 
 // TaxRate represents a Stripe tax rate.
@@ -490,18 +489,18 @@ type TaxRate struct {
 
 // Dispute represents a Stripe dispute/chargeback.
 type Dispute struct {
-	ID              string            `json:"id"`
-	Object          string            `json:"object"`
-	Amount          int64             `json:"amount"`
-	Currency        string            `json:"currency"`
-	Charge          string            `json:"charge"`
-	PaymentIntent   string            `json:"payment_intent,omitempty"`
-	Reason          string            `json:"reason"` // fraudulent, duplicate, etc.
-	Status          string            `json:"status"` // needs_response, under_review, won, lost
-	Evidence        map[string]string `json:"evidence,omitempty"`
-	Livemode        bool              `json:"livemode"`
-	Metadata        map[string]string `json:"metadata,omitempty"`
-	Created         int64             `json:"created"`
+	ID            string            `json:"id"`
+	Object        string            `json:"object"`
+	Amount        int64             `json:"amount"`
+	Currency      string            `json:"currency"`
+	Charge        string            `json:"charge"`
+	PaymentIntent string            `json:"payment_intent,omitempty"`
+	Reason        string            `json:"reason"` // fraudulent, duplicate, etc.
+	Status        string            `json:"status"` // needs_response, under_review, won, lost
+	Evidence      map[string]string `json:"evidence,omitempty"`
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Created       int64             `json:"created"`
 }
 
 // AccountBalance tracks per-account balance (available and pending).
@@ -529,25 +528,25 @@ const (
 
 // CheckoutSession represents a Stripe Checkout Session.
 type CheckoutSession struct {
-	ID            string            `json:"id"`
-	Object        string            `json:"object"`
-	Mode          string            `json:"mode"`
-	Status        string            `json:"status"`
-	URL           string            `json:"url,omitempty"`
-	SuccessURL    string            `json:"success_url,omitempty"`
-	CancelURL     string            `json:"cancel_url,omitempty"`
-	Customer      string            `json:"customer,omitempty"`
-	CustomerEmail string            `json:"customer_email,omitempty"`
-	PaymentIntent string            `json:"payment_intent,omitempty"`
-	Subscription  string            `json:"subscription,omitempty"`
-	PaymentStatus string            `json:"payment_status"`
-	Currency      string            `json:"currency,omitempty"`
-	AmountTotal   int64                `json:"amount_total"`
-	LineItems     []CheckoutLineItem   `json:"line_items,omitempty"`
-	ExpiresAt     int64                `json:"expires_at"`
-	Livemode      bool                 `json:"livemode"`
-	Metadata      map[string]string    `json:"metadata,omitempty"`
-	Created       int64                `json:"created"`
+	ID            string             `json:"id"`
+	Object        string             `json:"object"`
+	Mode          string             `json:"mode"`
+	Status        string             `json:"status"`
+	URL           string             `json:"url,omitempty"`
+	SuccessURL    string             `json:"success_url,omitempty"`
+	CancelURL     string             `json:"cancel_url,omitempty"`
+	Customer      string             `json:"customer,omitempty"`
+	CustomerEmail string             `json:"customer_email,omitempty"`
+	PaymentIntent string             `json:"payment_intent,omitempty"`
+	Subscription  string             `json:"subscription,omitempty"`
+	PaymentStatus string             `json:"payment_status"`
+	Currency      string             `json:"currency,omitempty"`
+	AmountTotal   int64              `json:"amount_total"`
+	LineItems     []CheckoutLineItem `json:"line_items,omitempty"`
+	ExpiresAt     int64              `json:"expires_at"`
+	Livemode      bool               `json:"livemode"`
+	Metadata      map[string]string  `json:"metadata,omitempty"`
+	Created       int64              `json:"created"`
 }
 
 // CheckoutLineItem represents a line item in a checkout session.

--- a/twin-twilio/cmd/twin-twilio/main.go
+++ b/twin-twilio/cmd/twin-twilio/main.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"os"
 
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 )
 
 func main() {

--- a/twin-twilio/internal/api/handlers_messages.go
+++ b/twin-twilio/internal/api/handlers_messages.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 )
 
 // otpRegex matches 4-6 digit OTP codes in message bodies.
@@ -146,15 +146,15 @@ func (h *Handler) ListMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	twincore.JSON(w, http.StatusOK, map[string]any{
-		"messages":         messages,
-		"end":              len(messages) - 1,
-		"first_page_uri":  "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
-		"next_page_uri":   nil,
-		"page":            0,
-		"page_size":       50,
+		"messages":          messages,
+		"end":               len(messages) - 1,
+		"first_page_uri":    "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
+		"next_page_uri":     nil,
+		"page":              0,
+		"page_size":         50,
 		"previous_page_uri": nil,
-		"start":           0,
-		"uri":             "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
+		"start":             0,
+		"uri":               "/2010-04-01/Accounts/Messages.json?PageSize=50&Page=0",
 	})
 }
 

--- a/twin-twilio/internal/api/handlers_messages_extra.go
+++ b/twin-twilio/internal/api/handlers_messages_extra.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // UpdateMessage handles POST /2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json
@@ -56,13 +56,13 @@ func (h *Handler) ListMessageMedia(w http.ResponseWriter, r *http.Request) {
 	}
 
 	twincore.JSON(w, http.StatusOK, map[string]any{
-		"media_list": []any{},
-		"end":        0,
+		"media_list":     []any{},
+		"end":            0,
 		"first_page_uri": fmt.Sprintf("/2010-04-01/Accounts/AC_sim_test/Messages/%s/Media.json?PageSize=50&Page=0", sid),
-		"page":       0,
-		"page_size":  50,
-		"start":      0,
-		"uri":        fmt.Sprintf("/2010-04-01/Accounts/AC_sim_test/Messages/%s/Media.json?PageSize=50&Page=0", sid),
+		"page":           0,
+		"page_size":      50,
+		"start":          0,
+		"uri":            fmt.Sprintf("/2010-04-01/Accounts/AC_sim_test/Messages/%s/Media.json?PageSize=50&Page=0", sid),
 	})
 }
 
@@ -83,12 +83,12 @@ func (h *Handler) CreateMessageFeedback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	twincore.JSON(w, http.StatusCreated, map[string]any{
-		"account_sid": "AC_sim_test",
-		"message_sid": msg.SID,
-		"outcome":     outcome,
+		"account_sid":  "AC_sim_test",
+		"message_sid":  msg.SID,
+		"outcome":      outcome,
 		"date_created": h.store.Clock.Now().Format("Mon, 02 Jan 2006 15:04:05 +0000"),
 		"date_updated": h.store.Clock.Now().Format("Mon, 02 Jan 2006 15:04:05 +0000"),
-		"uri":         fmt.Sprintf("/2010-04-01/Accounts/AC_sim_test/Messages/%s/Feedback.json", sid),
+		"uri":          fmt.Sprintf("/2010-04-01/Accounts/AC_sim_test/Messages/%s/Feedback.json", sid),
 	})
 }
 

--- a/twin-twilio/internal/api/handlers_test.go
+++ b/twin-twilio/internal/api/handlers_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/admin"
 	"github.com/wondertwin-ai/wondertwin/twinkit/testutil"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/api"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 )
 
 const testAccountSID = "AC_test_sim"

--- a/twin-twilio/internal/api/handlers_verify.go
+++ b/twin-twilio/internal/api/handlers_verify.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // CreateVerification handles POST /v2/Services/{ServiceSid}/Verifications

--- a/twin-twilio/internal/api/handlers_verify_services.go
+++ b/twin-twilio/internal/api/handlers_verify_services.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
+	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
 )
 
 // ListVerifyServices handles GET /v2/Services
@@ -15,10 +15,10 @@ func (h *Handler) ListVerifyServices(w http.ResponseWriter, r *http.Request) {
 	twincore.JSON(w, http.StatusOK, map[string]any{
 		"services": services,
 		"meta": map[string]any{
-			"page":      0,
-			"page_size": 50,
+			"page":           0,
+			"page_size":      50,
 			"first_page_url": "/v2/Services?PageSize=50&Page=0",
-			"url":       "/v2/Services?PageSize=50&Page=0",
+			"url":            "/v2/Services?PageSize=50&Page=0",
 		},
 	})
 }

--- a/twin-twilio/internal/api/router.go
+++ b/twin-twilio/internal/api/router.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 	"github.com/wondertwin-ai/wondertwin/twinkit/messaging"
 	"github.com/wondertwin-ai/wondertwin/twinkit/twincore"
-	"github.com/wondertwin-ai/wondertwin/twin-twilio/internal/store"
 )
 
 // Handler holds all API handler state.
@@ -80,10 +80,10 @@ func (h *Handler) basicAuthMiddleware(next http.Handler) http.Handler {
 		if !ok || user == "" || pass == "" {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Twilio API"`)
 			twincore.JSON(w, http.StatusUnauthorized, map[string]any{
-				"code":     20003,
-				"message":  "Authenticate",
+				"code":      20003,
+				"message":   "Authenticate",
 				"more_info": "https://www.twilio.com/docs/errors/20003",
-				"status":   401,
+				"status":    401,
 			})
 			return
 		}

--- a/twin-twilio/internal/store/types.go
+++ b/twin-twilio/internal/store/types.go
@@ -3,23 +3,23 @@ package store
 
 // Message represents a Twilio SMS message.
 type Message struct {
-	SID         string `json:"sid"`
-	AccountSID  string `json:"account_sid"`
-	To          string `json:"to"`
-	From        string `json:"from"`
-	Body        string `json:"body"`
-	Status      string `json:"status"`
-	Direction   string `json:"direction"`
-	NumSegments string `json:"num_segments"`
-	NumMedia    string `json:"num_media"`
-	Price       string `json:"price,omitempty"`
-	PriceUnit   string `json:"price_unit"`
-	ErrorCode   *int   `json:"error_code"`
+	SID          string `json:"sid"`
+	AccountSID   string `json:"account_sid"`
+	To           string `json:"to"`
+	From         string `json:"from"`
+	Body         string `json:"body"`
+	Status       string `json:"status"`
+	Direction    string `json:"direction"`
+	NumSegments  string `json:"num_segments"`
+	NumMedia     string `json:"num_media"`
+	Price        string `json:"price,omitempty"`
+	PriceUnit    string `json:"price_unit"`
+	ErrorCode    *int   `json:"error_code"`
 	ErrorMessage string `json:"error_message,omitempty"`
-	DateCreated string `json:"date_created"`
-	DateUpdated string `json:"date_updated"`
-	DateSent    string `json:"date_sent,omitempty"`
-	URI         string `json:"uri"`
+	DateCreated  string `json:"date_created"`
+	DateUpdated  string `json:"date_updated"`
+	DateSent     string `json:"date_sent,omitempty"`
+	URI          string `json:"uri"`
 }
 
 // Message status constants matching Twilio's lifecycle.
@@ -56,16 +56,16 @@ const (
 
 // VerifyService represents a Twilio Verify Service.
 type VerifyService struct {
-	SID                    string `json:"sid"`
-	AccountSID             string `json:"account_sid"`
-	FriendlyName           string `json:"friendly_name"`
-	CodeLength             int    `json:"code_length"`
-	LookupEnabled          bool   `json:"lookup_enabled"`
-	SkipSMSToLandlines     bool   `json:"skip_sms_to_landlines"`
-	DTMFInputRequired      bool   `json:"dtmf_input_required"`
-	TtsName                string `json:"tts_name,omitempty"`
-	DoNotShareWarningEnabled bool `json:"do_not_share_warning_enabled"`
-	DateCreated            string `json:"date_created"`
-	DateUpdated            string `json:"date_updated"`
-	URL                    string `json:"url"`
+	SID                      string `json:"sid"`
+	AccountSID               string `json:"account_sid"`
+	FriendlyName             string `json:"friendly_name"`
+	CodeLength               int    `json:"code_length"`
+	LookupEnabled            bool   `json:"lookup_enabled"`
+	SkipSMSToLandlines       bool   `json:"skip_sms_to_landlines"`
+	DTMFInputRequired        bool   `json:"dtmf_input_required"`
+	TtsName                  string `json:"tts_name,omitempty"`
+	DoNotShareWarningEnabled bool   `json:"do_not_share_warning_enabled"`
+	DateCreated              string `json:"date_created"`
+	DateUpdated              string `json:"date_updated"`
+	URL                      string `json:"url"`
 }

--- a/twinkit/contract/engine_test.go
+++ b/twinkit/contract/engine_test.go
@@ -337,14 +337,14 @@ func TestApprovalChain_NotImplementedV01(t *testing.T) {
 
 type recordingHooks struct {
 	NoOpHooks
-	executed       int
-	sigRecorded    int
-	transitions    []string // "FROM->TO"
-	declined       int
-	voided         int
-	expired        int
-	executeErr     error
-	validateErr    error
+	executed    int
+	sigRecorded int
+	transitions []string // "FROM->TO"
+	declined    int
+	voided      int
+	expired     int
+	executeErr  error
+	validateErr error
 }
 
 func (r *recordingHooks) ValidateCreate(_ context.Context, _ *Contract) error {

--- a/twinkit/contract/interface.go
+++ b/twinkit/contract/interface.go
@@ -88,16 +88,16 @@ type Attestation struct {
 type AuditEventType string
 
 const (
-	AuditCreated         AuditEventType = "CONTRACT_CREATED"
-	AuditUpdated         AuditEventType = "CONTRACT_UPDATED"
-	AuditSent            AuditEventType = "CONTRACT_SENT"
+	AuditCreated           AuditEventType = "CONTRACT_CREATED"
+	AuditUpdated           AuditEventType = "CONTRACT_UPDATED"
+	AuditSent              AuditEventType = "CONTRACT_SENT"
 	AuditSignatureRecorded AuditEventType = "SIGNATURE_RECORDED"
-	AuditPartiallySigned AuditEventType = "CONTRACT_PARTIALLY_SIGNED"
-	AuditSigned          AuditEventType = "CONTRACT_SIGNED"
-	AuditExecuted        AuditEventType = "CONTRACT_EXECUTED"
-	AuditDeclined        AuditEventType = "CONTRACT_DECLINED"
-	AuditVoided          AuditEventType = "CONTRACT_VOIDED"
-	AuditExpired         AuditEventType = "CONTRACT_EXPIRED"
+	AuditPartiallySigned   AuditEventType = "CONTRACT_PARTIALLY_SIGNED"
+	AuditSigned            AuditEventType = "CONTRACT_SIGNED"
+	AuditExecuted          AuditEventType = "CONTRACT_EXECUTED"
+	AuditDeclined          AuditEventType = "CONTRACT_DECLINED"
+	AuditVoided            AuditEventType = "CONTRACT_VOIDED"
+	AuditExpired           AuditEventType = "CONTRACT_EXPIRED"
 )
 
 // AuditEntry is one append-only entry in a contract's audit log.
@@ -131,11 +131,11 @@ type Contract struct {
 
 // CreateInput is the input to Engine.Create.
 type CreateInput struct {
-	ID        string         // optional; engine generates if empty
-	Parties   []Party        // engine validates routing-order + witness pairing
+	ID        string  // optional; engine generates if empty
+	Parties   []Party // engine validates routing-order + witness pairing
 	Documents []DocumentRef
 	Metadata  map[string]any
-	ExpiresAt time.Time      // optional
+	ExpiresAt time.Time // optional
 }
 
 // Mutation is a partial update to a draft contract via Engine.Update.

--- a/twinkit/grpc/grpc.go
+++ b/twinkit/grpc/grpc.go
@@ -31,8 +31,8 @@ type MethodInfo struct {
 	Name            string `json:"name"`
 	InputType       string `json:"input_type"`
 	OutputType      string `json:"output_type"`
-	ClientStreaming  bool   `json:"client_streaming,omitempty"`
-	ServerStreaming  bool   `json:"server_streaming,omitempty"`
+	ClientStreaming bool   `json:"client_streaming,omitempty"`
+	ServerStreaming bool   `json:"server_streaming,omitempty"`
 }
 
 // Registry tracks registered gRPC services for discovery.

--- a/twinkit/identity/doc.go
+++ b/twinkit/identity/doc.go
@@ -7,7 +7,7 @@
 //   - Publisher: who authored and ships the twin (e.g. "wondertwin")
 //   - Vendor:    the vendor's name in the world (e.g. "stripe")
 //   - TwinID:    the directory/binary identity within a tier+publisher
-//                scope (always "twin-" + Vendor)
+//     scope (always "twin-" + Vendor)
 //
 // The fully-qualified identity is a Twin: a (Tier, Publisher, Vendor)
 // tuple. TwinID alone is insufficient outside of a tier+publisher-scoped

--- a/twinkit/ledger/engine.go
+++ b/twinkit/ledger/engine.go
@@ -13,13 +13,13 @@ import (
 // Engine is the accounting ledger engine. It enforces accounting invariants
 // and delegates platform-specific behavior to hooks.
 type Engine struct {
-	mu         sync.RWMutex
-	journal    *journal.Journal
-	hooks      AccountingHooks
-	clock      *state.Clock
-	accounts   map[string]*Account
-	acctOrder  []string // insertion order
-	periodLock time.Time // reject entries before this time
+	mu          sync.RWMutex
+	journal     *journal.Journal
+	hooks       AccountingHooks
+	clock       *state.Clock
+	accounts    map[string]*Account
+	acctOrder   []string  // insertion order
+	periodLock  time.Time // reject entries before this time
 	acctCounter int
 
 	// Well-known account IDs for AR/AP. Set by CreateAccount or configurable.

--- a/twinkit/ledger/interface.go
+++ b/twinkit/ledger/interface.go
@@ -74,67 +74,67 @@ type LineItem struct {
 
 // Document represents an invoice, bill, or credit note.
 type Document struct {
-	ID          string         `json:"id"`
-	Type        DocumentType   `json:"type"`
-	Status      DocumentStatus `json:"status"`
-	ContactID   string         `json:"contact_id"`
-	Currency    string         `json:"currency"`
-	LineItems   []LineItem     `json:"line_items"`
-	SubTotal    int64          `json:"sub_total"`
-	Total       int64          `json:"total"`
-	AmountDue   int64          `json:"amount_due"`
-	AmountPaid  int64          `json:"amount_paid"`
-	Date        time.Time      `json:"date"`
-	DueDate     time.Time      `json:"due_date,omitempty"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	ID         string         `json:"id"`
+	Type       DocumentType   `json:"type"`
+	Status     DocumentStatus `json:"status"`
+	ContactID  string         `json:"contact_id"`
+	Currency   string         `json:"currency"`
+	LineItems  []LineItem     `json:"line_items"`
+	SubTotal   int64          `json:"sub_total"`
+	Total      int64          `json:"total"`
+	AmountDue  int64          `json:"amount_due"`
+	AmountPaid int64          `json:"amount_paid"`
+	Date       time.Time      `json:"date"`
+	DueDate    time.Time      `json:"due_date,omitempty"`
+	CreatedAt  time.Time      `json:"created_at"`
+	UpdatedAt  time.Time      `json:"updated_at"`
 }
 
 // Payment represents a payment applied against a document.
 type Payment struct {
-	ID            string    `json:"id"`
-	DocumentID    string    `json:"document_id"`
+	ID            string       `json:"id"`
+	DocumentID    string       `json:"document_id"`
 	DocumentType  DocumentType `json:"document_type"`
-	BankAccountID string    `json:"bank_account_id"`
-	Amount        int64     `json:"amount"`
-	Currency      string    `json:"currency"`
-	Date          time.Time `json:"date"`
-	CreatedAt     time.Time `json:"created_at"`
+	BankAccountID string       `json:"bank_account_id"`
+	Amount        int64        `json:"amount"`
+	Currency      string       `json:"currency"`
+	Date          time.Time    `json:"date"`
+	CreatedAt     time.Time    `json:"created_at"`
 }
 
 // ManualJournal represents a manually posted journal entry.
 type ManualJournal struct {
-	ID        string             `json:"id"`
-	Narration string             `json:"narration"`
+	ID        string              `json:"id"`
+	Narration string              `json:"narration"`
 	Lines     []ManualJournalLine `json:"lines"`
-	Date      time.Time          `json:"date"`
-	Status    string             `json:"status"` // DRAFT or POSTED
-	CreatedAt time.Time          `json:"created_at"`
+	Date      time.Time           `json:"date"`
+	Status    string              `json:"status"` // DRAFT or POSTED
+	CreatedAt time.Time           `json:"created_at"`
 }
 
 // ManualJournalLine is a single line in a manual journal.
 type ManualJournalLine struct {
-	AccountID   string `json:"account_id"`
-	Description string `json:"description"`
-	DebitAmount int64  `json:"debit_amount"`
-	CreditAmount int64 `json:"credit_amount"`
+	AccountID    string `json:"account_id"`
+	Description  string `json:"description"`
+	DebitAmount  int64  `json:"debit_amount"`
+	CreditAmount int64  `json:"credit_amount"`
 }
 
 // TrialBalanceRow is one row in a trial balance report.
 type TrialBalanceRow struct {
-	AccountID   string `json:"account_id"`
-	AccountName string `json:"account_name"`
+	AccountID   string      `json:"account_id"`
+	AccountName string      `json:"account_name"`
 	AccountType AccountType `json:"account_type"`
-	Debit       int64  `json:"debit"`
-	Credit      int64  `json:"credit"`
+	Debit       int64       `json:"debit"`
+	Credit      int64       `json:"credit"`
 }
 
 // TrialBalance is the full trial balance report.
 type TrialBalance struct {
-	Rows       []TrialBalanceRow `json:"rows"`
-	TotalDebit int64             `json:"total_debit"`
-	TotalCredit int64            `json:"total_credit"`
-	AsOf       time.Time         `json:"as_of"`
+	Rows        []TrialBalanceRow `json:"rows"`
+	TotalDebit  int64             `json:"total_debit"`
+	TotalCredit int64             `json:"total_credit"`
+	AsOf        time.Time         `json:"as_of"`
 }
 
 // ReportRow is a row in a P&L or balance sheet report.
@@ -154,11 +154,11 @@ type ReportSection struct {
 
 // ProfitAndLoss is the P&L report.
 type ProfitAndLoss struct {
-	Revenue     ReportSection `json:"revenue"`
-	Expenses    ReportSection `json:"expenses"`
-	NetProfit   int64         `json:"net_profit"`
-	FromDate    time.Time     `json:"from_date"`
-	ToDate      time.Time     `json:"to_date"`
+	Revenue   ReportSection `json:"revenue"`
+	Expenses  ReportSection `json:"expenses"`
+	NetProfit int64         `json:"net_profit"`
+	FromDate  time.Time     `json:"from_date"`
+	ToDate    time.Time     `json:"to_date"`
 }
 
 // BalanceSheet is the balance sheet report.

--- a/twinkit/messaging/engine.go
+++ b/twinkit/messaging/engine.go
@@ -12,10 +12,10 @@ import (
 // Engine processes messages through their lifecycle.
 type Engine struct {
 	mu           sync.RWMutex
-	messages     map[string]*Message          // id → message
+	messages     map[string]*Message // id → message
 	lifecycles   map[ChannelType]*Lifecycle
-	suppressions map[string]*Suppression      // "channel:address" → suppression
-	senders      map[string]*Sender           // id → sender
+	suppressions map[string]*Suppression // "channel:address" → suppression
+	senders      map[string]*Sender      // id → sender
 	hooks        MessagingHooks
 	clock        *state.Clock
 	idCounter    int

--- a/twinkit/messaging/engine_test.go
+++ b/twinkit/messaging/engine_test.go
@@ -447,8 +447,8 @@ func TestClock_UsedForTimestamps(t *testing.T) {
 	createdAt := msg.CreatedAt
 
 	clock.Advance(60_000_000_000) // 1 minute
-	e.Advance(ctx(), msg.ID) // → SENDING
-	e.Advance(ctx(), msg.ID) // → SENT
+	e.Advance(ctx(), msg.ID)      // → SENDING
+	e.Advance(ctx(), msg.ID)      // → SENT
 
 	if !msg.SentAt.After(createdAt) {
 		t.Error("SentAt should be after CreatedAt when clock advances")

--- a/twinkit/messaging/hooks.go
+++ b/twinkit/messaging/hooks.go
@@ -23,8 +23,8 @@ type MessagingHooks interface {
 // Embed this in the twin's hook implementation to avoid implementing unused hooks.
 type NoOpMessagingHooks struct{}
 
-func (NoOpMessagingHooks) ValidateMessage(_ context.Context, _ *Message) error        { return nil }
-func (NoOpMessagingHooks) OnMessageCreated(_ context.Context, _ *Message) error        { return nil }
+func (NoOpMessagingHooks) ValidateMessage(_ context.Context, _ *Message) error  { return nil }
+func (NoOpMessagingHooks) OnMessageCreated(_ context.Context, _ *Message) error { return nil }
 func (NoOpMessagingHooks) OnStatusChange(_ context.Context, _ *Message, _, _ MessageStatus) error {
 	return nil
 }

--- a/twinkit/messaging/lifecycle.go
+++ b/twinkit/messaging/lifecycle.go
@@ -12,7 +12,7 @@ type Lifecycle struct {
 // AutoAdvanceConfig controls automatic state progression.
 type AutoAdvanceConfig struct {
 	// To is the default next status (used when Outcomes is empty).
-	To    MessageStatus
+	To MessageStatus
 	// Delay is the base delay before advancing.
 	Delay time.Duration
 	// Outcomes defines weighted alternative states.
@@ -85,8 +85,8 @@ func VoiceLifecycle() *Lifecycle {
 		InitialStatus: StatusQueued,
 		Transitions: map[MessageStatus][]MessageStatus{
 			StatusQueued:  {StatusSending},
-			StatusSending: {StatusSent, StatusFailed},         // ringing
-			StatusSent:    {StatusDelivered, StatusFailed},     // in-progress → completed
+			StatusSending: {StatusSent, StatusFailed},      // ringing
+			StatusSent:    {StatusDelivered, StatusFailed}, // in-progress → completed
 		},
 		AutoAdvance: map[MessageStatus]AutoAdvanceConfig{
 			StatusQueued:  {To: StatusSending, Delay: 0},

--- a/twinkit/search/hooks.go
+++ b/twinkit/search/hooks.go
@@ -22,7 +22,7 @@ type NoOpSearchHooks struct{}
 
 func (NoOpSearchHooks) ValidateRecord(_ context.Context, _ string, _ *Record) error { return nil }
 func (NoOpSearchHooks) OnRecordSaved(_ context.Context, _ string, _ *Record) error  { return nil }
-func (NoOpSearchHooks) OnRecordDeleted(_ context.Context, _, _ string) error         { return nil }
+func (NoOpSearchHooks) OnRecordDeleted(_ context.Context, _, _ string) error        { return nil }
 func (NoOpSearchHooks) OnSearch(_ context.Context, _ string, _ *SearchParams, _ *SearchResult) error {
 	return nil
 }

--- a/twinkit/search/interface.go
+++ b/twinkit/search/interface.go
@@ -6,11 +6,11 @@ package search
 
 // Index represents a search index with its configuration.
 type Index struct {
-	Name                 string   `json:"name"`
-	SearchableAttributes []string `json:"searchableAttributes,omitempty"`
+	Name                  string   `json:"name"`
+	SearchableAttributes  []string `json:"searchableAttributes,omitempty"`
 	AttributesForFaceting []string `json:"attributesForFaceting,omitempty"`
-	CustomRanking        []string `json:"customRanking,omitempty"`
-	RecordCount          int      `json:"recordCount"`
+	CustomRanking         []string `json:"customRanking,omitempty"`
+	RecordCount           int      `json:"recordCount"`
 }
 
 // Record is a single document in a search index.
@@ -24,9 +24,9 @@ type Record struct {
 // SearchParams defines the parameters for a search query.
 type SearchParams struct {
 	Query                string   `json:"query"`
-	Filters              string   `json:"filters,omitempty"`             // filter expression: "category:electronics AND price < 100"
-	FacetFilters         []string `json:"facetFilters,omitempty"`        // ["category:electronics", "brand:apple"]
-	Facets               []string `json:"facets,omitempty"`              // attributes to compute facet counts for
+	Filters              string   `json:"filters,omitempty"`      // filter expression: "category:electronics AND price < 100"
+	FacetFilters         []string `json:"facetFilters,omitempty"` // ["category:electronics", "brand:apple"]
+	Facets               []string `json:"facets,omitempty"`       // attributes to compute facet counts for
 	Page                 int      `json:"page"`
 	HitsPerPage          int      `json:"hitsPerPage"`
 	AttributesToRetrieve []string `json:"attributesToRetrieve,omitempty"` // limit returned attributes

--- a/twinkit/search/telemetry.go
+++ b/twinkit/search/telemetry.go
@@ -11,8 +11,8 @@ func RecordSavedContext(indexName string, attributeCount int) map[string]any {
 // SearchContext builds the canonical Context map for OnSearch.
 func SearchContext(indexName string, hitCount int, hasFilters, hasFacets bool) map[string]any {
 	return map[string]any{
-		"index_name": indexName,
-		"hit_count":  hitCount,
+		"index_name":  indexName,
+		"hit_count":   hitCount,
 		"has_filters": hasFilters,
 		"has_facets":  hasFacets,
 	}

--- a/twinkit/state/journal/journal.go
+++ b/twinkit/state/journal/journal.go
@@ -26,7 +26,7 @@ type Entry struct {
 	TransactionID string    `json:"transaction_id"`
 	AccountID     string    `json:"account_id"`
 	Type          EntryType `json:"type"`
-	Amount        int64     `json:"amount"`   // always positive; direction determined by Type
+	Amount        int64     `json:"amount"` // always positive; direction determined by Type
 	Currency      string    `json:"currency"`
 	SourceType    string    `json:"source_type"` // what created this: "invoice", "payment", "manual"
 	SourceID      string    `json:"source_id"`

--- a/twinkit/twincore/oauth.go
+++ b/twinkit/twincore/oauth.go
@@ -50,7 +50,9 @@ func NewOAuthServer(cfg OAuthConfig, tokens *TokenRegistry) *OAuthServer {
 
 // Routes mounts the OAuth endpoints on the given router.
 // Call this from the twin's main.go to enable OAuth simulation.
-func (s *OAuthServer) Routes(mux interface{ HandleFunc(string, func(http.ResponseWriter, *http.Request)) }) {
+func (s *OAuthServer) Routes(mux interface {
+	HandleFunc(string, func(http.ResponseWriter, *http.Request))
+}) {
 	if s.config.AuthorizePath != "" {
 		mux.HandleFunc(s.config.AuthorizePath, s.handleAuthorize)
 	}

--- a/twinkit/workspace/engine_test.go
+++ b/twinkit/workspace/engine_test.go
@@ -452,11 +452,11 @@ func TestMembership_RemoveNonMember(t *testing.T) {
 
 type testHooks struct {
 	NoOpWorkspaceHooks
-	created    int
-	updated    int
-	deleted    int
+	created      int
+	updated      int
+	deleted      int
 	transitioned int
-	commented  int
+	commented    int
 }
 
 func (h *testHooks) OnEntityCreated(_ context.Context, _ *Entity) error {

--- a/twinkit/workspace/hooks.go
+++ b/twinkit/workspace/hooks.go
@@ -38,7 +38,7 @@ type WorkspaceHooks interface {
 // Embed this in the twin's hook implementation to avoid implementing unused hooks.
 type NoOpWorkspaceHooks struct{}
 
-func (NoOpWorkspaceHooks) ValidateEntity(_ context.Context, _ *Entity) error { return nil }
+func (NoOpWorkspaceHooks) ValidateEntity(_ context.Context, _ *Entity) error  { return nil }
 func (NoOpWorkspaceHooks) OnEntityCreated(_ context.Context, _ *Entity) error { return nil }
 func (NoOpWorkspaceHooks) OnEntityUpdated(_ context.Context, _ *Entity, _ map[string]any) error {
 	return nil
@@ -50,6 +50,6 @@ func (NoOpWorkspaceHooks) OnStatusTransition(_ context.Context, _ *Entity, _, _ 
 func (NoOpWorkspaceHooks) OnCommentAdded(_ context.Context, _ *Entity, _ *Comment) error {
 	return nil
 }
-func (NoOpWorkspaceHooks) OnMemberAdded(_ context.Context, _, _, _ string) error  { return nil }
-func (NoOpWorkspaceHooks) OnMemberRemoved(_ context.Context, _, _ string) error   { return nil }
-func (NoOpWorkspaceHooks) FormatEvent(event *MutationEvent) any                   { return event }
+func (NoOpWorkspaceHooks) OnMemberAdded(_ context.Context, _, _, _ string) error { return nil }
+func (NoOpWorkspaceHooks) OnMemberRemoved(_ context.Context, _, _ string) error  { return nil }
+func (NoOpWorkspaceHooks) FormatEvent(event *MutationEvent) any                  { return event }


### PR DESCRIPTION
Mechanical, semantics-preserving `gofmt -w` pass over first-party Go code in this repo. No behavior change.

Plain `gofmt -w` only — no `gofmt -s`, no `go fix`, no `golangci-lint --fix`, no refactors, no dependency changes, no `go mod tidy`.

## Scope

- **122 Go files** reformatted.
- Vendored third-party trees, `vendor/`, and `node_modules/` excluded. Scoped to git-**tracked** `.go` files so gitignored/generated Go sources are untouched.
- **No changes to `go.mod`, `go.sum`, `go.work`, or any import path.** Import *lines* added and removed are exactly equal (187 / 187) — pure reordering within existing groups, nothing added, removed, or repointed. The `github.com/localstack/…` namespace migration is untouched and remains separate work.
- The only non-Go file added is `.git-blame-ignore-revs`.

## On `git diff -w`

`git diff -w` is **not** empty here: `77 files changed, 101 insertions(+), 105 deletions(-)`.

That is expected, and it is not content drift. `-w` ignores whitespace *within* a line but still reports inserted lines and reordered lines. Every difference falls into one of four gofmt behaviors:

1. **Import sorting** within existing groups.
2. **Doc-comment reflow** — Go 1.19+ gofmt inserts a blank `//` before indented blocks so godoc renders them as code blocks.
3. **Line-wrapping** of long function literals and inline interface types (which also changes the count of auto-inserted semicolons).
4. **Inert token removals** — a redundant paren pair, or an optional trailing comma before a same-line `}`.

To verify this rather than assert it, every changed file's Go token stream was compared before/after with `go/scanner`, ignoring auto-inserted semicolons. Result: no identifier, literal, keyword, or operator changed anywhere in this repo. Differences are ordering-only, except for the inert removals in category 4, which were characterized exactly by token-multiset delta.

## Build / vet / test

Per module, on `main` before vs. this branch after:

| module | before (build/vet/test) | after (build/vet/test) | |
|---|---|---|---|
| `wondertwin` | PASS / PASS / PASS | PASS / PASS / PASS | match |
| `wondertwin/docs/TWIN_TEMPLATE` | FAIL / FAIL / FAIL | FAIL / FAIL / FAIL | match |
| `wondertwin/twinkit` | PASS / PASS / FAIL | PASS / PASS / FAIL | match |

Two pre-existing failures, unrelated to formatting and unchanged by it:

- `docs/TWIN_TEMPLATE` — its `replace` points at `../twinkit` instead of `../../twinkit`, so the module does not build. Known, tracked separately, and **deliberately not fixed here**; this PR does not touch any `go.mod`.
- `twinkit` — `TestHandleListQuirksNilStore` fails (expects 200, gets 404).

Both were re-run to confirm they are deterministic, not flaky. Failing test *names* and package-level results are identical before and after, not just the counts.

`gofmt -l` is empty across all in-scope paths on this branch.

## Reviewing

This PR is two commits: the formatting change, and the blame-ignore entry.

GitHub honors `.git-blame-ignore-revs` automatically in its blame view. Developers can also opt in locally:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Ignored revision: `f697d97f9929eff4bc15cca01ee2bd8b28795c21`

Reviewing with whitespace hidden is easiest — append `?w=1` to the Files-changed URL.
