### PR TITLE
chore(ci): add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# Dependabot configuration.
+#
+# Closes this repo's share of the SOC2 gap recorded in
+# wondertwin-docs/operations/wondertwin-operational-systems.md §8.3
+# ("no automated dependency update tooling"). wondertwin-ops had this
+# already; wondertwin, wondertwin-pro and wondertwin-app did not.
+#
+# Monthly cadence keeps the noise manageable for a tiny team. Bump to
+# weekly if patches lag enough to matter.
+
+version: 2
+updates:
+  # Three modules, not one. docs/TWIN_TEMPLATE is listed deliberately:
+  # it is the template every new community twin is copied from, and it
+  # spent months on a vulnerable chi precisely because nothing watched
+  # it.
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/twinkit"
+      - "/docs/TWIN_TEMPLATE"
+    schedule:
+      interval: "monthly"
+    # Wait 7 days before proposing a newly published version. A freshly
+    # released package is the window in which a compromised or yanked
+    # version is most likely to still be live.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "go"
+    # Minor and patch updates land as a single PR across the modules;
+    # majors stay individual so they can be reviewed on their own
+    # merits.
+    groups:
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes this repo's share of the SOC2 gap recorded in `wondertwin-docs/operations/wondertwin-operational-systems.md` §8.3 ("no automated dependency update tooling").

`wondertwin-ops` had dependabot. `wondertwin`, `wondertwin-pro` and `wondertwin-app` did not — which is a large part of why the fleet sat on a **reachable** chi advisory and a **CVSS 9.1** kin-openapi advisory until someone went looking.

## Two details that matter more than the boilerplate

### 1. Multi-module coverage

These repos aren't single modules — `wondertwin` is 3, `wondertwin-pro` is 30. A bare `directory: "/"` watches the root module and **silently ignores the rest**, which is exactly how the twin modules drifted onto a vulnerable chi.

The gomod block uses `directories` with globs instead. Verified coverage: **30/30** for `wondertwin-pro`, **3/3** for `wondertwin` — including `docs/TWIN_TEMPLATE`, the template every new community twin is copied from, which spent months on a vulnerable chi precisely because nothing watched it.

### 2. Grouping

Without it, one chi release means ~29 near-identical PRs in `wondertwin-pro`.

Minor and patch updates land as a **single grouped PR**; majors stay individual so they can be judged on their own merits. That split is drawn from experience with the last batch — the `setup-go` v6→v7 bump was worth reading, the patch bumps were not.

## Settings

Monthly cadence and a 7-day cooldown, matching the existing `wondertwin-ops` config. The cooldown matters: a freshly published version is the window in which a compromised or yanked release is most likely still live — which is also the Semgrep finding that flagged this gap originally.

## Heads up

Turning this on will produce an initial wave of PRs as dependabot catches up on whatever is currently behind. Grouping keeps that to roughly one PR per ecosystem rather than one per dependency per module.