### PR TITLE
fix(ci): resolve the Go toolchain from go.mod, not a hardcoded minor

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
Round 1 of 2 in a four-repo sweep. **This PR changes no behavior** — it makes the toolchain source explicit. The 1.26.6 bump rides on top in round 2 (#289).

## The bug

`setup-go` sets `GOTOOLCHAIN=local`, which disables Go's own ability to fetch a newer toolchain when go.mod asks for one. Whatever setup-go installs is final. With `go-version: "1.26"` it installs whichever patch its manifest happens to serve that day:

- **The build floats.** The same commit compiles against different toolchains on different days — how the fleet ended up on 1.26.5 without anyone deciding to be.
- **It can't satisfy a newer go directive.** Bumping go.mod past what the manifest serves fails hard:
  ```
  go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
  ```
  Confirmed empirically: 1.26.6 released 2026-08-13, and four days later setup-go's manifest was still serving 1.26.5.

In #289, this repo's `build-and-test` (already on `go-version-file`) passed the bump cleanly while `Go vulnerability check` — the one job still on the hardcoded minor — failed. Same commit, same repo, difference is only this line.

## Change

`security.yml`: `go-version: "1.26"` → `go-version-file: go.mod`. It was the last holdout here; `ci.yml`, `release.yml`, and `release-twin.yml` already used the file.

## Verification

go.mod still reads 1.26.5, so the job resolves to the toolchain it already ran — now explicitly rather than by chance.