### PR TITLE
fix(ci): run pull_request checks regardless of the base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Deliberately unfiltered. `branches:` on pull_request matches the
+    # PR's BASE branch, not its head, so a `[main]` filter gives a stacked
+    # PR (one based on another feature branch) zero checks. Keep the
+    # filter on push:, where it does mean what it looks like.
 
 jobs:
   build-and-test:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Deliberately unfiltered. `branches:` on pull_request matches the
+    # PR's BASE branch, not its head, so a `[main]` filter gives a stacked
+    # PR (one based on another feature branch) zero checks. Keep the
+    # filter on push:, where it does mean what it looks like.
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6am UTC
 


### PR DESCRIPTION
## Problem

`branches:` on a `pull_request:` trigger filters on the PR's **base** branch, not its head. With `branches: [main]`, a PR stacked on another feature branch matches nothing and gets **zero checks**, silently, with no failing run to draw attention to it.

wondertwin-pro #317 (base `chore/conformance-gate-ratchet`) had never had a single check run for exactly this reason.

## Change

Drop the filter from `pull_request:` in `ci.yml` and `security.yml`. The filter stays on `push:`, where it does restrict what it looks like it restricts.

`pull_request:` with no `branches:` key means all base branches with the default activity types (`opened`, `synchronize`, `reopened`). The same events as before, no longer dropped on the floor for stacked PRs.

## Notes

The same fix goes out as one PR per repo across wondertwin, wondertwin-app and wondertwin-pro. No other workflow in any of the three repos uses a `pull_request:` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)