### PR TITLE
fix(twinkit/admin): GET /admin/quirks returns 200 with empty list when no quirk store

### DIFF
--- a/twinkit/admin/admin.go
+++ b/twinkit/admin/admin.go
@@ -258,12 +258,23 @@ func (h *Handler) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleListQuirks reports the state of every quirk the twin knows about.
+//
+// A twin with no quirk store configured has an empty quirk set, not a missing
+// endpoint, so this returns 200 with an empty list rather than 404. Mutating a
+// *specific* quirk on such a twin still 404s — see handleEnableQuirk and
+// handleDisableQuirk, whose target genuinely cannot exist.
+//
+// The list is always emitted as [] and never null: a nil slice marshals to
+// null, which forces every client to special-case it.
 func (h *Handler) handleListQuirks(w http.ResponseWriter, r *http.Request) {
-	if h.quirks == nil {
-		twincore.Error(w, http.StatusNotFound, "quirk store not configured")
-		return
+	quirks := []QuirkStatus{}
+	if h.quirks != nil {
+		if got := h.quirks.ListQuirks(); got != nil {
+			quirks = got
+		}
 	}
-	twincore.JSON(w, http.StatusOK, h.quirks.ListQuirks())
+	twincore.JSON(w, http.StatusOK, quirks)
 }
 
 func (h *Handler) handleEnableQuirk(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes the pre-existing `TestHandleListQuirksNilStore` failure in `twinkit/admin`, surfaced while baselining the `gofmt` pass (#281).

## The failure

```
--- FAIL: TestHandleListQuirksNilStore
    admin_test.go:769: expected 200, got 404
```

`GET /admin/quirks` returned 404 when the handler had no quirk store configured. The test expects 200 and an empty list.

## Why the handler was wrong, not the test

The three nil-store handlers were symmetric — all 404 — but the tests are deliberately **asymmetric**, and only the list case disagreed:

| handler | nil-store test expects | code did |
|---|---|---|
| `handleListQuirks` | 200 + empty list | **404** |
| `handleEnableQuirk` | 404 | 404 |
| `handleDisableQuirk` | 404 | 404 |

That asymmetry is correct REST, not an oversight. A twin with no quirk store has an *empty quirk set*, not a missing endpoint — so listing yields `200 []`. But enabling or disabling a *specific* quirk on such a twin targets something that genuinely cannot exist, so those keep their 404.

All three tests landed together in #17, and two of the three already passed. The intent was encoded in the tests; the list handler just didn't implement it.

## Change

`handleListQuirks` now returns `200` with the quirk list, using an empty set when no store is configured.

The list is also always emitted as `[]` rather than `null`. A nil slice marshals to `null`, which forces every client to special-case it — the exact pitfall called out in this repo's `CLAUDE.md`. Previously a configured-but-empty store would have emitted `null`.

## Knock-on effects

Community twins don't configure a quirk store, so their `/admin/quirks` response changes from `404` to `200 []`. I checked both consumers:

- **`internal/conformance/conformance.go`** — `checkQuirks` already accepts *either* 200-with-valid-JSON *or* 404, so it still passes. Its 404 branch is simply no longer taken by twins built on twinkit's admin handler. Left as-is: it's a tolerant check, and older or third-party twins may still 404.
- **`internal/mcp/tools.go`** — the quirks tool previously reported `Error fetching quirks for <twin>: status 404` for any twin without a quirk store. It now returns an empty list. Strict improvement: an unconfigured quirk store is not an error condition.

No other references to `/admin/quirks` or `"quirk store not configured"` exist in this repo or in `wondertwin-pro`.

## Verification

- All 8 quirks handler tests pass (`TestHandleListQuirks*`, `TestHandleEnableQuirk*`, `TestHandleDisableQuirk*`).
- `twinkit` module: `go build`, `go vet`, `go test ./...` all clean — this was the last failure in that module.
- Root `wondertwin` module: `go build`, `go vet`, `go test ./...` all clean.

## Relationship to #281

Independent. #281 is formatting-only and does not touch `twinkit/admin/admin.go`, so there are **no overlapping files** — verified to merge cleanly in either order.

`docs/TWIN_TEMPLATE` still fails to build (its `replace` points at `../twinkit` instead of `../../twinkit`). That is unrelated, tracked separately, and deliberately untouched here.
