### PR TITLE
chore(ci): align pinned action versions with the rest of the fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.sum"
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.sum"

--- a/.github/workflows/release-twin.yml
+++ b/.github/workflows/release-twin.yml
@@ -21,13 +21,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout wondertwin
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           path: wondertwin
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: wondertwin/go.mod
           cache-dependency-path: "**/go.sum"
@@ -120,7 +120,7 @@ jobs:
             --notes "Twin release for ${TWIN} v${VERSION}. SBOM: twin-${TWIN}-${VERSION}.cdx.json (CycloneDX JSON)."
 
       - name: Checkout registry
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: wondertwin-ai/registry
           token: ${{ secrets.WONDERTWIN_REGISTRY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ jobs:
     name: Go vulnerability check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
 
@@ -29,7 +29,7 @@ jobs:
     name: Dependency vulnerability scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: OSV-Scanner
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
@@ -55,7 +55,7 @@ jobs:
     container:
       image: semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Semgrep
         # Rule packs are pinned explicitly rather than using --config auto.


### PR DESCRIPTION
Every action across the fleet was SHA-pinned, but at **four different versions** — and two repos disagreed with themselves.

## The drift

| repo | checkout | setup-go |
|---|---|---|
| wondertwin | v4.2.2 | v5.5.0 |
| wondertwin-pro | **v4 *and* v4.2.2** | **v5 *and* v5.5.0** |
| wondertwin-app | v4.2.2 | **v5.4.0 *and* v5.5.0** |
| wondertwin-ops | v7.0.1 | v7.0.0 |

The duplicates in `wondertwin-pro` are partly my doing: the security pass pinned whatever tag was in use rather than reconciling against the SHAs already there. This cleans that up.

`wondertwin-ops` moved to checkout v7.0.1 / setup-go v7.0.0 via dependabot and its CI is green on them, so that's the target. **One pin per action, fleet-wide.**

## Both bumps were checked, not assumed

- **setup-go v7.0.0** — ESM migration plus a `@actions/cache` bump. No behavioural change.
- **checkout v7.0.0** — ESM, plus one real change: it **blocks checking out fork PRs for `pull_request_target` and `workflow_run`**. That's GitHub hardening against the "pwn request" pattern, where a workflow runs with base-repo secrets but checks out untrusted fork code.

  I checked every trigger in the fleet before bumping. The only workflow using either is `wondertwin-app/staging-billing-smoke.yml`, which uses **no actions at all** — it's pure curl against the staging API. Nothing depends on the old behaviour.

## upload-artifact deliberately stays on v4

v7 exists, but the artifact actions have a history of cross-major incompatibility between upload and download, `wondertwin-app` pairs upload v4.6.2 with download v4.3.0, and those run in **deploy** workflows that don't execute on pull requests — so a break would surface late, in the worst place. Moving that pair is its own change with its own verification.

What this does fix is the label: `wondertwin-pro` carried the v4.6.2 SHA commented only as `# v4`.

## Verification

All workflow YAML parses. No unpinned action references remain in any repo.