### PR TITLE
add(twin-stripe): release notes for v0.2.0, and make them possible at all

### DIFF
--- a/cmd/gen-registry/main.go
+++ b/cmd/gen-registry/main.go
@@ -401,6 +401,17 @@ func upsert(reg *Registry, twin, version, tier string, manifest *TwinManifest, v
 		}
 	}
 
+	// Refresh manifest-derived fields on every release, not just on
+	// entry creation. A twin's description and category track what it
+	// actually covers, and both drift as the twin grows — twin-stripe
+	// went from 6 resources to 44 while its registry description still
+	// advertised the Connect-and-Payouts surface it shipped with at
+	// v0.1.0. Leaving these write-once meant the registry, and the
+	// /docs/twins pages generated from it, described the first release
+	// forever.
+	entry.Description = manifest.Description
+	entry.Category = manifest.Category
+
 	entry.Tier = tier
 	if tier == "commercial" {
 		entry.DownloadAuth = "required"

--- a/cmd/gen-registry/main_test.go
+++ b/cmd/gen-registry/main_test.go
@@ -180,6 +180,72 @@ func TestAddSecondVersion(t *testing.T) {
 	}
 }
 
+// A twin's description and category track what it actually covers, and
+// both drift as the twin grows. They were previously written only when
+// the registry entry was created, so a twin that expanded after its
+// first release kept advertising its original surface forever.
+func TestSecondVersionRefreshesDescriptionAndCategory(t *testing.T) {
+	dir := setupManifest(t)
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	checksumsPath := writeChecksums(t, dir)
+	registryPath := writeEmptyRegistry(t, dir)
+
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.1.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The twin grows: rewrite the manifest the way a real expansion would.
+	grown := `{
+  "twin": "stripe",
+  "display_name": "Stripe",
+  "category": "billing",
+  "description": "Now covers the full payments and billing surface",
+  "sdk_target": {
+    "primary": {
+      "package": "github.com/stripe/stripe-go",
+      "language": "go",
+      "version": "v81"
+    }
+  }
+}`
+	manifestPath := filepath.Join(dir, "twin-stripe", "twin-manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(grown), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run([]string{
+		"--twin", "stripe", "--version", "0.2.0",
+		"--checksums-file", checksumsPath, "--registry-file", registryPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(registryPath)
+	var reg Registry
+	json.Unmarshal(data, &reg)
+
+	entry := reg.Twins["stripe"]
+	if want := "Now covers the full payments and billing surface"; entry.Description != want {
+		t.Errorf("description = %q, want %q", entry.Description, want)
+	}
+	if want := "billing"; entry.Category != want {
+		t.Errorf("category = %q, want %q", entry.Category, want)
+	}
+	// Refreshing metadata must not disturb the version history.
+	if len(entry.Versions) != 2 {
+		t.Errorf("versions count = %d, want 2", len(entry.Versions))
+	}
+}
+
 func TestAddSecondTwin(t *testing.T) {
 	dir := setupManifest(t)
 	// Also create a twilio manifest

--- a/schemas/twin-manifest.schema.json
+++ b/schemas/twin-manifest.schema.json
@@ -5,11 +5,23 @@
   "title": "Twin Contribution Manifest",
   "description": "Schema for twin contribution manifests describing a twin's capabilities and coverage.",
   "type": "object",
-  "required": ["tier", "publisher", "vendor", "twin_id", "display_name", "category", "sdk_target", "service_surface", "coverage", "generation", "vendor_certification"],
+  "required": [
+    "tier",
+    "publisher",
+    "vendor",
+    "twin_id",
+    "display_name",
+    "category",
+    "sdk_target",
+    "service_surface",
+    "coverage",
+    "generation",
+    "vendor_certification"
+  ],
   "properties": {
     "tier": {
       "type": "string",
-      "description": "Distribution tier for the twin. Describes provenance and licensing, not pricing. 'community' = MIT licensed, public repo, no account needed. 'commercial' = BSL licensed, pro repo, account required. Pattern is permissive for forward-compat with future tiers (enterprise, hosted) per twin-naming-design §3.3.",
+      "description": "Distribution tier for the twin. Describes provenance and licensing, not pricing. 'community' = MIT licensed, public repo, no account needed. 'commercial' = BSL licensed, pro repo, account required. Pattern is permissive for forward-compat with future tiers (enterprise, hosted) per twin-naming-design \u00a73.3.",
       "pattern": "^[a-z]+$"
     },
     "publisher": {
@@ -38,43 +50,95 @@
     },
     "version": {
       "type": "string",
-      "description": "Twin's own semver version. Source of truth for the binary's Version (embedded via go:embed per twin-versioning-design §3.1).",
+      "description": "Twin's own semver version. Source of truth for the binary's Version (embedded via go:embed per twin-versioning-design \u00a73.1).",
       "pattern": "^\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?$"
     },
     "compatible_versions": {
       "type": "array",
-      "description": "Semver ranges this twin self-declares as wire-compatible across releases of itself. Consumed by `wt install` and license entitlement matching (twin-versioning-design §3.2).",
+      "description": "Semver ranges this twin self-declares as wire-compatible across releases of itself. Consumed by `wt install` and license entitlement matching (twin-versioning-design \u00a73.2).",
       "items": {
         "type": "string"
       },
       "minItems": 1
     },
     "vendor_api_version": {
-      "type": ["string", "null"],
-      "description": "Vendor API surface this twin claims to faithfully simulate (e.g. \"2024-10-15\" for Stripe). Vendor-specific format. Null if the vendor doesn't version its API or the twin tracks latest. Per twin-versioning-design §3.2."
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Vendor API surface this twin claims to faithfully simulate (e.g. \"2024-10-15\" for Stripe). Vendor-specific format. Null if the vendor doesn't version its API or the twin tracks latest. Per twin-versioning-design \u00a73.2."
     },
     "vendor_certification": {
       "type": "object",
-      "description": "Whether the vendor has officially certified the twin. Required on every manifest; may be {\"status\": \"none\"}. Per twin-versioning-design §3.2.",
-      "required": ["status"],
+      "description": "Whether the vendor has officially certified the twin. Required on every manifest; may be {\"status\": \"none\"}. Per twin-versioning-design \u00a73.2.",
+      "required": [
+        "status"
+      ],
       "properties": {
         "status": {
           "type": "string",
-          "enum": ["certified", "pending", "none"]
+          "enum": [
+            "certified",
+            "pending",
+            "none"
+          ]
         },
-        "certified_by": {"type": "string"},
-        "certified_at": {"type": "string", "format": "date-time"},
-        "certificate_url": {"type": "string", "format": "uri"},
-        "valid_until": {"type": "string", "format": "date-time"}
+        "certified_by": {
+          "type": "string"
+        },
+        "certified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "certificate_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "valid_until": {
+          "type": "string",
+          "format": "date-time"
+        }
       },
       "allOf": [
         {
-          "if": {"properties": {"status": {"const": "certified"}}, "required": ["status"]},
-          "then": {"required": ["status", "certified_by", "certified_at", "certificate_url", "valid_until"]}
+          "if": {
+            "properties": {
+              "status": {
+                "const": "certified"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "status",
+              "certified_by",
+              "certified_at",
+              "certificate_url",
+              "valid_until"
+            ]
+          }
         },
         {
-          "if": {"properties": {"status": {"const": "pending"}}, "required": ["status"]},
-          "then": {"required": ["status", "certified_by", "certified_at"]}
+          "if": {
+            "properties": {
+              "status": {
+                "const": "pending"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "status",
+              "certified_by",
+              "certified_at"
+            ]
+          }
         }
       ],
       "additionalProperties": false
@@ -95,12 +159,19 @@
     "sdk_target": {
       "type": "object",
       "description": "SDK targeting information.",
-      "required": ["primary"],
+      "required": [
+        "primary"
+      ],
       "properties": {
         "primary": {
           "type": "object",
           "description": "Primary SDK target.",
-          "required": ["package", "language", "version", "repo_url"],
+          "required": [
+            "package",
+            "language",
+            "version",
+            "repo_url"
+          ],
           "properties": {
             "package": {
               "type": "string",
@@ -134,7 +205,10 @@
           "description": "Additional SDK targets with compatibility status.",
           "items": {
             "type": "object",
-            "required": ["package", "language"],
+            "required": [
+              "package",
+              "language"
+            ],
             "properties": {
               "package": {
                 "type": "string",
@@ -159,7 +233,11 @@
               "compatibility": {
                 "type": "string",
                 "description": "Compatibility confidence level.",
-                "enum": ["tested", "inferred", "untested"]
+                "enum": [
+                  "tested",
+                  "inferred",
+                  "untested"
+                ]
               },
               "last_validated": {
                 "type": "string",
@@ -169,7 +247,11 @@
               "validation_method": {
                 "type": "string",
                 "description": "How compatibility was validated.",
-                "enum": ["scenario_suite", "manual", "none"]
+                "enum": [
+                  "scenario_suite",
+                  "manual",
+                  "none"
+                ]
               },
               "known_gaps": {
                 "type": "array",
@@ -211,7 +293,14 @@
         "auth_pattern": {
           "type": "string",
           "description": "Authentication pattern used by the service.",
-          "enum": ["api_key", "oauth2", "basic", "jwt", "custom", "none"]
+          "enum": [
+            "api_key",
+            "oauth2",
+            "basic",
+            "jwt",
+            "custom",
+            "none"
+          ]
         },
         "has_webhooks": {
           "type": "boolean",
@@ -249,18 +338,26 @@
           "maximum": 100
         }
       },
-      "required": ["resources_implemented"],
+      "required": [
+        "resources_implemented"
+      ],
       "additionalProperties": false
     },
     "generation": {
       "type": "object",
       "description": "How the twin was generated.",
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "properties": {
         "method": {
           "type": "string",
           "description": "Generation method used.",
-          "enum": ["wondertwin_skill", "manual", "other"]
+          "enum": [
+            "wondertwin_skill",
+            "manual",
+            "other"
+          ]
         },
         "skill_version": {
           "type": "string",
@@ -284,6 +381,59 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "Optional release lifecycle metadata. Consumed by cmd/gen-registry when publishing a version to the registry; CLI flags override any value supplied here.",
+      "properties": {
+        "release_type": {
+          "type": "string",
+          "description": "Release stream for this version.",
+          "enum": [
+            "stable",
+            "beta",
+            "rc"
+          ]
+        },
+        "maintenance_status": {
+          "type": "string",
+          "description": "Maintenance posture for this twin.",
+          "enum": [
+            "active",
+            "security_only",
+            "eol"
+          ]
+        },
+        "maintenance_until": {
+          "type": "string",
+          "description": "Maintenance end date, ISO 8601 (YYYY-MM-DD).",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "bsl_expiry_date": {
+          "type": "string",
+          "description": "BSL expiry date, ISO 8601 (YYYY-MM-DD). Commercial tier only.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "changelog": {
+          "type": "string",
+          "description": "Release notes for this version, as markdown. Rendered on /docs/twins/<vendor>/releases and used as the GitHub release body.",
+          "minLength": 1
+        },
+        "announcement_url": {
+          "type": "string",
+          "description": "Optional link to a longer-form /updates post for notable releases.",
+          "format": "uri"
+        },
+        "breaking_changes": {
+          "type": "array",
+          "description": "Breaking changes introduced by this version.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       },
       "additionalProperties": false

--- a/twin-stripe/twin-manifest.json
+++ b/twin-stripe/twin-manifest.json
@@ -123,5 +123,10 @@
   "twin_id": "twin-stripe",
   "vendor_certification": {
     "status": "none"
+  },
+  "lifecycle": {
+    "release_type": "stable",
+    "maintenance_status": "active",
+    "changelog": "Stripe twin now covers the full payments and billing surface, not just Connect and Payouts. If you tested against v0.1.0, this is the release where the twin stops being a Connect fixture and starts standing in for Stripe proper — customers, subscriptions, invoices, checkout, and disputes all run their real lifecycles, deterministically.\n\n### Features\n- Full payments surface: Customers, Products, Prices, PaymentIntents, PaymentMethods, Charges, Refunds (#131, #138, #139)\n- Subscription lifecycle — trials, cancel-at-period-end, renewal (#145)\n- Invoice lifecycle, payout cancel, product cascade (#150)\n- Checkout session completion flow (#144)\n- Coupon/discount application and tax rate calculation (#143)\n- Proration on subscription item changes (#149)\n- Dispute lifecycle and 3D Secure simulation (#151)\n- Test card number support (#146)\n- Manual capture on payment intents, `POST /v1/charges` (#141)\n- Workspace engine driving invoice, subscription and payment-intent lifecycles (#174)\n- Deterministic seeding contract (#234)\n\n### Fixes\n- Webhook delivery now reaches registered endpoints (#142)\n- Customer validation and deletion cascade (#148)\n- Randomness routed through `twin.Rand` / `twin.Clock`, so runs are reproducible\n\n### Coverage\n- 44 resources implemented, ~80% of the SDK surface (v0.1.0: 6 resources, ~5%)\n- Not yet covered: Issuing, Terminal, Treasury, Radar, Identity, Financial Connections, Tax, Climate, Sigma, Reporting, Forwarding\n"
   }
 }

--- a/twin-stripe/twin.json
+++ b/twin-stripe/twin.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe",
-  "description": "Simulates the Stripe Connect and Payouts API surface, including accounts, external accounts, transfers, balance, payouts, and events with webhook delivery.",
+  "description": "Simulates the Stripe API — Customers, Products, Prices, PaymentIntents, PaymentMethods, Charges, Refunds, Subscriptions, Invoices, Coupons, SetupIntents, TaxRates, Disputes, Connect accounts, transfers, balance, payouts, events, checkout sessions, payment links, credit notes, promotion codes, subscription items, quotes, billing portal sessions, tokens, sources, mandates, confirmation tokens, application fees, application fee refunds, transfer reversals, account links, persons, topups, webhook endpoints, files, file links, shipping rates, reviews, and tax IDs with webhook delivery.",
   "category": "payments",
   "sdk": {
     "package": "github.com/stripe/stripe-go",


### PR DESCRIPTION
Unblocks a properly-noted `twin-stripe` v0.2.0 release. Three commits, smallest first.

## Why this was needed

`twin-stripe` v0.1.0 shipped 6 resources (~5% coverage). It now covers **44 (~80%)**. Dispatching `release-twin.yml` as-is would have published that as:

> Twin release for stripe v0.2.0. SBOM: twin-stripe-0.2.0.cdx.json (CycloneDX JSON).

…with a blank changelog on `/docs/twins/stripe/releases`, and a registry description still advertising the Connect-and-Payouts surface from February.

## 1. `add(schema)` — optional `lifecycle` block

`cmd/gen-registry` has read `lifecycle` from the manifest for some time — `release_type`, `maintenance_status`, `maintenance_until`, `bsl_expiry_date`, `changelog`, `breaking_changes`, each with a CLI override. But the manifest schema never modelled the block and sets `additionalProperties: false`, so **any twin supplying one failed `validate-schemas`**. The feature was unreachable, which is why no twin has ever shipped release notes.

Enums mirror `validateLifecycle` exactly. `announcement_url` is added so notable releases can point at a longer-form `/updates` post rather than inlining links in prose.

## 2. `fix(gen-registry)` — refresh description and category on every release

`entry.Description` and `entry.Category` were assigned only inside the entry-*creation* branch of `upsert`, so they froze at whatever the twin's first release declared. `entry.Tier`, immediately below, is refreshed on every call — that is the behaviour these should have had.

Confirmed against the live registry: a dry run of `--twin stripe --version 0.2.0` against the real `registry.json` left the description as the v0.1.0 text. With the fix it updates, `latest` advances, and the `0.1.0` entry is untouched.

The regression test rewrites the manifest between two releases and asserts both fields follow. It **fails** against the previous behaviour:

```
--- FAIL: TestSecondVersionRefreshesDescriptionAndCategory
    description = "Stripe twin for testing", want "Now covers the full payments and billing surface"
    category = "payments", want "billing"
```

## 3. `add(twin-stripe)` — the notes themselves

Populates `lifecycle.changelog`, and syncs `twin.json`'s description, which also still described the v0.1.0 surface.

## Verification

Full pre-push checklist from `CLAUDE.md`:

- `go run ./cmd/validate-schemas/` — 30 files across 10 twins, ok
- `go test ./twin-stripe/... -count=1` — pass
- `go test ./... -short` — pass
- `go build ./twin-stripe/cmd/twin-stripe/` — ok
- `go vet` — clean
- `wt conformance` on the built binary — **10/10**

Dry run against the real `registry.json` produces: description refreshed, `latest: 0.2.0`, changelog 1458 chars, `0.1.0` preserved.

## Not in this PR

`release-twin.yml` still passes a hardcoded `--notes` to `gh release create` and never fails when a changelog is absent — so a future twin can still ship silent. That gate is a follow-up; this PR makes good notes *possible*, not yet *mandatory*.